### PR TITLE
 Evitar duplicidade de conteúdo no Object Store

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -120,8 +120,7 @@ def get_xml_data(xml_content, xml_package_name):
 
 def files_sha1(file):
     _sum = hashlib.sha1()
-    chunk = file[:1024]
-    _sum.update(chunk)
+    _sum.update(file)
     return _sum.hexdigest()
 
 

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -682,11 +682,10 @@ class TestPutXMLIntoObjectStore(TestCase):
 
 class TestFilesSha1(TestCase):
     def test_files_sha1_return_value(self):
-        MockFile = MagicMock()
 
-        MockFile.__getitem__.return_value = b"1806-907X-rba-53-01-1-8.xml"
+        file = b"1806-907X-rba-53-01-1-8.xml"
         self.assertEqual(
-            "3a4dae699f59a3b89b231845def80efe89a5a15e", files_sha1(MockFile)
+            "3a4dae699f59a3b89b231845def80efe89a5a15e", files_sha1(file)
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR adição um mecanismo de geração de hash para o filename com base no conteúdo do arquivo.

**Explicação**
Para a geração do hash, a ideia foi usar os primeiros 1024 bytes do arquivo e assim gerar um sha1, e essa estratégia é a mesma utilizada no utilitario de migração `document-store-migracao`

Abaixo segue o comentario que motivou essa implementação
>Essa implementação pode potencialmente consumir muita memória, uma vez que ela lê todo o conteúdo do arquivo em memória de uma vez para calcular a soma. Sugiro fazer algo mais econômico como:
> ```python
>def sha1(path):
>    _sum = hashlib.sha1()
>    with open(path, 'rb') as file:
>        while True:
>            chunk = file.read(1024)
>            if not chunk:
>                break
>            _sum.update(chunk)
>    return _sum.hexdigest()
>
>```


_PS: também foi executado o comando `black` nos arquivos editado e por isso gerou mais alterações que o necessario_ 

#### Onde a revisão poderia começar?
Pelo arquivo:
* `airflow/dags/operations/docs_utils.py`
* `airflow/tests/test_docs_utils.py`

#### Como este poderia ser testado manualmente?
* Rodando os testes unitários:
```
    docker-compose -f docker-compose.yml exec opac-airflow python -m unittest -v
```

#### Algum cenário de contexto que queira dar?
Essa alteração visa mandar um controle de versão no Object store, pois caso haja um reprocessamento, o arquivo enviado para o Object store, não sera duplicado, a não ser que aja mudanças no arquivo que ai faz motivo termos dois objetos distintos.

#### Quais são tickets relevantes?
#73 

#### Referências
https://github.com/scieloorg/document-store-migracao/pull/54#pullrequestreview-231168707
https://github.com/scieloorg/document-store-migracao/pull/54#discussion_r278979486