### PR TITLE
Adiciona conceito de pastas temporárias de trabalho

### DIFF
--- a/airflow/dags/kernel_gate.py
+++ b/airflow/dags/kernel_gate.py
@@ -268,13 +268,20 @@ def process_journals(**context):
     """Processa uma lista de journals carregados a partir do resultado
     de leitura da base MST"""
 
-    journals = context["ti"].xcom_pull(task_ids="read_title_mst")
+    title_json_path = context["ti"].xcom_pull(
+        task_ids="copy_mst_bases_to_work_folder_task", key="title_json_path"
+    )
+
+    with open(title_json_path, "r") as f:
+        journals = f.read()
+        logging.info("reading file from %s." % (title_json_path))
+
     journals = json.loads(journals)
     journals_as_kernel = [journal_as_kernel(Journal(journal)) for journal in journals]
 
     for journal in journals_as_kernel:
         _id = journal.pop("_id")
-        response = register_or_update(_id, journal, KERNEL_API_JOURNAL_ENDPOINT)
+        register_or_update(_id, journal, KERNEL_API_JOURNAL_ENDPOINT)
 
 
 def process_issues(**context):
@@ -295,7 +302,14 @@ def process_issues(**context):
 
         return issues
 
-    issues = context["ti"].xcom_pull(task_ids="read_issue_mst")
+    issue_json_path = context["ti"].xcom_pull(
+        task_ids="copy_mst_bases_to_work_folder_task", key="issue_json_path"
+    )
+
+    with open(issue_json_path, "r") as f:
+        issues = f.read()
+        logging.info("reading file from %s." % (issue_json_path))
+
     issues = json.loads(issues)
     issues = [Issue({"issue": data}) for data in issues]
     issues = filter_issues(issues)
@@ -303,7 +317,7 @@ def process_issues(**context):
 
     for issue in issues_as_kernel:
         _id = issue.pop("_id")
-        response = register_or_update(_id, issue, KERNEL_API_BUNDLES_ENDPOINT)
+        register_or_update(_id, issue, KERNEL_API_BUNDLES_ENDPOINT)
 
 
 def copy_mst_files_to_work_folder(**kwargs):

--- a/airflow/dags/kernel_gate.py
+++ b/airflow/dags/kernel_gate.py
@@ -415,20 +415,20 @@ extract_issue_task = BashOperator(
 )
 
 
