### PR TITLE
Marcar os periódico como despublicados

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -476,8 +476,16 @@ delete_issues_task = PythonOperator(
 
 def delete_journals(ds, **kwargs):
     tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
-    return tasks
 
+    journal_changes = filter_changes(tasks, "journals", "delete")
+
+    for journal in journal_changes:
+
+        journal = Journal.objects.get(_id=get_id(journal.get("id")))
+        journal.is_public = False
+        journal.save()
+
+    return tasks
 
 delete_journals_task = PythonOperator(
     task_id="delete_journals_task",


### PR DESCRIPTION
#### O que esse PR faz?

Marca os periódicos como despublicados.

#### Onde a revisão poderia começar?

No módulo: airflow/dags/kernel_changes.py

#### Como este poderia ser testado manualmente?

Manualmente realizando o commando do docker: docker-compose build && docker-compose up

Acessando a interface administrativa do AirFlow e ligando a DAG: kernel_changes.py

Veja: 

![Screenshot 2019-04-15 15 36 28](https://user-images.githubusercontent.com/373745/56156770-4d687280-5f94-11e9-9ec9-eed10002ca7d.png)


#### Algum cenário de contexto que queira dar?

Necessário um URL do Kernel acessível para realizar o teste.

Também é necessário adicionar duas conexões no Airflow 

![Screenshot 2019-04-03 11 58 52](https://user-images.githubusercontent.com/373745/55489202-dcc26d00-5607-11e9-96d1-df7e06871a0e.png)

opac_conn: 

![Screenshot 2019-04-03 12 00 02](https://user-images.githubusercontent.com/373745/55489287-0a0f1b00-5608-11e9-91b8-96ddac10b819.png)

kernel_conn:

![Screenshot 2019-04-03 12 00 37](https://user-images.githubusercontent.com/373745/55489323-1a26fa80-5608-11e9-9576-2e0d1d230546.png)


#### Quais são tickets relevantes?

tk #10 

### Referências
Não ha.