### PR TITLE
Adiciona registro/atualização de documentos no Minio e Kernel

### DIFF
--- a/airflow/.coveragerc
+++ b/airflow/.coveragerc
@@ -1,0 +1,29 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+source =
+    dags/
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+omit =
+    src/
+    tests/

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir numpy==1.16.2 \
     && pip install --no-cache-dir pandas==0.24.1 \
     && pip install --no-cache-dir -r requirements.txt \
-    && pip install --no-cache-dir apache-airflow==01.10.2 \
+    && pip install --no-cache-dir apache-airflow[s3]==01.10.2 \
     && pip install --no-cache-dir -e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
 
 RUN pip install --no-cache-dir xylose==1.35.1 \

--- a/airflow/Dockerfile-dev
+++ b/airflow/Dockerfile-dev
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir numpy==1.16.2 \
     && pip install --no-cache-dir pandas==0.24.1 \
     && pip install --no-cache-dir -r requirements.txt \
-    && pip install --no-cache-dir apache-airflow==01.10.2 \
+    && pip install --no-cache-dir apache-airflow[s3]==01.10.2 \
     && pip install --no-cache-dir -e git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
 
 RUN pip install --no-cache-dir xylose==1.35.1 \

--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -6,18 +6,30 @@ from tenacity import (
     retry_if_exception_type,
 )
 from airflow.hooks.http_hook import HttpHook
+from airflow.hooks.S3_hook import S3Hook
 
 
 @retry(
     wait=wait_exponential(),
     stop=stop_after_attempt(4),
-    retry=retry_if_exception_type(
-        (requests.ConnectionError,
-        requests.Timeout),
-    ),
+    retry=retry_if_exception_type((requests.ConnectionError, requests.Timeout)),
 )
-def kernel_connect(endpoint, method, timeout=1):
+def kernel_connect(endpoint, method, data=None, timeout=1):
     api_hook = HttpHook(http_conn_id="kernel_conn", method=method)
-    response = api_hook.run(endpoint=endpoint, extra_options={"timeout": timeout})
+    response = api_hook.run(
+        endpoint=endpoint, data=data, extra_options={"timeout": timeout}
+    )
     response.raise_for_status()
     return response
+
+
+@retry(
+    wait=wait_exponential(),
+    stop=stop_after_attempt(4),
+    retry=retry_if_exception_type((requests.ConnectionError, requests.Timeout)),
+)
+def object_store_connect(bytes_data, filepath, bucket_name):
+    s3_hook = S3Hook(aws_conn_id="aws_default")
+    s3_hook.load_bytes(bytes_data, key=filepath, bucket_name=bucket_name, replace=True)
+    s3_host = s3_hook.get_connection("aws_default").extra_dejson.get("host")
+    return "{}/{}/{}".format(s3_host, bucket_name, filepath)