-work_on_journals = PythonOperator(
-    task_id="work_on_journals",
+process_journals_task = PythonOperator(
+    task_id="process_journals_task",
     python_callable=process_journals,
     dag=dag,
     provide_context=True,
     params={"process_journals": True},
 )
 
-work_on_issues = PythonOperator(
-    task_id="work_on_issues",
+process_issues_task = PythonOperator(
+    task_id="process_issues_task",
     python_callable=process_issues,
     dag=dag,
     provide_context=True,
 )
 
 create_work_folders_task >> copy_mst_bases_to_work_folder_task >> extract_title_task
-extract_title_task >> extract_issue_task >> work_on_journals >> work_on_issues
+extract_title_task >> extract_issue_task >> process_journals_task >> process_issues_task

--- a/airflow/dags/kernel_gate.py
+++ b/airflow/dags/kernel_gate.py
@@ -24,22 +24,27 @@ Para o devido entendimento desta DAG pode-se ter como base a seguinte explicaç�
 Esta DAG possui tarefas que são iniciadas a partir de um TRIGGER externo. As fases
 de execução são às seguintes:
 
-1) Ler a base TITLE em formato MST
-1.1) Armazena output do isis2json na área de trabalho xcom
-
-2) Ler a base ISSUE em formato MST
-2.2) Armazena output do isis2json na área de trabalho xcom
-
-3) Envia os dados da base TITLE para a API do Kernel
-3.1) Itera entre os periódicos lidos da base TITLE
-3.2) Converte o periódico para o formato JSON aceito pelo Kernel
-3.3) Verifica se o Journal já existe na API Kernel
-3.3.1) Faz o diff do entre o payload gerado e os metadados vindos do Kernel
-3.3.2) Se houver diferenças faz-ze um PATCH para atualizar o registro
-3.4) Se o Journal não existir
-3.4.1) Remove as chaves nulas
-3.4.2) Faz-se um PUT para criar o registro
-3.5) Dispara o DAG subsequente.
+1) Cria as pastas temporárias de trabalho, sendo elas:
+    a) /airflow_home/{{ dag_run }}/isis
+    b) /airflow_home/{{ dag_run }}/json
+2) Faz uma cópia das bases MST:
+    a) A partir das variáveis `BASE_ISSUE_FOLDER_PATH` e `BASE_TITLE_FOLDER_PATH`
+    b) Retorna XCOM com os paths exatos de onde os arquivos MST estarão
+    c) Retorna XCOM com os paths exatos de onde os resultados da extração MST devem ser depositados  
+3) Ler a base TITLE em formato MST
+    a) Armazena output do isis2json no arquivo `/airflow_home/{{ dag_run }}/json/title.json`
+4) Ler a base ISSUE em formato MST
+    a) Armazena output do isis2json no arquivo `/airflow_home/{{ dag_run }}/json/issue.json`
+5) Envia os dados da base TITLE para a API do Kernel
+    a) Itera entre os periódicos lidos da base TITLE
+    b) Converte o periódico para o formato JSON aceito pelo Kernel
+    c) Verifica se o Journal já existe na API Kernel
+        I) Faz o diff do entre o payload gerado e os metadados vindos do Kernel
+        II) Se houver diferenças faz-ze um PATCH para atualizar o registro
+    d) Se o Journal não existir
+        I) Remove as chaves nulas
+        II) Faz-se um PUT para criar o registro
+6) Dispara o DAG subsequente.
 """
 
 BASE_PATH = os.path.dirname(os.path.dirname(__file__))

--- a/airflow/dags/kernel_gate.py
+++ b/airflow/dags/kernel_gate.py
@@ -333,6 +333,16 @@ def process_issues(**context):
         response = register_or_update(_id, issue, KERNEL_API_BUNDLES_ENDPOINT)
 
 
+CREATE_FOLDER_TEMPLATES = """
+    mkdir -p '{{ var.value.WORK_FOLDER_PATH }}/{{ run_id }}/isis' && \
+    mkdir -p '{{ var.value.WORK_FOLDER_PATH }}/{{ run_id }}/json'"""
+
+create_work_folders_task = BashOperator(
+    task_id="create_work_folders_task", bash_command=CREATE_FOLDER_TEMPLATES, dag=dag
+)
+
+
+
 work_on_journals = PythonOperator(
     task_id="work_on_journals",
     python_callable=process_journals,


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona o conceito de pastas temporárias de trabalho onde os insumos de dados como por ex bases MST, arquivos JSON, viverão durante o período de vida do processo.

#### Onde a revisão poderia começar?
- `airflow/dags/kernel_gate.py` L: `368`

#### Como este poderia ser testado manualmente?
Para testar manualmente este PR deve-se:
- Configurar a variável `BASE_TITLE_FOLDER_PATH` para a pasta que contenha a base issue, ex: `/usr/local/airflow/bases/scl/title`;
- Configurar a variável `BASE_ISSUE_FOLDER_PATH` para a pasta que contenha a base issue, ex: `/usr/local/airflow/bases/scl/issue`;
- Configurar a variável `WORK_FOLDER_PATH` para a pasta de trabalho temporária ex ` /usr/local/airflow/work/ `
- Inicie a DAG;
- Observe a criação as pastas de trabalho e pastas de execução com a data e hora relativas ao horário de execução da DAG;
- O processo de espelhamento deve ocorrer com sucesso;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A