### PR TITLE
Adiciona a ordem nos fascículos

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -323,8 +323,12 @@ def register_issues(ds, **kwargs):
     for issue in issue_changes:
         resp_json = api_hook.run(endpoint=issue.get("id")).json()
 
+        issue_id = get_id(issue.get("id"))
+        journal = get_journal(j_issues, issue_id)
+
         t_issue = transform_issue(resp_json)
-        t_issue.journal = get_journal(j_issues, get_id(issue.get("id")))
+        t_issue.journal = journal
+        t_issue.order = j_issues.get(journal.id).index(issue_id)
         t_issue.save()
 
         i_documents[get_id(issue.get("id"))] = resp_json.get('items', [])


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a ordem nos fascículos.

#### Onde a revisão poderia começar?

airflow/dags/kernel_changes.py:register_issues

#### Como este poderia ser testado manualmente?

```python
make dev_compose_up
```

#### Algum cenário de contexto que queira dar?

Adiciona a ordem do fascículo conforme a posição na lista de fascículos.

### Screenshots

<img width="1355" alt="Screenshot 2019-04-16 15 58 11" src="https://user-images.githubusercontent.com/373745/56236629-75bda300-6060-11e9-95a7-14e7615e4fba.png">

#### Quais são tickets relevantes?

tk #28 

### Referências
Não há.