--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -1,0 +1,357 @@
+import os
+import itertools
+import logging
+
+from copy import deepcopy
+from lxml import etree
+
+
+logger = logging.getLogger(__name__)
+
+
+def parse_date(_date):
+    def format(value):
+        if value and value.isdigit():
+            return value.zfill(2)
+        return value or ""
+
+    if _date is not None:
+        return tuple(
+            [format(_date.findtext(item) or "") for item in ["year", "month", "day"]]
+        )
+    return "", "", ""
+
+
+def parse_value(value):
+    value = value.lower()
+    if value.isdigit():
+        return value.zfill(2)
+    if "spe" in value:
+        return "spe"
+    if "sup" in value:
+        return "s"
+    return value
+
+
+def parse_issue(issue):
+    issue = " ".join([item for item in issue.split()])
+    parts = issue.split()
+    parts = [parse_value(item) for item in parts]
+    s = "-".join(parts)
+    s = s.replace("spe-", "spe")
+    s = s.replace("s-", "s")
+    if s.endswith("s"):
+        s += "0"
+    return s
+
+
+class SPS_Package:
+    def __init__(self, xmltree, _original_asset_name_prefix=None):
+        self.xmltree = xmltree
+        self._original_asset_name_prefix = _original_asset_name_prefix
+
+    @property
+    def article_meta(self):
+        return self.xmltree.find(".//article-meta")
+
+    @property
+    def xmltree(self):
+        return self._xmltree
+
+    @xmltree.setter
+    def xmltree(self, value):
+        try:
+            etree.tostring(value)
+        except TypeError:
+            raise
+        else:
+            self._xmltree = value
+
+    @property
+    def issn(self):
+        return (
+            self.xmltree.findtext('.//issn[@pub-type="epub"]')
+            or self.xmltree.findtext('.//issn[@pub-type="ppub"]')
+            or self.xmltree.findtext(".//issn")
+        )
+
+    @property
+    def acron(self):
+        return self.xmltree.findtext('.//journal-id[@journal-id-type="publisher-id"]')
+
+    @property
+    def publisher_id(self):
+        try:
+            return self.xmltree.xpath(
+                './/article-id[not(@specific-use="scielo") and @pub-id-type="publisher-id"]/text()'
+            )[0]
+        except IndexError:
+            return None
+
+    @property
+    def journal_meta(self):
+        data = []
+        issns = [
+            self.xmltree.findtext('.//issn[@pub-type="epub"]'),
+            self.xmltree.findtext('.//issn[@pub-type="ppub"]'),
+            self.xmltree.findtext(".//issn"),
+        ]
+        for issn_type, issn in zip(["eissn", "pissn", "issn"], issns):
+            if issn:
+                data.append((issn_type, issn))
+        if self.acron:
+            data.append(("acron", self.acron))
+        return data
+
+    @property
+    def document_bundle_pub_year(self):
+        if self.article_meta is not None:
+            xpaths = (
+                'pub-date[@pub-type="collection"]',
+                'pub-date[@date-type="collection"]',
+                'pub-date[@pub-type="epub-pub"]',
+                'pub-date[@pub-type="epub"]',
+            )
+            for xpath in xpaths:
+                pubdate = self.article_meta.find(xpath)
+                if pubdate is not None and pubdate.findtext("year"):
+                    return pubdate.findtext("year")
+
+    @property
+    def parse_article_meta(self):
+        elements = [
+            "volume",
+            "issue",
+            "fpage",
+            "lpage",
+            "elocation-id",
+            "pub-date",
+            "article-id",
+        ]
+        items = []
+        for elem_name in elements:
+            xpath = ".//article-meta//{}".format(elem_name)
+            for node in self.xmltree.findall(xpath):
+                if node is not None:
+                    content = node.text
+                    if node.tag == "article-id":
+                        elem_name = node.get("pub-id-type")
+                        if elem_name == "doi":
+                            if "/" in content:
+                                content = content[content.find("/") + 1 :]
+                    if node.tag == "issue":
+                        content = parse_issue(content)
+                    elif node.tag == "pub-date":
+                        content = self.document_bundle_pub_year
+                        elem_name = "year"
+                    if content and content.isdigit() and int(content) == 0:
+                        content = ""
+                    if content:
+                        items.append((elem_name, content))
+        return items
+
+    @property
+    def package_name(self):
+        if self._original_asset_name_prefix is None:
+            raise ValueError(
+                "SPS_Package._original_asset_name_prefix has an invalid value."
+            )
+        data = dict(self.parse_article_meta)
+        data_labels = data.keys()
+        labels = ["volume", "issue", "fpage", "lpage", "elocation-id"]
+        if "volume" not in data_labels and "issue" not in data_labels:
+            if "doi" in data_labels:
+                data.update({"type": "ahead"})
+                labels.append("type")
+                labels.append("year")
+                labels.append("doi")
+            elif "other" in data_labels:
+                data.update({"type": "ahead"})
+                labels.append("type")
+                labels.append("year")
+                labels.append("other")
+        elif (
+            "fpage" not in data_labels
+            and "lpage" not in data_labels
+            and "elocation-id" not in data_labels
+            and "doi" not in data_labels
+        ):
+            labels.append("other")
+        items = [self.issn, self.acron]
+        items += [data[k] for k in labels if k in data_labels]
+        return (
+            "-".join([item for item in items if item])
+            or self._original_asset_name_prefix
+        )
+
+    def asset_name(self, img_filename):
+        if self._original_asset_name_prefix is None:
+            raise ValueError(
+                "SPS_Package._original_asset_name_prefix has an invalid value."
+            )
+        filename, ext = os.path.splitext(self._original_asset_name_prefix)
+        suffix = img_filename
+        if img_filename.startswith(filename):
+            suffix = img_filename[len(filename) :]
+        return "-g".join([self.package_name, suffix])
+
+    @property
+    def elements_which_has_xlink_href(self):
+        paths = [
+            ".//ext-link[@xlink:href]",
+            ".//graphic[@xlink:href]",
+            ".//inline-graphic[@xlink:href]",
+            ".//inline-supplementary-material[@xlink:href]",
+            ".//media[@xlink:href]",
+            ".//supplementary-material[@xlink:href]",
+        ]
+        iterators = [
+            self.xmltree.iterfind(
+                path, namespaces={"xlink": "http://www.w3.org/1999/xlink"}
+            )
+            for path in paths
+        ]
+        return itertools.chain(*iterators)
+
+    @property
+    def volume(self):
+        return dict(self.parse_article_meta).get("volume")
+
+    @property
+    def number(self):
+        issue = dict(self.parse_article_meta).get("issue")
+        if issue:
+            if "s" in issue and "spe" not in issue:
+                if "-s" in issue:
+                    return issue[: issue.find("-s")]
+                if issue.startswith("s"):
+                    return None
+        return issue
+
+    @property
+    def supplement(self):
+        issue = dict(self.parse_article_meta).get("issue")
+        if issue:
+            if "s" in issue and "spe" not in issue:
+                if "-s" in issue:
+                    return issue[issue.find("-s") + 2 :]
+                if issue.startswith("s"):
+                    return issue[1:]
+
+    @property
+    def year(self):
+        return self.documents_bundle_pubdate[0]
+
+    @property
+    def documents_bundle_id(self):
+        items = []
+        data = dict(self.journal_meta)
+        for label in ["eissn", "pissn", "issn"]:
+            if data.get(label):
+                items = [data.get(label)]
+                break
+
+        items.append(data.get("acron"))
+
+        data = dict(self.parse_article_meta)
+        if not data.get("volume") and not data.get("issue"):
+            items.append("aop")
+        else:
+            labels = ("year", "volume", "issue")
+            items.extend([data[k] for k in labels if data.get(k)])
+        return "-".join(items)
+
+    @property
+    def is_only_online_publication(self):
+        fpage = self.article_meta.findtext("fpage")
+        if fpage and fpage.isdigit():
+            fpage = int(fpage)
+        if fpage:
+            return False
+
+        lpage = self.article_meta.findtext("lpage")
+        if lpage and lpage.isdigit():
+            lpage = int(lpage)
+        if lpage:
+            return False
+
+        volume = self.article_meta.findtext("volume")
+        issue = self.article_meta.findtext("issue")
+        if volume or issue:
+            return bool(self.article_meta.findtext("elocation-id"))
+
+        return True
+
+    @property
+    def order_meta(self):
+        def format(value):
+            if value and value.isdigit():
+                return value.zfill(5)
+            return value or ""
+
+        data = dict(self.parse_article_meta)
+        return (
+            ("other", format(data.get("other"))),
+            ("fpage", format(data.get("fpage"))),
+            ("lpage", format(data.get("lpage"))),
+            ("documents_bundle_pubdate", self.documents_bundle_pubdate),
+            ("document_pubdate", self.document_pubdate),
+            ("elocation-id", data.get("elocation-id", "")),
+        )
+
+    @property
+    def order(self):
+        return tuple(item[1] for item in self.order_meta)
+
+    def _match_pubdate(self, pubdate_xpaths):
+        """
+        Retorna o primeiro match da lista de pubdate_xpaths
+        """
+        for xpath in pubdate_xpaths:
+            pubdate = self.article_meta.find(xpath)
+            if pubdate is not None:
+                return pubdate
+
+    @property
+    def document_pubdate(self):
+        xpaths = (
+            'pub-date[@pub-type="epub"]',
+            'pub-date[@date-type="pub"]',
+            "pub-date",
+        )
+        return parse_date(self._match_pubdate(xpaths))
+
+    @property
+    def documents_bundle_pubdate(self):
+        xpaths = (
+            'pub-date[@pub-type="epub-ppub"]',
+            'pub-date[@pub-type="collection"]',
+            'pub-date[@date-type="collection"]',
+            "pub-date",
+        )
+        return parse_date(self._match_pubdate(xpaths))
+
+    @property
+    def scielo_id(self):
+        """The scielo id of the main document.
+        """
+        return self.xmltree.findtext(".//article-id[@specific-use='scielo']")
+
+    @property
+    def original_language(self):
+        """The the main document language.
+        """
+        return self.xmltree.get("{http://www.w3.org/XML/1998/namespace}lang")
+
+    @property
+    def translation_languages(self):
+        """All document translation languages.
+        """
+        return self.xmltree.xpath(
+            '//sub-article[@article-type="translation"]/@xml:lang'
+        )
+
+    @property
+    def assets_names(self):
+        attr_name = "{http://www.w3.org/1999/xlink}href"
+        return [node.get(attr_name) for node in self.elements_which_has_xlink_href]

