### PR TITLE
Marcar os fascículos como despublicados

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -463,6 +463,15 @@ delete_documents_task = PythonOperator(
 
 def delete_issues(ds, **kwargs):
     tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
+
+    issue_changes = filter_changes(tasks, "bundles", "delete")
+
+    for issue in issue_changes:
+
+        issue = Issue.objects.get(_id=get_id(issue.get("id")))
+        issue.is_public = False
+        issue.save()
+
     return tasks
 
 


### PR DESCRIPTION
#### O que esse PR faz?

Marca os fascículos como despublicados.

#### Onde a revisão poderia começar?

No módulo: airflow/dags/kernel_changes.py

#### Como este poderia ser testado manualmente?

Manualmente realizando o commando do docker: docker-compose build && docker-compose up

Acessando a interface administrativa do AirFlow e ligando a DAG: kernel_changes.py

Veja: 

![Screenshot 2019-04-15 15 36 28](https://user-images.githubusercontent.com/373745/56156770-4d687280-5f94-11e9-9ec9-eed10002ca7d.png)


#### Algum cenário de contexto que queira dar?

Necessário um URL do Kernel acessível para realizar o teste.

Também é necessário adicionar duas conexões no Airflow 

![Screenshot 2019-04-03 11 58 52](https://user-images.githubusercontent.com/373745/55489202-dcc26d00-5607-11e9-96d1-df7e06871a0e.png)

opac_conn: 

![Screenshot 2019-04-03 12 00 02](https://user-images.githubusercontent.com/373745/55489287-0a0f1b00-5608-11e9-91b8-96ddac10b819.png)

kernel_conn:

![Screenshot 2019-04-03 12 00 37](https://user-images.githubusercontent.com/373745/55489323-1a26fa80-5608-11e9-9576-2e0d1d230546.png)


#### Quais são tickets relevantes?

tk #9 

### Referências
Não ha.