### PR TITLE
Altera a obtenção do pacotes SPS p/ ler Scilista de arquivo

### DIFF
--- a/airflow/dags/kernel_documents.py
+++ b/airflow/dags/kernel_documents.py
@@ -55,19 +55,24 @@ def get_sps_packages(**kwargs):
     processamento do Airflow.
 
     list scilista: lista com as linhas do arquivo scilista.lst
-        rsp v10n4 => ["rsp v10n4"]
+        rsp v10n4
+        rsp 2018nahead
+        csp v4n2-3
     list sps_packages: lista com os paths dos pacotes SPS no diretório de
     processamento
     """
     logging.debug("get_sps_packages IN")
+
+    scilista_file_path = Variable.get("SCILISTA_FILE_PATH")
     xc_dir_name = Variable.get("XC_SPS_PACKAGES_DIR")
     proc_dir_name = Variable.get("PROC_SPS_PACKAGES_DIR")
-    scilista = kwargs.get("scilista")
-    if xc_dir_name is not None and proc_dir_name is not None:
-        xc_dir_path = Path(xc_dir_name)
-        proc_dir_path = Path(proc_dir_name)
-        sps_packages_list = []
-        for acron_issue in (scilista or []):
+
+    xc_dir_path = Path(xc_dir_name)
+    proc_dir_path = Path(proc_dir_name)
+    sps_packages_list = []
+
+    with open(scilista_file_path) as scilista:
+        for acron_issue in scilista.readlines():
             zip_filename = "{}.zip".format('_'.join(acron_issue.split()))
             source = xc_dir_path / zip_filename
             destination = proc_dir_path / zip_filename
@@ -76,8 +81,9 @@ def get_sps_packages(**kwargs):
                 logging.info("Moving to dir: %s" % str(destination))
                 shutil.move(str(source), str(destination))
                 sps_packages_list.append(str(destination))
-        if sps_packages_list:
-            kwargs["ti"].xcom_push(key="sps_packages", value=sorted(sps_packages_list))
+
+    if sps_packages_list:
+        kwargs["ti"].xcom_push(key="sps_packages", value=sorted(sps_packages_list))
     logging.debug("get_sps_packages OUT")
 
 

--- a/airflow/tests/test_kernel_documents.py
+++ b/airflow/tests/test_kernel_documents.py
@@ -11,58 +11,59 @@ from kernel_documents import get_sps_packages
 
 
 class TestGetSPSPackages(TestCase):
-
-    def setUp(self):
-        self.test_environ = {
-            "XC_SPS_PACKAGES_DIR": "dir/source",
-            "PROC_SPS_PACKAGES_DIR": "dir/destination",
-        }
+    @patch('kernel_documents.Variable.get')
+    def test_get_sps_packages_raises_error_if_no_xc_dir_from_variable(self,
+                                                                      mk_variable_get):
+        mk_variable_get.side_effect = KeyError
+        self.assertRaises(KeyError, get_sps_packages)
 
     @patch('kernel_documents.Path')
     @patch('kernel_documents.Variable.get')
-    def test_get_sps_packages_xc_dir_from_env_var_is_None(self, mk_variable_get,
-                                                          MockPath):
-        mk_variable_get.return_value = None
-        get_sps_packages(**{"scilista": ["rba v53n1"]})
-        MockPath.assert_not_called()
-
-    @patch('kernel_documents.Path')
-    @patch('kernel_documents.Variable.get')
-    def test_get_sps_packages_gets_xc_dir_from_env_var(self, mk_variable_get,
+    @patch('kernel_documents.open')
+    def test_get_sps_packages_gets_xc_dir_from_variable(self, mk_open, mk_variable_get,
                                                        MockPath):
 
-        mk_variable_get.side_effect = ["dir/source", "dir/destination"]
-        get_sps_packages(**{"scilista": ["rba v53n1"]})
+        mk_variable_get.side_effect = ["dir/path/scilista.lst",
+                                       "dir/source",
+                                       "dir/destination"]
+        get_sps_packages()
         MockPath.assert_any_call("dir/source")
         MockPath.assert_any_call("dir/destination")
 
     @patch('kernel_documents.shutil')
     @patch('kernel_documents.Variable.get')
+    @patch('kernel_documents.open')
     def test_get_sps_packages_moves_from_xc_dir_if_xc_source_exists(self,
+                                                                    mk_open,
                                                                     mk_variable_get,
                                                                     mk_shutil):
-        mk_variable_get.return_value = None
-        get_sps_packages(**{"scilista": {"rba": "v53n2"}})
+        mk_variable_get.return_value = ""
+        get_sps_packages()
         mk_shutil.move.assert_not_called()
 
     @patch('kernel_documents.shutil')
     @patch('kernel_documents.os.path.exists')
     @patch('kernel_documents.Variable.get')
+    @patch('kernel_documents.open')
     def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(self,
+                                                            mk_open,
                                                             mk_variable_get,
                                                             mk_path_exists,
                                                             mk_shutil):
         test_dest_dir_name = "sps_packages"
         mk_path_exists.return_value = True
+        mk_open.return_value.__enter__.return_value.readlines.return_value = [
+            "rba v53n1",
+        ]
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             test_paths = [
+                "dir/path/scilista.lst",
                 "../fixtures",
                 tmpdirname,
             ]
             mk_variable_get.side_effect = test_paths
             kwargs = {
-                "scilista": ["rba v53n1"],
                 "ti": MagicMock(),
             }
             get_sps_packages(**kwargs)
@@ -74,11 +75,12 @@ class TestGetSPSPackages(TestCase):
     @patch('kernel_documents.shutil')
     @patch('kernel_documents.os.path.exists')
     @patch('kernel_documents.Variable.get')
+    @patch('kernel_documents.open')
     def test_get_sps_packages_doesnt_call_ti_xcom_push_if_no_sps_packages_list(
-        self,  mk_variable_get, mk_path_exists, mk_shutil
+        self, mk_open, mk_variable_get, mk_path_exists, mk_shutil
     ):
         mk_path_exists.return_value = False
-        mk_variable_get.return_value = None
+        mk_variable_get.return_value = ""
         kwargs = {
             "scilista": ["rba v53n1"],
             "ti": MagicMock(),
@@ -89,20 +91,21 @@ class TestGetSPSPackages(TestCase):
     @patch('kernel_documents.shutil')
     @patch('kernel_documents.os.path.exists')
     @patch('kernel_documents.Variable.get')
+    @patch('kernel_documents.open')
     def test_get_sps_packages_calls_ti_xcom_push_with_sps_packages_list(
-        self, mk_variable_get, mk_path_exists, mk_shutil
+        self, mk_open, mk_variable_get, mk_path_exists, mk_shutil
     ):
         mk_path_exists.return_value = True
         mk_variable_get.return_value = "dir/destination/"
+        mk_open.return_value.__enter__.return_value.readlines.return_value = [
+            "rba v53n1",
+            "rba 2018nahead",
+            "rsp v10n2-3",
+            "abc v50"
+        ]
         kwargs = {
-            "scilista": [
-                "rba v53n1",
-                "rba 2018nahead",
-                "rsp v10n2-3",
-                "abc v50"
-            ]
+            "ti": MagicMock()
         }
-        kwargs["ti"] = MagicMock()
         get_sps_packages(**kwargs)
         kwargs["ti"].xcom_push.assert_called_once_with(
             key="sps_packages",
@@ -113,6 +116,13 @@ class TestGetSPSPackages(TestCase):
                 "dir/destination/rsp_v10n2-3.zip",
             ]
         )
+
+    @patch('kernel_documents.open')
+    @patch('kernel_documents.Variable.get')
+    def test_read_scilista_from_file(self, mk_variable_get, mk_open):
+        mk_variable_get.return_value = "dir/path/scilista.lst"
+        get_sps_packages()
+        mk_open.assert_called_once_with("dir/path/scilista.lst")
 
 
 suite = TestLoader().loadTestsFromTestCase(TestGetSPSPackages)


### PR DESCRIPTION
#### O que esse PR faz?
Altera a obtenção do pacotes SPS p/ ler Scilista de arquivo. Antes da alteração estava recebendo uma lista como parâmetros mas decidimos que ler do arquivo `scilista.lst` seria melhor. Este arquivo será lido de path configurado no Airflow, que deve ser acessível pelo servidor onde a aplicação rodar.

#### Onde a revisão poderia começar?
Em `airflow/dags/kernel_documents.py`

#### Como este poderia ser testado manualmente?
- Rodando os testes unitários:
`docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest discover -v`
OU
- Configurando as variáveis:
  * `SCILISTA_FILE_PATH`: caminho do arquivo `scilista.lst`
  * `XC_SPS_PACKAGES_DIR`: diretório com pacotes SPS (.zips)
  * `PROC_SPS_PACKAGES_DIR `: diretório de processamento
  Ao executar a DAG, os pacotes determinados na scilista devem ter sido movidos de `XC_SPS_PACKAGES_DIR` para `PROC_SPS_PACKAGES_DIR`

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#53 #45

### Referências
Nenhuma.