--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -198,7 +198,6 @@ class SPS_Package:
     @property
     def elements_which_has_xlink_href(self):
         paths = [
-            ".//ext-link[@xlink:href]",
             ".//graphic[@xlink:href]",
             ".//inline-graphic[@xlink:href]",
             ".//inline-supplementary-material[@xlink:href]",

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -1,0 +1,155 @@
+import logging
+import os
+
+import requests
+from lxml import etree
+
+import common.hooks as hooks
+from operations.exceptions import (
+    PutDocInObjectStoreException,
+    RegisterUpdateDocIntoKernelException,
+)
+from common.sps_package import SPS_Package
+
+Logger = logging.getLogger(__name__)
+
+
+def read_file_from_zip(zipfile, filename):
+    try:
+        return zipfile.read(filename)
+    except KeyError as exc:
+        raise PutDocInObjectStoreException(
+            'Could not read file "{}" from zipfile "{}": {}'.format(
+                filename, zipfile, str(exc)
+            )
+        ) from None
+
+
+def register_update_doc_into_kernel(xml_data):
+
+    payload = {"data": xml_data["xml_url"], "assets": xml_data["assets"]}
+    try:
+        hooks.kernel_connect(
+            "/documents/{}".format(xml_data["scielo_id"]), "PUT", payload
+        )
+    except requests.exceptions.HTTPError as exc:
+        raise RegisterUpdateDocIntoKernelException(
+            'Could not PUT document "{}" in Kernel : {}'.format(
+                xml_data["xml_package_name"], str(exc)
+            )
+        ) from None
+    else:
+        for pdf_payload in (xml_data or {}).get("pdfs", []):
+            Logger.info('Putting Rendition "%s" to Kernel', pdf_payload["filename"])
+            try:
+                hooks.kernel_connect(
+                    "/documents/{}/renditions".format(xml_data["scielo_id"]),
+                    "PATCH",
+                    pdf_payload,
+                )
+            except requests.exceptions.HTTPError as exc:
+                raise RegisterUpdateDocIntoKernelException(
+                    'Could not PATCH rendition "{}" in Kernel : {}'.format(
+                        pdf_payload["filename"], str(exc)
+                    )
+                ) from None
+
+
+def get_xml_data(xml_content, xml_package_name):
+    """
+    - Obter scielo ID
+    - Obter infos de periódico e fascículo
+    - Obter nomes dos arquivos ativos digitais
+    - Obter nomes dos arquivos PDF
+    - Obter idiomas (original e traduções)
+    """
+    parser = etree.XMLParser(remove_blank_text=True, no_network=True)
+    try:
+        metadata = SPS_Package(etree.XML(xml_content, parser), xml_package_name)
+    except TypeError as exc:
+        raise PutDocInObjectStoreException(
+            'Could not get xml data from "{}" : {}'.format(xml_package_name, str(exc))
+        ) from None
+    else:
+        pdfs = [
+            {
+                "lang": metadata.original_language,
+                "filename": "{}.pdf".format(xml_package_name),
+                "mimetype": "application/pdf",
+            }
+        ]
+        for lang in metadata.translation_languages:
+            pdfs.append(
+                {
+                    "lang": lang,
+                    "filename": "{}-{}.pdf".format(xml_package_name, lang),
+                    "mimetype": "application/pdf",
+                }
+            )
+
+        return {
+            "scielo_id": metadata.scielo_id,
+            "issn": metadata.issn,
+            "volume": metadata.volume,
+            "number": metadata.number,
+            "xml_package_name": xml_package_name,
+            "assets": [
+                {"asset_id": asset_name} for asset_name in metadata.assets_names
+            ],
+            "pdfs": pdfs,
+        }
+
+
+def put_object_in_object_store(file, journal, scielo_id, filename):
+    """
+    - Persistir no Minio
+    - Adicionar em dict a URL do Minio
+    """
+    filepath = "{}/{}/{}".format(journal, scielo_id, filename)
+    try:
+        return hooks.object_store_connect(file, filepath, "documentstore")
+    except Exception as exc:
+        raise PutDocInObjectStoreException(
+            'Could not put object "{}" in object store : {}'.format(filepath, str(exc))
+        ) from None
+
+
+def put_assets_and_pdfs_in_object_store(zipfile, xml_data):
+    """
+    - Ler XML
+        - Obter dados do XML
+        - Persistir cada ativo digital
+        - Persistir cada PDF
+        - Persistir XML no Minio
+    - Retornar os dados do documento para persistir no Kernel
+    - Raise PutDocInObjectStoreException
+    """
+    for asset in (xml_data or {}).get("assets", []):
+        Logger.info('Putting Asset file "%s" to Object Store', asset["asset_id"])
+        asset["asset_url"] = put_object_in_object_store(
+            read_file_from_zip(zipfile, asset["asset_id"]),
+            xml_data["issn"],
+            xml_data["scielo_id"],
+            asset["asset_id"],
+        )
+    for pdf in (xml_data or {}).get("pdfs", []):
+        Logger.info('Putting PDF file "%s" to Object Store', pdf["filename"])
+        pdf_file = read_file_from_zip(zipfile, pdf["filename"])
+        pdf["data_url"] = put_object_in_object_store(
+            pdf_file,
+            xml_data["issn"],
+            xml_data["scielo_id"],
+            pdf["filename"],
+        )
+        pdf["size_bytes"] = len(pdf_file)
+    return xml_data
+
+
+def put_xml_into_object_store(zipfile, xml_filename):
+    xml_file = read_file_from_zip(zipfile, xml_filename)
+    xml_data = get_xml_data(xml_file, os.path.splitext(xml_filename)[-2])
+    Logger.info('Putting XML file "%s" to Object Store', xml_filename)
+    xml_data["xml_url"] = put_object_in_object_store(
+        xml_file, xml_data["issn"], xml_data["scielo_id"], xml_filename
+    )
+    return xml_data

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -87,7 +87,7 @@ def get_xml_data(xml_content, xml_package_name):
                 }
             )
 
-        return {
+        _xml_data = {
             "scielo_id": metadata.scielo_id,
             "issn": metadata.issn,
             "volume": metadata.volume,
@@ -98,6 +98,9 @@ def get_xml_data(xml_content, xml_package_name):
             ],
             "pdfs": pdfs,
         }
+        if metadata.supplement:
+            _xml_data["supplement"] = metadata.supplement
+        return _xml_data
 
 
 def put_object_in_object_store(file, journal, scielo_id, filename):

--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -1,0 +1,6 @@
+class PutDocInObjectStoreException(Exception):
+    ...
+
+
+class RegisterUpdateDocIntoKernelException(Exception):
+    ...

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -64,11 +64,12 @@ def register_update_documents(dag_run, **kwargs):
     _xmls_to_preserve = kwargs["ti"].xcom_pull(
         key="xmls_to_preserve", task_ids="delete_docs_task_id"
     )
