### PR TITLE
Adiciona a capacidade de registrarmos a conexão do OPAC no modelo airflow.models.Connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,7 @@ services:
         command: webserver
         environment:
           - AIRFLOW_HOME=/usr/local/airflow
-          - EMIAL_ON_FAILURE_RECIPIENTS=atta.jamil@gmail.com,jamil.atta@gmail.com
-          - OPAC_MONGODB_NAME = ${OPAC_MONGODB_NAME}
-          - OPAC_MONGODB_HOSTNAME = ${OPAC_MONGODB_HOSTNAME}
-          - OPAC_MONGODB_USERNAME = ${OPAC_MONGODB_USERNAME}
-          - OPAC_MONGODB_PASS = ${OPAC_MONGODB_PASS}
+          - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org
           - AIRFLOW__SMTP__SMTP_HOST = ${AIRFLOW__SMTP__SMTP_HOST}
           - AIRFLOW__SMTP__SMTP_USER = ${AIRFLOW__SMTP__SMTP_USER}
           - AIRFLOW__SMTP__SMTP_PASSWORD = ${AIRFLOW__SMTP__SMTP_PASSWORD}


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a capacidade de registrarmos a conexão do OPAC no modelo airflow.models.Connection

#### Onde a revisão poderia começar?

Na Dag: dags/kernel_changes.py

#### Como este poderia ser testado manualmente?

Manualmente realizando o commando do docker: docker-compose build && docker-compose up

Acessando a interface administrativa do AirFlow e ligando a DAG: kernel_changes.py

Veja: 

![Screenshot 2019-04-03 11 57 48](https://user-images.githubusercontent.com/373745/55489133-b997bd80-5607-11e9-9005-c4d1d03c3e01.png)


#### Algum cenário de contexto que queira dar?

Necessário um URL do Kernel acessível para realizar o teste.

Também é necessário adicionar duas conexões no Airflow 

![Screenshot 2019-04-03 11 58 52](https://user-images.githubusercontent.com/373745/55489202-dcc26d00-5607-11e9-96d1-df7e06871a0e.png)


opac_conn: 

![Screenshot 2019-04-03 12 00 02](https://user-images.githubusercontent.com/373745/55489287-0a0f1b00-5608-11e9-91b8-96ddac10b819.png)

kernel_conn:

![Screenshot 2019-04-03 12 00 37](https://user-images.githubusercontent.com/373745/55489323-1a26fa80-5608-11e9-9576-2e0d1d230546.png)


### Screenshots

Adicionado no item anterior

#### Quais são tickets relevantes?

tk #14 

### Referências

https://github.com/apache/airflow/blob/master/airflow/models/connection.py#L47
https://github.com/apache/airflow/blob/master/airflow/contrib/hooks/mongo_hook.py
http://docs.mongoengine.org/guide/connecting.html
https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/connection.py