### PR TITLE
Adiciona retry para as funções que utilizam requests e liga o envio de e-mail em caso de falha

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,15 @@ services:
         command: webserver
         environment:
           - AIRFLOW_HOME=/usr/local/airflow
-          - KERNEL_URL=${KERNEL_URL}
+          - EMIAL_ON_FAILURE_RECIPIENTS=atta.jamil@gmail.com,jamil.atta@gmail.com
           - OPAC_MONGODB_NAME = ${OPAC_MONGODB_NAME}
           - OPAC_MONGODB_HOSTNAME = ${OPAC_MONGODB_HOSTNAME}
           - OPAC_MONGODB_USERNAME = ${OPAC_MONGODB_USERNAME}
           - OPAC_MONGODB_PASS = ${OPAC_MONGODB_PASS}
+          - AIRFLOW__SMTP__SMTP_HOST = ${AIRFLOW__SMTP__SMTP_HOST}
+          - AIRFLOW__SMTP__SMTP_USER = ${AIRFLOW__SMTP__SMTP_USER}
+          - AIRFLOW__SMTP__SMTP_PASSWORD = ${AIRFLOW__SMTP__SMTP_PASSWORD}
+          - AIRFLOW__SMTP__SMTP_MAIL_FROM = ${AIRFLOW__SMTP__SMTP_MAIL_FROM}
+          - AIRFLOW__SMTP__SMTP_SSL = ${AIRFLOW__SMTP__SMTP_SSL}
+          - AIRFLOW__SMTP__SMTP_PORT = ${AIRFLOW__SMTP__SMTP_PORT}
+


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a capacidade de realizar tentativas no ponto de integração com o Kernel

#### Onde a revisão poderia começar?

Na Dag: dags/read_documetstore_changes.py

#### Como este poderia ser testado manualmente?

Manualmente realizando o commando do docker: docker-compose build && docker-compose up

Acessando a interface administrativa do AirFlow e ligando a DAG: documentstore_changes 

![Screenshot 2019-04-02 17 07 48](https://user-images.githubusercontent.com/373745/55432672-db426780-5569-11e9-992b-d56bf8c348bf.png)

#### Algum cenário de contexto que queira dar?

Necessário um URL do Kernel acessível para realizar o teste.

### Screenshots

Não há.

#### Quais são tickets relevantes?
Não há. 

### Referências
Não há.