### PR TITLE
Adiciona deleção de documentos do Kernel

### DIFF
--- a/airflow/dags/kernel_documents.py
+++ b/airflow/dags/kernel_documents.py
@@ -6,10 +6,12 @@ from datetime import timedelta
 from pathlib import Path
 from zipfile import ZipFile
 
+from lxml import etree
 from airflow import DAG
 from airflow.models import Variable
 from airflow import utils as airflow_utils
 from airflow.operators.python_operator import PythonOperator
+
 
 """
     DAG responsável adicionar/atualizar os pacotes SPS no Kernel.
@@ -94,34 +96,75 @@ def list_documents(**kwargs):
     Lista todos os XMLs dos SPS Packages da lista obtida do diretório do XC.
 
     list sps_packages: lista com os paths dos pacotes SPS no diretório de processamento
-    list sps_xmls_list: lista com os nomes dos arquivos XML existentes nos pacotes SPS
+    dict sps_packages_xmls: dict com os paths dos pacotes SPS e os respectivos nomes dos
+        arquivos XML.
     """
     logging.debug("list_documents IN")
     sps_packages_list = kwargs["ti"].xcom_pull(
         key="sps_packages",
         task_ids="get_sps_packages_id"
     )
-    xmls_filenames = []
-    for sps_package in sps_packages_list:
+    sps_packages_xmls = {}
+    for sps_package in sps_packages_list or []:
         logging.info("Reading sps_package: %s" % sps_package)
         with ZipFile(sps_package) as zf:
