### PR TITLE
Adiciona a capacidade de cadastrar documentos orfãos

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -578,7 +578,7 @@ def register_document(data, issue_id, document_id, i_documents):
     document.journal = issue.journal
 
     document.order = i_documents.get(issue.id).index(document_id)
-    document.xml = "%s%s" % (api_hook.base_url, document.get("id"))
+    document.xml = "%s%s" % (api_hook.base_url, document._id)
 
     document.save()
 
@@ -786,7 +786,9 @@ register_issues_task << register_orphan_issues_task
 
 register_last_issues_task << register_issues_task
 
-register_documents_task << register_last_issues_task
+register_orphan_documents_task << register_last_issues_task
+
+register_documents_task << register_orphan_documents_task
 
 delete_journals_task << register_documents_task
 


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a capacidade de cadastrar documento orfãos.

#### Onde a revisão poderia começar?

É possível revisar esse PR verificando no seguinte módulo: 

- airflow/dags/kernel_changes.py. 

#### Como este poderia ser testado manualmente?

Executando manualmente o opac-arflow.

#### Algum cenário de contexto que queira dar?

A motivação desse PR está relacionado com a necessidade de podermos cadastrar artigo cientifico, sem necessariamente de ter um fascículo relacionado.

### Screenshots

Não há.

#### Quais são tickets relevantes?

tk #38 

### Referências

Não há.