-    _documents = sync_documents_to_kernel_operations.register_update_documents(
-        _sps_package, _xmls_to_preserve
-    )
-    if _documents:
-        kwargs["ti"].xcom_push(key="documents", value=_documents)
+    if _xmls_to_preserve:
+        _documents = sync_documents_to_kernel_operations.register_update_documents(
+            _sps_package, _xmls_to_preserve
+        )
+        if _documents:
+            kwargs["ti"].xcom_push(key="documents", value=_documents)
 
 
 list_documents_task = PythonOperator(

--- a/airflow/tests/fixtures/__init__.py
+++ b/airflow/tests/fixtures/__init__.py
@@ -1,0 +1,26 @@
+XML_FILE_CONTENT = b"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "JATS-journalpublishing1.dtd">
+<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.5" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <front>
+        <journal-meta>
+            <journal-id journal-id-type="publisher-id">rba</journal-id>
+            <issn pub-type="ppub">0034-7094</issn>
+            <issn pub-type="epub">1806-907X</issn>
+            <publisher><publisher-name>Sociedade Brasileira de Anestesiologia</publisher-name><publisher-loc>Campinas, SP, Brazil</publisher-loc></publisher>
+        </journal-meta>
+        <article-meta>
+            <article-id pub-id-type="publisher-id" specific-use="scielo">FX6F3cbyYmmwvtGmMB7WCgr</article-id>
+            <volume>53</volume>
+            <issue>1</issue>
+            <fpage>1</fpage>
+            <lpage>8</lpage>
+        </article-meta>
+    </front>
+    <body>
+        <graphic xlink:href="1806-907X-rba-53-01-1-8-g01.jpg" />
+        <graphic xlink:href="1806-907X-rba-53-01-1-8-g02.jpg" />
+    </body>
+    <sub-article article-type="translation" xml:lang="pt">
+    </sub-article>
+</article>
+"""

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -1,0 +1,477 @@
+import os
+import copy
+import random
+from unittest import TestCase, main, skip
+from unittest.mock import patch, Mock, MagicMock
+
+import requests
+from airflow import DAG
+
+from operations.docs_utils import (
+    get_xml_data,
+    read_file_from_zip,
+    register_update_doc_into_kernel,
+    put_object_in_object_store,
+    put_assets_and_pdfs_in_object_store,
+    put_xml_into_object_store,
+)
+from operations.exceptions import (
+    PutDocInObjectStoreException,
+    RegisterUpdateDocIntoKernelException,
+)
+
+from tests.fixtures import XML_FILE_CONTENT
+
+
+class TestGetXMLData(TestCase):
+    @patch("operations.docs_utils.SPS_Package")
+    @patch("operations.docs_utils.etree")
+    def test_get_xml_data_creates_etree_parser(self, mk_etree, MockSPS_Package):
+        get_xml_data(XML_FILE_CONTENT, None)
+        mk_etree.XMLParser.assert_called_once_with(
+            remove_blank_text=True, no_network=True
+        )
+
+    @patch("operations.docs_utils.SPS_Package")
+    @patch("operations.docs_utils.etree")
+    def test_get_xml_data_creates_etree_xml(self, mk_etree, MockSPS_Package):
+        xml_content = XML_FILE_CONTENT
+        MockParser = Mock()
+        mk_etree.XMLParser.return_value = MockParser
+        get_xml_data(xml_content, None)
+        mk_etree.XML.assert_called_once_with(xml_content, MockParser)
+
+    @patch("operations.docs_utils.SPS_Package")
+    @patch("operations.docs_utils.etree")
+    def test_get_xml_data_creates_SPS_Package_instance(self, mk_etree, MockSPS_Package):
+        xml_content = XML_FILE_CONTENT
+        MockXML = Mock()
+        mk_etree.XML.return_value = MockXML
+        get_xml_data(xml_content, None)
+        MockSPS_Package.assert_called_once_with(MockXML, None)
+
+    def test_get_xml_data_returns_xml_metadata(self):
+        xml_content = XML_FILE_CONTENT
+        result = get_xml_data(xml_content, "1806-907X-rba-53-01-1-8")
+        self.assertEqual(result["xml_package_name"], "1806-907X-rba-53-01-1-8")
+        self.assertEqual(result["scielo_id"], "FX6F3cbyYmmwvtGmMB7WCgr")
+        self.assertEqual(result["issn"], "1806-907X")
+        self.assertEqual(result["volume"], "53")
+        self.assertEqual(result["number"], "01")
+        self.assertEqual(
+            result["assets"],
+            [
+                {"asset_id": "1806-907X-rba-53-01-1-8-g01.jpg"},
+                {"asset_id": "1806-907X-rba-53-01-1-8-g02.jpg"},
+            ],
+        )
+        self.assertEqual(
+            result["pdfs"],
+            [
+                {
+                    "lang": "en",
+                    "filename": "1806-907X-rba-53-01-1-8.pdf",
+                    "mimetype": "application/pdf",
+                },
+                {
+                    "lang": "pt",
+                    "filename": "1806-907X-rba-53-01-1-8-pt.pdf",
+                    "mimetype": "application/pdf",
+                },
+            ],
+        )
+
+    @patch("operations.docs_utils.SPS_Package")
+    @patch("operations.docs_utils.etree")
+    def test_get_xml_data_raise_except_error(self, mk_etree, MockSPS_Package):
+        xml_content = XML_FILE_CONTENT
+
+        MockSPS_Package.side_effect = TypeError()
+        self.assertRaises(PutDocInObjectStoreException, get_xml_data, xml_content, None)
+
+
+class TestRegisterUpdateDocIntoKernel(TestCase):
+    """
+    Payload do documento
+    {
+        "data": "http://minio/document-store/filename.xml",
+        "assets": [
+            {
+                "asset_id": "image.jpg",
+                "asset_url": "http://minio/document-store/image.jpg",
+            }
+        ]
+    }
+    """
+
+    def setUp(self):
+        self.xml_data = {
+            "xml_package_name": "1806-907X-rba-53-01-1-8",
+            "journal": "1806-907X",
+            "scielo_id": "FX6F3cbyYmmwvtGmMB7WCgr",
+            "xml_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml",
+            "assets": [
+                {
+                    "asset_id": "1806-907X-rba-53-01-1-8-g01.jpg",
+                    "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-g01.jpg",
+                },
+                {
+                    "asset_id": "1806-907X-rba-53-01-1-8-g02.jpg",
+                    "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-g02.jpg",
+                },
+            ],
+            "pdfs": [
+                {
+                    "lang": "en",
+                    "filename": "1806-907X-rba-53-01-1-8.pdf",
+                    "mimetype": "application/pdf",
+                    "data_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8.pdf",
+                    "size_bytes": 80000,
+                },
+                {
+                    "lang": "pt",
+                    "filename": "1806-907X-rba-53-01-1-8-pt.pdf",
+                    "mimetype": "application/pdf",
+                    "data_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-pt.pdf",
+                    "size_bytes": 90000,
+                },
+                {
+                    "lang": "de",
+                    "filename": "1806-907X-rba-53-01-1-8-de.pdf",
+                    "mimetype": "application/pdf",
+                    "data_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-de.pdf",
+                    "size_bytes": 100000,
+                },
+            ],
+        }
+
+    @patch("operations.docs_utils.hooks")
+    def test_register_update_doc_into_kernel_put_to_kernel_doc(self, mk_hooks):
+
+        payload = {"data": self.xml_data["xml_url"], "assets": self.xml_data["assets"]}
+        register_update_doc_into_kernel(self.xml_data)
+        mk_hooks.kernel_connect.assert_any_call(
+            "/documents/FX6F3cbyYmmwvtGmMB7WCgr", "PUT", payload
+        )
+
+    @patch("operations.docs_utils.hooks")
+    def test_register_update_doc_into_kernel_put_to_kernel_pdfs(self, mk_hooks):
+
+        register_update_doc_into_kernel(self.xml_data)
+        for pdf_payload in self.xml_data["pdfs"]:
+            with self.subTest(pdf_payload=pdf_payload):
+                mk_hooks.kernel_connect.assert_any_call(
+                    "/documents/FX6F3cbyYmmwvtGmMB7WCgr/renditions",
+                    "PATCH",
+                    pdf_payload,
+                )
+
+    @patch("operations.docs_utils.hooks")
+    def test_register_update_doc_into_kernel_put_to_kernel_doc_hook_HttpError(
+        self, mk_hooks
+    ):
+
+        payload = {"data": self.xml_data["xml_url"], "assets": self.xml_data["assets"]}
+        mk_hooks.kernel_connect.side_effect = requests.exceptions.HTTPError(
+            "404 Client Error: Not Found"
+        )
+
+        self.assertRaises(
+            RegisterUpdateDocIntoKernelException,
+            register_update_doc_into_kernel,
+            self.xml_data,
+        )
+
+    @patch("operations.docs_utils.Logger")
+    @patch("operations.docs_utils.hooks")
+    def test_register_update_doc_into_kernel_put_to_kernel_pdfs_hook_HttpError(
+        self, mk_hooks, MockLogger
+    ):
+
+        payload = {"data": self.xml_data["xml_url"], "assets": self.xml_data["assets"]}
+        mk_hooks.kernel_connect.side_effect = [
+            None,
+            None,
+            requests.exceptions.HTTPError("404 Client Error: Not Found"),
+        ]
+
+        with self.assertRaises(RegisterUpdateDocIntoKernelException):
+            register_update_doc_into_kernel(self.xml_data)
+
+        MockLogger.info.assert_any_call(
+            'Putting Rendition "%s" to Kernel', "1806-907X-rba-53-01-1-8.pdf"
+        )
+        mk_hooks.kernel_connect.assert_any_call(
+            "/documents/FX6F3cbyYmmwvtGmMB7WCgr/renditions",
+            "PATCH",
+            self.xml_data["pdfs"][0],
+        )
+
+
+class TestPutAssetsAndPdfsInObjectStore(TestCase):
+    def setUp(self):
+        self.xml_data = {
+            "issn": "1806-907X",
+            "scielo_id": "FX6F3cbyYmmwvtGmMB7WCgr",
+            "assets": [
+                {"asset_id": "1806-907X-rba-53-01-1-8-g01.jpg"},
+                {"asset_id": "1806-907X-rba-53-01-1-8-g02.jpg"},
+            ],
+            "pdfs": [
+                {
+                    "lang": "en",
+                    "filename": "1806-907X-rba-53-01-1-8.pdf",
+                    "mimetype": "application/pdf",
+                },
+                {
+                    "lang": "pt",
+                    "filename": "1806-907X-rba-53-01-1-8-pt.pdf",
+                    "mimetype": "application/pdf",
+                },
+            ],
+        }
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    def test_put_assets_and_pdfs_in_object_store_reads_each_asset_from_xml(
+        self, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        MockZipFile = Mock()
+        put_assets_and_pdfs_in_object_store(MockZipFile, self.xml_data)
+        for asset in self.xml_data["assets"]:
+            with self.subTest(asset=asset):
+                mk_read_file_from_zip.assert_any_call(MockZipFile, asset["asset_id"])
+                mk_put_object_in_object_store.assert_any_call(
+                    mk_read_file_from_zip.return_value,
+                    self.xml_data["issn"],
+                    self.xml_data["scielo_id"],
+                    asset["asset_id"],
+                )
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    def test_put_assets_and_pdfs_in_object_store_reads_each_pdf_from_xml(
+        self, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        MockZipFile = Mock()
+        mk_read_file_from_zip.return_value = b""
+        put_assets_and_pdfs_in_object_store(MockZipFile, self.xml_data)
+
+        for pdf in self.xml_data["pdfs"]:
+            with self.subTest(pdf=pdf):
+                mk_read_file_from_zip.assert_any_call(MockZipFile, pdf["filename"])
+                mk_put_object_in_object_store.assert_any_call(
+                    mk_read_file_from_zip.return_value,
+                    self.xml_data["issn"],
+                    self.xml_data["scielo_id"],
+                    pdf["filename"],
+                )
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    def test_put_assets_and_pdfs_in_object_store_return_data_asset(
+        self, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        expected = copy.deepcopy(self.xml_data)
+        for asset in expected["assets"]:
+            asset["asset_url"] = "http://minio/documentstore/{}".format(
+                asset["asset_id"]
+            )
+        mk_read_file_from_zip.return_value = b""
+        mk_put_object_in_object_store.side_effect = [
+            asset["asset_url"] for asset in expected["assets"]
+        ] + [None, None, None]
+
+        result = put_assets_and_pdfs_in_object_store(
+            Mock(), self.xml_data
+        )
+        for expected_asset, result_asset in zip(expected["assets"], result["assets"]):
+
+            self.assertEqual(expected_asset["asset_id"], result_asset["asset_id"])
+            self.assertEqual(expected_asset["asset_url"], result_asset["asset_url"])
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    def test_put_assets_and_pdfs_in_object_store_return_data_pdf(
+        self, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        expected = copy.deepcopy(self.xml_data)
+        pdfs_size = []
+        for pdf in expected["pdfs"]:
+            pdf["data_url"] = "http://minio/documentstore/{}".format(pdf["filename"])
+            pdf["size_bytes"] = random.randint(80000, 100000)
+            pdfs_size.append(pdf["size_bytes"])
+
+        mk_read_file = MagicMock(return_value=b"")
+        mk_read_file.__len__.side_effect = pdfs_size
+        mk_read_file_from_zip.return_value = mk_read_file
+        mk_put_object_in_object_store.side_effect = (
+            [None, None] + [pdf["data_url"] for pdf in expected["pdfs"]] + [None]
+        )
+
+        result = put_assets_and_pdfs_in_object_store(
+            Mock(), self.xml_data
+        )
+        for expected_pdf, result_pdf in zip(expected["pdfs"], result["pdfs"]):
+
+            self.assertEqual(expected_pdf["filename"], result_pdf["filename"])
+            self.assertEqual(expected_pdf["data_url"], result_pdf["data_url"])
+            self.assertEqual(expected_pdf["size_bytes"], result_pdf["size_bytes"])
+
+
+class TestReadFileFromZip(TestCase):
+    def test_read_file_from_zip_call_read(self):
+
+        MockZipFile = Mock()
+        read_file_from_zip(MockZipFile, "filename.pdf")
+        MockZipFile.read.assert_called_once_with("filename.pdf")
+
+    def test_read_file_from_zip_return_value(self):
+
+        MockZipFile = Mock()
+        MockZipFile.read.return_value = b"1806-907X-rba-53-01-1-8-g01"
+        result = read_file_from_zip(MockZipFile, "filename.pdf")
+        self.assertEqual(result, b"1806-907X-rba-53-01-1-8-g01")
+
+    def test_read_file_from_zip_raise_except_error(self):
+
+        MockZipFile = Mock()
+        MockZipFile.read.side_effect = KeyError()
+        self.assertRaises(
+            PutDocInObjectStoreException,
+            read_file_from_zip,
+            MockZipFile,
+            "filename.pdf",
+        )
+
+
+class TestPutObjectInObjectStore(TestCase):
+    @patch("operations.docs_utils.hooks")
+    def test_put_object_in_object_store_call_hook(self, mk_hooks):
+
+        MockFile = Mock()
+        put_object_in_object_store(
+            MockFile,
+            "1806-907X",
+            "FX6F3cbyYmmwvtGmMB7WCgr",
+            "1806-907X-rba-53-01-1-8.xml",
+        )
+        mk_hooks.object_store_connect.assert_called_once_with(
+            MockFile,
+            "1806-907X/FX6F3cbyYmmwvtGmMB7WCgr/1806-907X-rba-53-01-1-8.xml",
+            "documentstore",
+        )
+
+    @patch("operations.docs_utils.hooks")
+    def test_put_object_in_object_store_return_url_object(self, mk_hooks):
+
+        MockFile = Mock()
+        mk_hooks.object_store_connect.return_value = (
+            "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml"
+        )
+
+        result = put_object_in_object_store(
+            MockFile,
+            "1806-907X",
+            "FX6F3cbyYmmwvtGmMB7WCgr",
+            "1806-907X-rba-53-01-1-8.xml",
+        )
+        self.assertEqual(
+            "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml", result
+        )
+
+    @patch("operations.docs_utils.hooks")
+    def test_put_object_in_object_store_raise_exception_error(self, mk_hooks):
+
+        MockFile = Mock()
+
+        mk_hooks.object_store_connect.side_effect = Exception()
+        self.assertRaises(
+            PutDocInObjectStoreException,
+            put_object_in_object_store,
+            MockFile,
+            "1806-907X",
+            "FX6F3cbyYmmwvtGmMB7WCgr",
+            "1806-907X-rba-53-01-1-8.xml",
+        )
+
+
+class TestPutXMLIntoObjectStore(TestCase):
+    def setUp(self):
+        self.xml_data = {
+            "issn": "1806-907X",
+            "scielo_id": "FX6F3cbyYmmwvtGmMB7WCgr",
+            "assets": [
+                {"asset_id": "1806-907X-rba-53-01-1-8-g01.jpg"},
+                {"asset_id": "1806-907X-rba-53-01-1-8-g02.jpg"},
+            ],
+            "pdfs": [
+                {
+                    "lang": "en",
+                    "filename": "1806-907X-rba-53-01-1-8.pdf",
+                    "mimetype": "application/pdf",
+                },
+                {
+                    "lang": "pt",
+                    "filename": "1806-907X-rba-53-01-1-8-pt.pdf",
+                    "mimetype": "application/pdf",
+                },
+            ],
+        }
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    @patch("operations.docs_utils.get_xml_data")
+    def test_put_xml_into_object_store_calls_get_xml_data(
+        self, mk_get_xml_data, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        MockZipFile = Mock()
+        mk_read_file_from_zip.return_value = b"1806-907X-rba-53-01-1-8.xml"
+        put_xml_into_object_store(MockZipFile, "1806-907X-rba-53-01-1-8.xml")
+        mk_get_xml_data.assert_any_call(
+            b"1806-907X-rba-53-01-1-8.xml", "1806-907X-rba-53-01-1-8"
+        )
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    @patch("operations.docs_utils.get_xml_data")
+    def test_put_xml_into_object_store_reads_xml(
+        self, mk_get_xml_data, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        MockZipFile = Mock()
+        mk_read_file_from_zip.return_value = b""
+        mk_get_xml_data.return_value = self.xml_data
+        put_xml_into_object_store(MockZipFile, "1806-907X-rba-53-01-1-8.xml")
+
+        mk_read_file_from_zip.assert_any_call(
+            MockZipFile, "1806-907X-rba-53-01-1-8.xml"
+        )
+        mk_put_object_in_object_store.assert_any_call(
+            mk_read_file_from_zip.return_value,
+            self.xml_data["issn"],
+            self.xml_data["scielo_id"],
+            "1806-907X-rba-53-01-1-8.xml",
+        )
+
+    @patch("operations.docs_utils.read_file_from_zip")
+    @patch("operations.docs_utils.put_object_in_object_store")
+    @patch("operations.docs_utils.get_xml_data")
+    def test_put_xml_into_object_store_return_data_xml(
+        self, mk_get_xml_data, mk_put_object_in_object_store, mk_read_file_from_zip
+    ):
+        MockZipFile = Mock()
+        mk_read_file_from_zip.return_value = b""
+        mk_get_xml_data.return_value = self.xml_data
+        mk_put_object_in_object_store.return_value = \
+            "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml"
+
+        result = put_xml_into_object_store(
+            MockZipFile, "1806-907X-rba-53-01-1-8.xml"
+        )
+        self.assertEqual(
+            "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml", result["xml_url"]
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import patch, Mock, MagicMock
 
 import requests
 from airflow import DAG
+from lxml import etree
 
 from operations.docs_utils import (
     get_xml_data,
@@ -49,6 +50,17 @@ class TestGetXMLData(TestCase):
         mk_etree.XML.return_value = MockXML
         get_xml_data(xml_content, None)
         MockSPS_Package.assert_called_once_with(MockXML, None)
+
+    def test_get_xml_data_returns_supplement_when_it_is_in_xml_content(self):
+        xml_content = XML_FILE_CONTENT
+        result = get_xml_data(xml_content, "1806-907X-rba-53-01-1-8")
+        self.assertIsNone(result.get("supplement"))
+
+        xml_file = etree.XML(XML_FILE_CONTENT)
+        issue_tag = xml_file.find(".//article-meta/issue")
+        issue_tag.text = "suppl 2"
+        result = get_xml_data(etree.tostring(xml_file), "1806-907X-rba-53-01-1-8")
+        self.assertEqual(result.get("supplement"), "02")
 
     def test_get_xml_data_returns_xml_metadata(self):
         xml_content = XML_FILE_CONTENT

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -3,7 +3,11 @@ from unittest.mock import patch, MagicMock
 
 from airflow import DAG
 
-from sync_documents_to_kernel import list_documents, delete_documents
+from sync_documents_to_kernel import (
+    list_documents,
+    delete_documents,
+    register_update_documents,
+)
 
 
 class TestListDocuments(TestCase):
@@ -115,6 +119,89 @@ class TestDeleteDocuments(TestCase):
         delete_documents(**kwargs)
         kwargs["ti"].xcom_push.assert_called_once_with(
             key="xmls_to_preserve", value=xmls_to_preserve
+        )
+
+
+class TestRegisterUpdateDocuments(TestCase):
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.register_update_documents")
+    def test_register_update_documents_gets_sps_package_from_dag_run_conf(
+        self, mk_register_update_documents
+    ):
+        mk_dag_run = MagicMock()
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        register_update_documents(**kwargs)
+        mk_dag_run.conf.get.assert_called_once_with("sps_package")
+
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.register_update_documents")
+    def test_register_update_documents_gets_ti_xcom_info(self, mk_register_update_documents):
+        mk_dag_run = MagicMock()
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        register_update_documents(**kwargs)
+        kwargs["ti"].xcom_pull.assert_called_once_with(
+            key="xmls_to_preserve", task_ids="delete_docs_task_id"
+        )
+
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.register_update_documents")
+    def test_register_update_documents_empty_ti_xcom_info(self, mk_register_update_documents):
+        mk_dag_run = MagicMock()
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = None
+        register_update_documents(**kwargs)
+        mk_register_update_documents.assert_not_called()
+        kwargs["ti"].xcom_push.assert_not_called()
+
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.register_update_documents")
+    def test_register_update_documents_calls_register_update_documents_operation(
+        self, mk_register_update_documents
+    ):
+        xmls_filenames = [
+            "1806-907X-rba-53-01-1-8.xml",
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        mk_dag_run = MagicMock()
+        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        register_update_documents(**kwargs)
+        mk_register_update_documents.assert_called_once_with(
+            "path_to_sps_package/package.zip", xmls_filenames
+        )
+
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.register_update_documents")
+    def test_register_update_documents_does_not_push_if_no_documents_into_kernel(self, mk_register_update_documents):
+        xmls_filenames = [
+            "1806-907X-rba-53-01-1-8.xml",
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        mk_dag_run = MagicMock()
+        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_register_update_documents.return_value = []
+        register_update_documents(**kwargs)
+        kwargs["ti"].xcom_push.assert_not_called()
+
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.register_update_documents")
+    def test_register_update_documents_pushes_documents(self, mk_register_update_documents):
+        xmls_filenames = [
+            "1806-907X-rba-53-01-1-8.xml",
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        documents = [
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        mk_dag_run = MagicMock()
+        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_register_update_documents.return_value = documents
+        register_update_documents(**kwargs)
+        kwargs["ti"].xcom_push.assert_called_once_with(
+            key="documents", value=documents
         )
 
 

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -13,17 +13,13 @@ from operations.sync_documents_to_kernel_operations import (
     list_documents,
     documents_to_delete,
     delete_documents,
+    register_update_documents,
 )
-
-
-XML_FILE_CONTENT = b"""<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE article PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Publishing DTD v1.0 20120330//EN" "JATS-journalpublishing1.dtd">
-<article article-type="research-article" dtd-version="1.0" specific-use="sps-1.5" xml:lang="en" xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <article-meta>
-        <article-id pub-id-type="publisher-id" specific-use="scielo">FX6F3cbyYmmwvtGmMB7WCgr</article-id>
-    </article-meta>
-</article>
-"""
+from operations.exceptions import (
+    PutDocInObjectStoreException,
+    RegisterUpdateDocIntoKernelException,
+)
+from tests.fixtures import XML_FILE_CONTENT
 
 
 class TestListDocuments(TestCase):
@@ -229,6 +225,293 @@ class TestDeleteDocuments(TestCase):
         result = delete_documents(**self.kwargs)
         self.assertEqual(
             result, list(set(self.kwargs["xmls_filenames"]) - set(docs_to_delete[0]))
+        )
+
+
+class TestRegisterUpdateDocuments(TestCase):
+    """
+    - Minio
+        - Abrir o ZIP
+        - Ler cada XML
+            - Obter scielo ID
+            - Obter infos de periódico e fascículo
+            - Obter nomes dos arquivos ativos digitais
+            - Obter nomes dos arquivos PDF
+            - Obter idiomas (original e traduções)
+            - Ler cada ativo digital
+                - Persistir no Minio
+                - Adicionar em dict a URL do Minio
+            - Ler cada PDF
+                - Persistir no Minio
+                - Adicionar em dict a URL do Minio
+            - Persistir XML no Minio
+            - Adicionar em dict a URL do Minio
+    """
+
+    def setUp(self):
+        self.kwargs = {
+            "sps_package": "dir/destination/rba_v53n1.zip",
+            "xmls_to_preserve": [
+                "1806-907X-rba-53-01-1-8.xml",
+                "1806-907X-rba-53-01-9-18.xml",
+                "1806-907X-rba-53-01-19-25.xml",
+            ],
+        }
+        self.xmls_data = [
+            {
+                "journal": "1806-907X",
+                "scielo_id": "FX6F3cbyYmmwvtGmMB7WCgr",
+                "xml_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml",
+                "assets": [
+                    {
+                        "asset_id": "1806-907X-rba-53-01-1-8-g01.jpg",
+                        "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-g01.jpg",
+                    },
+                    {
+                        "asset_id": "1806-907X-rba-53-01-1-8-g02.jpg",
+                        "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-g02.jpg",
+                    },
+                ],
+                "pdfs": [
+                    {
+                        "lang": "en",
+                        "filename": "1806-907X-rba-53-01-1-8.pdf",
+                        "mimetype": "application/pdf",
+                        "pdf_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8.pdf",
+                    },
+                    {
+                        "lang": "pt",
+                        "filename": "1806-907X-rba-53-01-1-8-pt.pdf",
+                        "mimetype": "application/pdf",
+                        "pdf_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-pt.pdf",
+                    },
+                    {
+                        "lang": "de",
+                        "filename": "1806-907X-rba-53-01-1-8-de.pdf",
+                        "mimetype": "application/pdf",
+                        "pdf_url": "http://minio/documentstore/1806-907X-rba-53-01-1-8-de.pdf",
+                    },
+                ],
+            },
+            {
+                "journal": "1806-907X",
+                "scielo_id": "GZ5K2cbyYmmwvtGmMB71243",
+                "xml_url": "http://minio/documentstore/1806-907X-rba-53-01-9-18.xml",
+                "assets": [
+                    {
+                        "asset_id": "1806-907X-rba-53-01-9-18-g01.jpg",
+                        "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-9-18-g01.jpg",
+                    },
+                    {
+                        "asset_id": "1806-907X-rba-53-01-9-18-g02.jpg",
+                        "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-9-18-g02.jpg",
+                    },
+                ],
+                "pdfs": [
+                    {
+                        "lang": "en",
+                        "filename": "1806-907X-rba-53-01-9-18.pdf",
+                        "mimetype": "application/pdf",
+                        "pdf_url": "http://minio/documentstore/1806-907X-rba-53-01-9-18.pdf",
+                    }
+                ],
+            },
+            {
+                "journal": "1806-907X",
+                "scielo_id": "KU890cbyYmmwvtGmMB7JUk4",
+                "xml_url": "http://minio/documentstore/1806-907X-rba-53-01-19-25.xml",
+                "assets": [
+                    {
+                        "asset_id": "1806-907X-rba-53-01-19-25-tb01.tiff",
+                        "asset_url": "http://minio/documentstore/1806-907X-rba-53-01-19-25-tb01.tiff",
+                    }
+                ],
+                "pdfs": [
+                    {
+                        "lang": "es",
+                        "filename": "1806-907X-rba-53-01-19-25.pdf",
+                        "mimetype": "application/pdf",
+                        "pdf_url": "http://minio/documentstore/1806-907X-rba-53-01-19-25.pdf",
+                    },
+                    {
+                        "lang": "en",
+                        "filename": "1806-907X-rba-53-01-19-25-en.pdf",
+                        "mimetype": "application/pdf",
+                        "pdf_url": "http://minio/documentstore/1806-907X-rba-53-01-19-25-en.pdf",
+                    },
+                ],
+            },
+        ]
+        self.zip_file_returns = [
+            b"1806-907X-rba-53-01-1-8.xml",
+            b"1806-907X-rba-53-01-1-8-g01.jpg",
+            b"1806-907X-rba-53-01-1-8-g02.jpg",
+            b"1806-907X-rba-53-01-1-8.pdf",
+            b"1806-907X-rba-53-01-1-8-en.pdf",
+            b"1806-907X-rba-53-01-1-8-de.pdf",
+            b"1806-907X-rba-53-01-9-18.xml",
+            b"1806-907X-rba-53-01-9-18-g1.gif",
+            b"1806-907X-rba-53-01-9-18-g2.gif",
+            b"1806-907X-rba-53-01-9-18-g3.gif",
+            b"1806-907X-rba-53-01-9-18.pdf",
+            b"1806-907X-rba-53-01-19-25.xml",
+            b"1806-907X-rba-53-01-19-25-tb01.tiff",
+            b"1806-907X-rba-53-01-19-25.pdf",
+            b"1806-907X-rba-53-01-19-25-en.pdf",
+        ]
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_opens_zip(
+        self,
+        MockZipFile,
+        MockLogger,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        register_update_documents(**self.kwargs)
+        MockZipFile.assert_called_once_with(self.kwargs["sps_package"])
+
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_open_zip_raises_error(self, MockZipFile):
+        MockZipFile.side_effect = Exception("Zipfile error")
+        self.assertRaises(Exception, register_update_documents, **self.kwargs)
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_calls_put_xml_into_object_store(
+        self,
+        MockZipFile,
+        MockLogger,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        register_update_documents(**self.kwargs)
+        for xml_filename in self.kwargs["xmls_to_preserve"]:
+            with self.subTest(xml_filename=xml_filename):
+                mk_put_xml_into_object_store.assert_any_call(
+                    MockZipFile.return_value.__enter__.return_value, xml_filename
+                )
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_logs_error_if_put_xml_into_object_store_error(
+        self,
+        MockZipFile,
+        MockLogger,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        MockZipFile.return_value.__enter__.return_value.read.return_value = b""
+        mk_put_xml_into_object_store.side_effect = [
+            None,
+            PutDocInObjectStoreException("Put Doc in Object Store Error"),
+            None,
+        ]
+        register_update_documents(**self.kwargs)
+        MockLogger.info.assert_any_call(
+            'Could not put document "%s" in object store: %s',
+            self.kwargs["xmls_to_preserve"][1],
+            "Put Doc in Object Store Error",
+        )
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_puts_each_doc_in_object_store(
+        self,
+        MockZipFile,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        mk_put_xml_into_object_store.side_effect = self.xmls_data
+        register_update_documents(**self.kwargs)
+        for xml_data in self.xmls_data:
+            with self.subTest(xml_data=xml_data):
+                mk_put_assets_and_pdfs_in_object_store.assert_any_call(
+                    MockZipFile.return_value.__enter__.return_value, xml_data
+                )
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_call_register_update_doc_into_kernel(
+        self,
+        MockZipFile,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        mk_put_xml_into_object_store.side_effect = self.xmls_data
+        register_update_documents(**self.kwargs)
+        for xml_data in self.xmls_data:
+            with self.subTest(xml_data=xml_data):
+                mk_register_update_doc_into_kernel.assert_any_call(xml_data)
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_call_register_update_doc_into_kernel_raise_error(
+        self,
+        MockZipFile,
+        MockLogger,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        mk_put_assets_and_pdfs_in_object_store.side_effect = self.xmls_data
+        mk_register_update_doc_into_kernel.side_effect = [
+            None,
+            RegisterUpdateDocIntoKernelException("Register Doc in Kernel Error"),
+            None,
+        ]
+
+        register_update_documents(**self.kwargs)
+        MockLogger.info.assert_any_call(
+            'Could not register or update document "%s" in Kernel: %s',
+            self.kwargs["xmls_to_preserve"][1],
+            "Register Doc in Kernel Error",
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Implementa `register_update_documents`, função responsável por registrar/atualizar documentos no Kernel e persistir o XMLs, seus ativos digitais e manifestações no Minio.
É realizado em cada pacote SPS:
- Leitura e persistência no Minio dos XMLs a serem persistidos, além da extração de metadados
- Extração e persistência no Minio dos ativos digitais e manifestações de cada um dos XMLs
- Registro/atualização dos documentos no Kernel
- Registro das manifestações dos documentos no Kernel

Este PR também inclui:
- configurações do Coverage
- instalação da biblioteca do S3 no Airflow para conexão com o Minio
- utilização do módulo `sps_package.py` do projeto `document-store-migração`, adaptado para esta aplicação

#### Onde a revisão poderia começar?
Em `airflow/dags/operations/sync_documents_to_kernel_operations.py`: função que executa o processo principal.
Em `airflow/dags/operations/docs_utils.py`: funções que executam cada parte do processo de registro/atualização dos documentos no Minio e no Kernel.

#### Como este poderia ser testado manualmente?
- Rodando os testes unitários:
`docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest -v`
OU
- Criando pacote SPS e scilista em diretórios locais e configurando as variáveis pela interface do airflow:
  * `SCILISTA_FILE_PATH`: caminho do arquivo `scilista.lst`
  * `XC_SPS_PACKAGES_DIR`: diretório com pacotes SPS (.zips)
  * `PROC_SPS_PACKAGES_DIR `: diretório de processamento
  - Acessar a interface do Airflow em Admin > conections
    * Editar a conexão `aws_default`
    * Configurar login e senha do Minio
    * Configurar campo `Extra` com chave `host` no JSON com endereço HTTP do Minio. Ex.: `"host": "http://enderecodohost:9009"`
    * Retirar a configuração da chave `region` do JSON no campo `Extra`
  - Executar a DAG `pre_sync_documents_to_kernel` manualmente pela interface, que executará ao final a DAG `sync_documents_to_kernel` para cada um dos pacotes SPS da scilista.

#### Algum cenário de contexto que queira dar?
Esta implementação não trata todos os cenários de exceção levantados e com devidos tratamentos.

### Screenshots
N/A

#### Quais são tickets relevantes?
#51 #43

### Referências
Nenhuma.