-            xmls_filenames += [
+            xmls_filenames = [
                 xml_filename
                 for xml_filename in zf.namelist()
                 if os.path.splitext(xml_filename)[-1] == '.xml'
             ]
-    if xmls_filenames:
+            if xmls_filenames:
+                sps_packages_xmls[sps_package] = xmls_filenames
+    if sps_packages_xmls:
         kwargs["ti"].xcom_push(
-            key="sps_xmls_list",
-            value=xmls_filenames
+            key="sps_packages_xmls",
+            value=sps_packages_xmls
         )
     logging.debug("list_documents OUT")
 
 
 def read_xmls(**kwargs):
-    print("read_xmls IN")
-    print("Lê XMLs para tratar documentos (Deletar, Registrar ou Atualizar) e gera listas")
-    print("read_xmls OUT")
+    """
+    Lê XMLs para tratar documentos (Deletar, Registrar ou Atualizar) e gera listas
+
+    dict sps_packages_xmls: dict com os paths dos pacotes SPS e os respectivos nomes dos
+        arquivos XML.
+    list docs_to_delete: lista de XMLs para deletar do Kernel
+    list docs_to_preserve: lista de XMLs para manter no Kernel (Registrar ou atualizar)
+    """
+    logging.debug("read_xmls IN")
+    sps_packages_xmls = kwargs["ti"].xcom_pull(key="sps_packages_xmls", task_id="list_documents_id")
+
+    docs_to_delete = []
+    docs_to_preserve = []
+    for sps_package, sps_xml_files in (sps_packages_xmls or {}).items():
+        logging.info("Reading sps_package: %s" % sps_package)
+        with ZipFile(sps_package) as zf:
+            for sps_xml_file in sps_xml_files:
+                xml_content = zf.read(sps_xml_file)
+                if len(xml_content) > 0:
+                    xml_file = etree.XML(xml_content)
+                    scielo_id = xml_file.find(".//article-id[@specific-use='scielo']")
+                    if scielo_id is not None:
+                        delete_tag = scielo_id.getparent().find(
+                            "./article-id[@specific-use='delete']"
+                        )
+                        if delete_tag is not None:
+                            docs_to_delete.append(scielo_id.text)
+                        else:
+                            docs_to_preserve.append(scielo_id.text)
+
+    if docs_to_delete:
+        kwargs["ti"].xcom_push(
+            key="docs_to_delete",
+            value=docs_to_delete
+        )
+    if docs_to_preserve:
+        kwargs["ti"].xcom_push(
+            key="docs_to_preserve",
+            value=docs_to_preserve
+        )
+    logging.debug("read_xmls OUT")
 
 
 def delete_documents(**kwargs):

--- a/airflow/tests/test_kernel_documents.py
+++ b/airflow/tests/test_kernel_documents.py
@@ -4,8 +4,19 @@ from unittest import TestSuite, TestCase, TestLoader, TextTestRunner
 from unittest.mock import patch, MagicMock
 
 from airflow import DAG
+from lxml import etree
 
-from kernel_documents import get_sps_packages, list_documents
+from kernel_documents import get_sps_packages, list_documents, read_xmls
+
+
+XML_FILE_CONTENT = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "JATS-journalpublishing1.dtd">
+<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.5" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <article-meta>
+        <article-id pub-id-type="publisher-id" specific-use="scielo">FX6F3cbyYmmwvtGmMB7WCgr</article-id>
+    </article-meta>
+</article>
+"""
 
 
 class TestGetSPSPackages(TestCase):
@@ -145,6 +156,14 @@ class TestListDocuments(TestCase):
         )
 
     @patch('kernel_documents.ZipFile')
+    def test_list_document_empty_ti_sps_packages_list(self, MockZipFile):
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = None
+        list_documents(**kwargs)
+        MockZipFile.assert_not_called()
+        kwargs["ti"].xcom_push.assert_not_called()
+
+    @patch('kernel_documents.ZipFile')
     def test_list_document_opens_all_zips(self, MockZipFile):
         sps_packages = [
             "dir/destination/abc_v50.zip",
@@ -160,31 +179,47 @@ class TestListDocuments(TestCase):
     @patch('kernel_documents.ZipFile')
     def test_list_document_reads_all_xmls_from_all_zips(self, MockZipFile):
         sps_packages = [
+            "dir/destination/abc_v50.zip",
             "dir/destination/rba_v53n1.zip",
         ]
-        sps_packages_file_list = [
-            '1806-907X-rba-53-01-1-8.xml',
-            'v53n1a01.pdf',
-            '1806-907X-rba-53-01-1-8-gpn1a01t1.htm',
-            '1806-907X-rba-53-01-1-8-gpn1a01g1.htm',
-            '1806-907X-rba-53-01-9-18.xml',
-            'v53n1a02.pdf',
-            '1806-907X-rba-53-01-19-25.xml',
-            '1806-907X-rba-53-01-19-25-g1.jpg',
-            'v53n1a03.pdf',
+        sps_packages_file_lists = [
+            [
+                '0123-4567-abc-50-1-8.xml',
+                'v53n1a01.pdf',
+                '0123-4567-abc-50-1-8-gpn1a01t1.htm',
+                '0123-4567-abc-50-1-8-gpn1a01g1.htm',
+                '0123-4567-abc-50-9-18.xml',
+                'v53n1a02.pdf',
+            ],
+            [
+                '1806-907X-rba-53-01-1-8.xml',
+                'v53n1a01.pdf',
+                '1806-907X-rba-53-01-1-8-gpn1a01t1.htm',
+                '1806-907X-rba-53-01-1-8-gpn1a01g1.htm',
+                '1806-907X-rba-53-01-9-18.xml',
+                'v53n1a02.pdf',
+                '1806-907X-rba-53-01-19-25.xml',
+                '1806-907X-rba-53-01-19-25-g1.jpg',
+                'v53n1a03.pdf',
+            ],
         ]
         kwargs = {"ti": MagicMock()}
         kwargs["ti"].xcom_pull.return_value = sps_packages
-        MockZipFile.return_value.__enter__.return_value.namelist.return_value = \
-            sps_packages_file_list
+        MockZipFile.return_value.__enter__.return_value.namelist.side_effect = \
+            sps_packages_file_lists
         list_documents(**kwargs)
         kwargs["ti"].xcom_push.assert_called_once_with(
-            key="sps_xmls_list",
-            value=[
-                xml_filename
-                for xml_filename in sps_packages_file_list
-                if os.path.splitext(xml_filename)[-1] == '.xml'
-            ]
+            key="sps_packages_xmls",
+            value={
+                'dir/destination/abc_v50.zip': [
+                    '0123-4567-abc-50-1-8.xml',
+                    '0123-4567-abc-50-9-18.xml'
+                ],
+                'dir/destination/rba_v53n1.zip': [
+                    '1806-907X-rba-53-01-1-8.xml',
+                    '1806-907X-rba-53-01-9-18.xml',
+                    '1806-907X-rba-53-01-19-25.xml']
+            }
         )
 
     @patch('kernel_documents.ZipFile')
@@ -203,6 +238,105 @@ class TestListDocuments(TestCase):
             sps_packages_file_list
         list_documents(**kwargs)
         kwargs["ti"].xcom_push.assert_not_called()
+
+
+class TestReadXML(TestCase):
+    def test_read_xmls_gets_ti_xcom_info(self):
+        kwargs = {"ti": MagicMock()}
+        read_xmls(**kwargs)
+        kwargs["ti"].xcom_pull.assert_called_once_with(
+            key="sps_packages_xmls",
+            task_id="list_documents_id"
+        )
+
+    @patch('kernel_documents.ZipFile')
+    def test_read_xmls_empty_ti_xcom_info(self, MockZipFile):
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = None
+        read_xmls(**kwargs)
+        MockZipFile.assert_not_called()
+        kwargs["ti"].xcom_push.assert_not_called()
+
+    @patch('kernel_documents.ZipFile')
+    def test_read_xmls_opens_all_zips(self, MockZipFile):
+        sps_packages_xmls = {
+            'dir/destination/abc_v50.zip': [],
+            'dir/destination/rba_v53n1.zip': []
+        }
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = sps_packages_xmls
+        read_xmls(**kwargs)
+        for sps_package in sps_packages_xmls.keys():
+            with self.subTest(sps_package=sps_package):
+                MockZipFile.assert_any_call(sps_package)
+
+    @patch('kernel_documents.ZipFile')
+    def test_read_xmls_reads_each_xml_from_each_zips(self, MockZipFile):
+        sps_packages_xmls = {
+            'dir/destination/abc_v50.zip': [
+                '0123-4567-abc-50-1-8.xml',
+                '0123-4567-abc-50-9-18.xml'
+            ],
+            'dir/destination/rba_v53n1.zip': [
+                '1806-907X-rba-53-01-1-8.xml',
+                '1806-907X-rba-53-01-9-18.xml',
+                '1806-907X-rba-53-01-19-25.xml']
+        }
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = sps_packages_xmls
+        MockZipFile.return_value.__enter__.return_value.read.return_value = b""
+
+        read_xmls(**kwargs)
+        for sps_xml_files in sps_packages_xmls.values():
+            with self.subTest(sps_xml_files=sps_xml_files):
+                for sps_xml_file in sps_xml_files:
+                    MockZipFile.return_value.__enter__.return_value.read.assert_any_call(
+                        sps_xml_file
+                    )
+
+    @patch('kernel_documents.ZipFile')
+    def test_read_xmls_adds_scielo_id_from_deleted_xml_to_docs_to_delete(self, MockZipFile):
+        sps_packages_xmls = {
+            'dir/destination/rba_v53n1.zip': [
+                '1806-907X-rba-53-01-1-8.xml',
+            ]
+        }
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = sps_packages_xmls
+        article_id = etree.Element("article-id")
+        article_id.set("specific-use", "delete")
+        xml_file = etree.XML(XML_FILE_CONTENT)
+        am_tag = xml_file.find(".//article-meta")
+        am_tag.append(article_id)
+        deleted_xml_file = etree.tostring(xml_file)
+        MockZipFile.return_value.__enter__.return_value.read.return_value = deleted_xml_file
+
+        read_xmls(**kwargs)
+        kwargs["ti"].xcom_push.assert_called_once_with(
+            key="docs_to_delete",
+            value=["FX6F3cbyYmmwvtGmMB7WCgr"]   # SciELO ID de XML_FILE_CONTENT
+        )
+
+    @patch('kernel_documents.ZipFile')
+    def test_read_xmls_adds_scielo_id_from_xml_to_docs_to_preserve_if_it_isnt_doc_to_delete(
+        self, MockZipFile
+    ):
+        sps_packages_xmls = {
+            'dir/destination/rba_v53n1.zip': [
+                '1806-907X-rba-53-01-1-8.xml',
+            ]
+        }
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = sps_packages_xmls
+        xml_file = etree.XML(XML_FILE_CONTENT)
+        xml_file_to_preserve = etree.tostring(xml_file)
+        MockZipFile.return_value.__enter__.return_value.read.return_value = xml_file_to_preserve
+
+        read_xmls(**kwargs)
+        kwargs["ti"].xcom_push.assert_called_once_with(
+            key="docs_to_preserve",
+            value=["FX6F3cbyYmmwvtGmMB7WCgr"]   # SciELO ID de XML_FILE_CONTENT
+        )
 
 
 if __name__ == '__main__':

--- a/airflow/tests/test_kernel_documents.py
+++ b/airflow/tests/test_kernel_documents.py
@@ -1,12 +1,19 @@
 import os
+import http.client
+import shutil
 import tempfile
 from unittest import TestSuite, TestCase, TestLoader, TextTestRunner
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, Mock, MagicMock
 
 from airflow import DAG
 from lxml import etree
 
-from kernel_documents import get_sps_packages, list_documents, read_xmls
+from kernel_documents import (
+    get_sps_packages,
+    list_documents,
+    read_xmls,
+    delete_documents,
+)
 
 
 XML_FILE_CONTENT = b"""<?xml version="1.0" encoding="UTF-8"?>
@@ -246,7 +253,7 @@ class TestReadXML(TestCase):
         read_xmls(**kwargs)
         kwargs["ti"].xcom_pull.assert_called_once_with(
             key="sps_packages_xmls",
-            task_id="list_documents_id"
+            task_ids="list_documents_id"
         )
 
     @patch('kernel_documents.ZipFile')
@@ -336,6 +343,78 @@ class TestReadXML(TestCase):
         kwargs["ti"].xcom_push.assert_called_once_with(
             key="docs_to_preserve",
             value=["FX6F3cbyYmmwvtGmMB7WCgr"]   # SciELO ID de XML_FILE_CONTENT
+        )
+
+
+class TestDeleteDocuments(TestCase):
+    def test_delete_documents_gets_ti_xcom_info(self):
+        kwargs = {"ti": MagicMock()}
+        delete_documents(**kwargs)
+        kwargs["ti"].xcom_pull.assert_called_once_with(
+            key="docs_to_delete",
+            task_ids="read_xmls_id"
+        )
+
+    @patch('kernel_documents.kernel_connect')
+    def test_delete_documents_empty_ti_xcom_info(
+        self, mk_kernel_connect
+    ):
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = None
+        delete_documents(**kwargs)
+        mk_kernel_connect.assert_not_called()
+
+    @patch('kernel_documents.kernel_connect')
+    def test_delete_documents_calls_kernel_connect_with_docs_to_delete(
+        self, mk_kernel_connect
+    ):
+        docs_to_delete = [
+            "FX6F3cbyYmmwvtGmMB7WCgr",
+            "GZ5K2cbyYmmwvtGmMB71243",
+            "KU890cbyYmmwvtGmMB7JUk4",
+        ]
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = docs_to_delete
+        delete_documents(**kwargs)
+        for doc_to_delete in docs_to_delete:
+            with self.subTest(doc_to_delete=doc_to_delete):
+                mk_kernel_connect.assert_any_call(
+                    "/documents/" + doc_to_delete,
+                    "DELETE"
+                )
+
+    @patch('kernel_documents.kernel_connect')
+    @patch('kernel_documents.logging')
+    def test_delete_documents_calls_kernel_connect_with_docs_to_delete(
+        self, mk_logging, mk_kernel_connect
+    ):
+        docs_to_delete = [
+            "FX6F3cbyYmmwvtGmMB7WCgr",
+            "GZ5K2cbyYmmwvtGmMB71243",
+            "KU890cbyYmmwvtGmMB7JUk4",
+        ]
+        kwargs = {"ti": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = docs_to_delete
+        mk_response_ok = Mock(status_code=http.client.NO_CONTENT)
+        mk_response_error = Mock(status_code=http.client.NOT_FOUND)
+        kernel_conn_status = [
+            mk_response_ok,
+            mk_response_error,
+            mk_response_ok,
+        ]
+        mk_kernel_connect.side_effect = kernel_conn_status
+        delete_documents(**kwargs)
+        mk_logging.info.assert_any_call(
+            "Document %s deleted from kernel status: %d"
+            % (docs_to_delete[0], http.client.NO_CONTENT)
+        )
+        mk_logging.info.assert_any_call(
+            "Document %s not found in kernel: %d"
+            % (docs_to_delete[1], http.client.NOT_FOUND)
+        )
+        mk_logging.info.assert_any_call(
+            "Document %s deleted from kernel status: %d"
+            % (docs_to_delete[2], http.client.NO_CONTENT)
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Implementa a leitura dos XML dos pacotes SPS listados na tarefa `list_documents` e cria duas listas: uma com os SciELO IDs de documentos para deletar e outra de documentos para manter. Os documentos para deleção são deletados do Kernel na tarefa de deleção.
Também foram feitos ajustes no `list_documents` para entregar os pacotes SPS e seus respectivos XMLs

#### Onde a revisão poderia começar?
Em `airflow/dags/kernel_documents.py`, no callable Python `read_xmls`.

#### Como este poderia ser testado manualmente?
- Rodando os testes unitários:
`docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest discover -v`
OU
- Criando pacote SPS e scilista em diretórios locais e configurando as variáveis pela interface do airflow:
  * `SCILISTA_FILE_PATH`: caminho do arquivo `scilista.lst`
  * `XC_SPS_PACKAGES_DIR`: diretório com pacotes SPS (.zips)
  * `PROC_SPS_PACKAGES_DIR `: diretório de processamento
  - Executar as tasks na sequencia:
     * `docker-compose -f docker-compose-dev.yml exec opac-airflow test kernel_documents get_sps_packages_id 2019-07-22`
     * `docker-compose -f docker-compose-dev.yml exec opac-airflow test kernel_documents list_documents_id 2019-07-22`
     * `docker-compose -f docker-compose-dev.yml exec opac-airflow test kernel_documents read_xmls_id 2019-07-22`
     * `docker-compose -f docker-compose-dev.yml exec opac-airflow test kernel_documents delete_documents_id 2019-07-22`

#### Algum cenário de contexto que queira dar?
N/A.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#43 #52

### Referências
Nenhuma.
