### PR TITLE
Altera obtenção de metadados do XMLs e retorno de tarefa

### DIFF
--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -282,25 +282,14 @@ class SPS_Package:
         return True
 
     @property
-    def order_meta(self):
+    def order(self):
         def format(value):
             if value and value.isdigit():
                 return value.zfill(5)
             return value or ""
 
         data = dict(self.parse_article_meta)
-        return (
-            ("other", format(data.get("other"))),
-            ("fpage", format(data.get("fpage"))),
-            ("lpage", format(data.get("lpage"))),
-            ("documents_bundle_pubdate", self.documents_bundle_pubdate),
-            ("document_pubdate", self.document_pubdate),
-            ("elocation-id", data.get("elocation-id", "")),
-        )
-
-    @property
-    def order(self):
-        return tuple(item[1] for item in self.order_meta)
+        return format(data.get("other")) or format(data.get("fpage"))
 
     def _match_pubdate(self, pubdate_xpaths):
         """

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -107,16 +107,17 @@ def get_xml_data(xml_content, xml_package_name):
         _xml_data = {
             "scielo_id": metadata.scielo_id,
             "issn": metadata.issn,
-            "volume": metadata.volume,
-            "number": metadata.number,
+            "year": metadata.year,
+            "order": metadata.order,
             "xml_package_name": xml_package_name,
             "assets": [
                 {"asset_id": asset_name} for asset_name in metadata.assets_names
             ],
             "pdfs": pdfs,
         }
-        if metadata.supplement:
-            _xml_data["supplement"] = metadata.supplement
+        for attr in ["volume", "number", "supplement"]:
+            if getattr(metadata, attr) is not None:
+                _xml_data[attr] = getattr(metadata, attr)
         return _xml_data
 
 

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -3,6 +3,7 @@ import logging
 import shutil
 from pathlib import Path
 from zipfile import ZipFile
+from copy import deepcopy
 
 import requests
 from lxml import etree
@@ -102,6 +103,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
     """
     Logger.debug("register_update_documents IN")
     with ZipFile(sps_package) as zipfile:
+        synchronized_docs_metadata = []
         for i, xml_filename in enumerate(xmls_to_preserve):
             Logger.info(
                 'Reading XML file "%s" from ZIP file "%s" [%s/%s]',
@@ -120,9 +122,10 @@ def register_update_documents(sps_package, xmls_to_preserve):
                 )
             else:
                 assets_and_pdfs_data = put_assets_and_pdfs_in_object_store(zipfile, xml_data)
-                xml_data.update(assets_and_pdfs_data)
+                _document_metadata = deepcopy(xml_data)
+                _document_metadata.update(assets_and_pdfs_data)
                 try:
-                    register_update_doc_into_kernel(xml_data)
+                    register_update_doc_into_kernel(_document_metadata)
 
                 except RegisterUpdateDocIntoKernelException as exc:
                     Logger.info(
@@ -130,5 +133,8 @@ def register_update_documents(sps_package, xmls_to_preserve):
                         xml_filename,
                         str(exc),
                     )
+                else:
+                    synchronized_docs_metadata.append(xml_data)
 
     Logger.debug("register_update_documents OUT")
+    return synchronized_docs_metadata

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -32,7 +32,7 @@ Logger = logging.getLogger(__name__)
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime.utcnow(),
+    "start_date": datetime(2019, 7, 22),
 }
 
 dag = DAG(

--- a/airflow/tests/fixtures/__init__.py
+++ b/airflow/tests/fixtures/__init__.py
@@ -10,6 +10,11 @@ XML_FILE_CONTENT = b"""<?xml version="1.0" encoding="UTF-8"?>
         </journal-meta>
         <article-meta>
             <article-id pub-id-type="publisher-id" specific-use="scielo">FX6F3cbyYmmwvtGmMB7WCgr</article-id>
+            <pub-date pub-type="epub">
+                <day>31</day>
+                <month>01</month>
+                <year>2018</year>
+            </pub-date>
             <volume>53</volume>
             <issue>1</issue>
             <fpage>1</fpage>

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -483,6 +483,32 @@ class TestRegisterUpdateDocuments(TestCase):
             "Register Doc in Kernel Error",
         )
 
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_returns_syncronized_documents_metadata_list(
+        self,
+        MockZipFile,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        expected = [self.xmls_data[0], self.xmls_data[2]]
+        mk_put_xml_into_object_store.side_effect = self.xmls_data
+        mk_register_update_doc_into_kernel.side_effect = [
+            None,
+            RegisterUpdateDocIntoKernelException("Register Doc in Kernel Error"),
+            None,
+        ]
+
+        result = register_update_documents(**self.kwargs)
+        self.assertEqual(result, expected)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
#### O que esse PR faz?
Ajustes para o funcionamento da tarefa de relacionamento dos documentos com os _Documents Bundles_:

- Inclui `year` nos metadados obtidos do XMLs
- Retorna nos metadados do XMLs `volume`, `number` e `supplement` somente se eles forem diferentes de nulo
- `register_update_documents` retorna lista com os metadados dos documentos sincronizados com o Kernel para o relacionamento dos documentos com os bundles

#### Onde a revisão poderia começar?
Em `airflow/dags/operations/docs_utils.py`, para as alterações nos metadados
Em `airflow/dags/operations/sync_documents_to_kernel_operations.py`, para o retorno da lista de documentos

#### Como este poderia ser testado manualmente?
- Rodando os testes unitários:
`docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest -v`
OU
- Criando pacote SPS e scilista em diretórios locais e configurando as variáveis pela interface do airflow:
  * `SCILISTA_FILE_PATH`: caminho do arquivo `scilista.lst`
  * `XC_SPS_PACKAGES_DIR`: diretório com pacotes SPS (.zips)
  * `PROC_SPS_PACKAGES_DIR `: diretório de processamento
  - Acessar a interface do Airflow em Admin > conections
    * Editar a conexão `aws_default`
    * Configurar login e senha do Minio
    * Configurar campo `Extra` com chave `host` no JSON com endereço HTTP do Minio. Ex.: `"host": "http://enderecodohost:9009"`
    * Retirar a configuração da chave `region` do JSON no campo `Extra`
  - Executar a DAG `pre_sync_documents_to_kernel` manualmente pela interface, que executará ao final a DAG `sync_documents_to_kernel` para cada um dos pacotes SPS da scilista. Ao final da execução da tarefa `register_update_docs_id`, o XCom deve estar com uma lista `documents` contendo os metadados dos documentos sincronizados com o Kernel.

#### Algum cenário de contexto que queira dar?
Nenhum.

### Screenshots
N/A

#### Quais são tickets relevantes?
#43

### Referências
Nenhuma.