### PR TITLE
Adequar relacionamento de bundle e documentos às mudanças do Kernel

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -4,6 +4,7 @@ import json
 import logging
 from datetime import timedelta
 import itertools
+from typing import Dict, List, Tuple
 
 import tenacity
 from tenacity import retry
@@ -22,6 +23,7 @@ from mongoengine import connect
 
 from opac_schema.v1 import models
 
+from operations.kernel_changes_operations import try_register_documents, ArticleFactory
 from common.hooks import mongo_connect
 
 failure_recipients = os.environ.get("EMIAL_ON_FAILURE_RECIPIENTS", None)
@@ -467,240 +469,90 @@ register_issues_task = PythonOperator(
 )
 
 
-def register_document(data, issue_id, document_id, i_documents):
-    """
-    Esta função pode lançar a exceção `models.Issue.DoesNotExist`.
-    """
+def register_documents(**kwargs):
+    """Registra documentos na base de dados do OPAC a partir de
+    informações vindas da API do `Kernel`. Armazena como órfãos nas variáveis
+    do Airflow os documentos que não puderam ser salvos."""
 
-    def nestget(data, *path, default=""):
-        """
-        Obtém valores de list ou dicionários.
-        """
-        for key_or_index in path:
-            try:
-                data = data[key_or_index]
-            except (KeyError, IndexError):
-                return default
-        return data
-
-    article = nestget(data, "article", 0)
-    article_meta = nestget(data, "article_meta", 0)
-    pub_date = nestget(data, "pub_date", 0)
-    sub_articles = nestget(data, "sub_article")
-    contribs = nestget(data, "contrib")
-
-    document = models.Article()
-
-    document.title = nestget(article_meta, "article_title", 0)
-    document.section = nestget(article_meta, "pub_subject", 0)
-
-    authors = []
-
-    valid_contrib_types = [
-        "author",
-        "editor",
-        "organizer",
-        "translator",
-        "autor",
-        "compiler",
-    ]
-
-    for contrib in contribs:
-
-        if nestget(contrib, "contrib_type", 0) in valid_contrib_types:
-            authors.append(
-                "%s, %s"
-                % (
-                    nestget(contrib, "contrib_surname", 0),
-                    nestget(contrib, "contrib_given_names", 0),
-                )
-            )
-
-    document.authors = authors
-
-    document.abstract = nestget(article_meta, "abstract", 0)
-
-    publisher_id = nestget(article_meta, "article_publisher_id", 0)
-
-    document._id = publisher_id
-    document.aid = publisher_id
-    document.pid = nestget(article_meta, "article_publisher_id", 1)
-    document.doi = nestget(article_meta, "article_doi", 0)
-
-    original_lang = nestget(article, "lang", 0)
-
-    # article.languages contém todas as traduções do artigo e o idioma original
-    languages = [original_lang]
-    trans_titles = []
-    trans_sections = []
-    trans_abstracts = []
-
-    trans_sections.append(
-        models.TranslatedSection(
-            **{
-                "name": nestget(article_meta, "pub_subject", 0),
-                "language": original_lang,
-            }
-        )
-    )
-
-    trans_abstracts.append(
-        models.Abstract(**{"text": document.abstract, "language": original_lang})
-    )
-
-    if data.get("trans_abstract"):
-
-        for trans_abs in data.get("trans_abstract"):
-            trans_abstracts.append(
-                models.Abstract(
-                    **{
-                        "text": nestget(trans_abs, "text", 0),
-                        "language": nestget(trans_abs, "lang", 0),
-                    }
-                )
-            )
-
-    keywords = []
-    for sub in sub_articles:
-        lang = nestget(sub, "article", 0, "lang", 0)
-
-        languages.append(lang)
-
-        trans_titles.append(
-            models.TranslatedTitle(
-                **{
-                    "name": nestget(sub, "article_meta", 0, "article_title", 0),
-                    "language": lang,
-                }
-            )
-        )
-
-        trans_sections.append(
-            models.TranslatedSection(
-                **{
-                    "name": nestget(sub, "article_meta", 0, "pub_subject", 0),
-                    "language": lang,
-                }
-            )
-        )
-
-        trans_abstracts.append(
-            models.Abstract(
-                **{
-                    "text": nestget(sub, "article_meta", 0, "abstract_p", 0),
-                    "language": lang,
-                }
-            )
-        )
-
-    if data.get("kwd_group"):
-
-        for kwd_group in nestget(data, "kwd_group"):
-
-            keywords.append(
-                models.ArticleKeyword(
-                    **{
-                        "keywords": nestget(kwd_group, "kwd", default=[]),
-                        "language": nestget(kwd_group, "lang", 0),
-                    }
-                )
-            )
-
-    document.languages = languages
-    document.translated_titles = trans_titles
-    document.sections = trans_sections
-    document.abstracts = trans_abstracts
-    document.keywords = keywords
-    document.abstract_languages = [
-        trans_abs["language"] for trans_abs in trans_abstracts
-    ]
-
-    document.original_language = original_lang
-
-    document.publication_date = nestget(pub_date, "text", 0)
-
-    document.type = nestget(article, "type", 0)
-    document.elocation = nestget(article_meta, "pub_elocation", 0)
-    document.fpage = nestget(article_meta, "pub_fpage", 0)
-    document.fpage_sequence = nestget(article_meta, "pub_fpage_seq", 0)
-    document.lpage = nestget(article_meta, "pub_lpage", 0)
-
-    issue = models.Issue.objects.get(_id=issue_id)
-
-    document.issue = issue
-    document.journal = issue.journal
-
-    document.order = i_documents.get(issue.id).index(document_id)
-    document.xml = "%s/documents/%s" % (api_hook.base_url, document._id)
-
-    document.save()
-
-    return document
-
-
-def register_orphan_documents(ds, **kwargs):
-    """
-    Registrar os documentos orfãos.
-    """
-
-    i_documents = kwargs["ti"].xcom_pull(
-        key="i_documents", task_ids="register_issues_task"
-    )
-
-    orphan_documents = []
-
-    for document_id in json.loads(Variable.get("orphan_documents", "[]")):
-
-        issue_id = [i for i, d in i_documents.items() if document_id in d]
-
-        if issue_id:
-            resp_json = fetch_documents_front(document_id)
-            try:
-                register_document(resp_json, issue_id[0], document_id, i_documents)
-            except models.Issue.DoesNotExist:
-                orphan_documents.append(document_id)
-        else:
-            orphan_documents.append(document_id)
-
-    Variable.set("orphan_documents", json.dumps(orphan_documents))
-
-
-register_orphan_documents_task = PythonOperator(
-    task_id="register_orphan_documents",
-    provide_context=True,
-    python_callable=register_orphan_documents,
-    dag=dag,
-)
-
-
-def register_documents(ds, **kwargs):
     mongo_connect()
 
     tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
 
-    i_documents = kwargs["ti"].xcom_pull(
-        key="i_documents", task_ids="register_issues_task"
+    def _get_relation_data(document_id: str) -> Tuple[str, Dict]:
+        """Recupera informações sobre o relacionamento entre o 
+        DocumentsBundle e o Document.
+
+        Retorna uma tupla contendo o identificador da issue onde o
+        documento está relacionado e o item do relacionamento.
+
+        >> _get_relation_data("67TH7T7CyPPmgtVrGXhWXVs")
+        ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+
+        :param document_id: Identificador único de um documento
+        """
+
+        for issue_id, items in known_documents.items():
+            for item in items:
+                if document_id == item["id"]:
+                    return (issue_id, item)
+
+        return ()
+
+    def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
+        """Recupera a lista de todos os documentos que estão relacionados com
+        um `DocumentsBundle`.
+
+        Levando em consideração que a DAG que detecta mudanças na API do Kernel
+        roda de forma assíncrona em relação a DAG de espelhamento/sincronização.
+
+        É possível que algumas situações especiais ocorram onde em uma rodada
+        **anterior** o **evento de registro** de um `Document` foi capturado mas a 
+        atualização de seu `DocumentsBundle` não ocorreu (elas ocorrem em transações
+        distintas e possuem timestamps também distintos). O documento será
+        registrado como **órfão** e sua `task` não será processada na próxima
+        execução.
+
+        Na próxima execução a task `register_issue_task` entenderá que o
+        `bundle` é órfão e não conhecerá os seus documentos (known_documents)
+        e consequentemente o documento continuará órfão.
+
+        Uma solução para este problema é atualizar a lista de documentos
+        conhecidos a partir da lista de eventos de `get` de `bundles`.
+        """
+
+        known_documents = kwargs["ti"].xcom_pull(
+            key="i_documents", task_ids="register_issues_task"
+        )
+
+        issues_recently_updated = [
+            get_id(task["id"]) for task in filter_changes(tasks, "bundles", "get")
+            if known_documents.get(get_id(task["id"])) is None
+        ]
+
+        for issue_id in issues_recently_updated:
+            known_documents.setdefault(issue_id, [])
+            known_documents[issue_id] = list(
+                itertools.chain(
+                    known_documents[issue_id], fetch_bundles(issue_id).get("items", [])
+                )
+            )
+        return known_documents
+
+    known_documents = _get_known_documents(**kwargs)
+
+    # TODO: Em caso de um update no document é preciso atualizar o registro
+    # Precisamos de uma nova task?
+
+    documents_to_get = itertools.chain(
+        Variable.get("orphan_documents", default_var=[], deserialize_json=True),
+        (get_id(task["id"]) for task in filter_changes(tasks, "documents", "get")),
     )
 
-    orphan_documents = []
+    orphans = try_register_documents(
+        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory
+    )
 
-    document_changes = filter_changes(tasks, "documents", "get")
-
-    for document in document_changes:
-        document_id = get_id(document.get("id"))
-        issue_id = [i for i, d in i_documents.items() if document_id in d]
-
-        if issue_id:
-            resp_json = fetch_documents_front(document_id)
-            try:
-                register_document(resp_json, issue_id[0], document_id, i_documents)
-            except models.Issue.DoesNotExist:
-                orphan_documents.append(document_id)
-        else:
-            orphan_documents.append(document_id)
-
-    Variable.set("orphan_documents", json.dumps(orphan_documents))
-    return tasks
+    Variable.set("orphan_documents", orphans, serialize_json=True)
 
 
 register_documents_task = PythonOperator(
@@ -844,9 +696,7 @@ register_issues_task << register_journals_task
 
 register_last_issues_task << register_issues_task
 
-register_orphan_documents_task << register_last_issues_task
-
-register_documents_task << register_orphan_documents_task
+register_documents_task << register_last_issues_task
 
 delete_journals_task << register_documents_task
 

--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -22,6 +22,7 @@ from mongoengine import connect
 
 from opac_schema.v1 import models
 
+from common.hooks import mongo_connect
 
 failure_recipients = os.environ.get("EMIAL_ON_FAILURE_RECIPIENTS", None)
 EMIAL_ON_FAILURE_RECIPIENTS = (
@@ -47,21 +48,6 @@ dag = DAG(
 )
 
 api_hook = HttpHook(http_conn_id="kernel_conn", method="GET")
-
-
-@retry(wait=tenacity.wait_exponential(), stop=tenacity.stop_after_attempt(10))
-def mongo_connect():
-    # TODO: Necessário adicionar um commando para adicionar previamente uma conexão, ver: https://github.com/puckel/docker-airflow/issues/75
-    conn = BaseHook.get_connection("opac_conn")
-
-    uri = "mongodb://{creds}{host}{port}/{database}".format(
-        creds="{}:{}@".format(conn.login, conn.password) if conn.login else "",
-        host=conn.host,
-        port="" if conn.port is None else ":{}".format(conn.port),
-        database=conn.schema,
-    )
-
-    connect(host=uri, **conn.extra_dejson)
 
 
 class EnqueuedState:

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -1,0 +1,228 @@
+import logging
+from typing import Iterable, Generator, Dict, List, Tuple
+
+from opac_schema.v1 import models
+
+import common.hooks as hooks
+
+
+def ArticleFactory(
+    document_id: str,
+    data: dict,
+    issue_id: str,
+    document_order: int,
+    document_xml_url: str,
+) -> models.Article:
+    """Cria uma instância de artigo a partir dos dados de entrada.
+
+    Os dados do parâmetro `data` são adaptados ao formato exigido pelo
+    modelo Article do OPAC Schema.
+
+    Args:
+        document_id (str): Identificador do documento
+        data (dict): Estrutura contendo o `front` do documento.
+        issue_id (str): Identificador de issue.
+        document_order (int): Posição do artigo.
+        document_xml_url (str): URL do XML do artigo
+
+    Returns:
+        models.Article: Instância de um artigo próprio do modelo de dados do
+            OPAC.
+    """
+
+    def _nestget(data, *path, default=""):
+        """Obtém valores de list ou dicionários."""
+        for key_or_index in path:
+            try:
+                data = data[key_or_index]
+            except (KeyError, IndexError):
+                return default
+        return data
+
+    AUTHOR_CONTRIB_TYPES = (
+        "author",
+        "editor",
+        "organizer",
+        "translator",
+        "autor",
+        "compiler",
+    )
+
+    try:
+        article = models.Article.objects.get(_id=document_id)
+    except models.Article.DoesNotExist:
+        article = models.Article()
+
+    # Dados principais
+    article.title = _nestget(data, "article_meta", 0, "article_title", 0)
+    article.section = _nestget(data, "article_meta", 0, "pub_subject", 0)
+    article.abstract = _nestget(data, "article_meta", 0, "abstract", 0)
+
+    # Identificadores
+    article._id = _nestget(data, "article_meta", 0, "article_publisher_id", 0)
+    article.aid = _nestget(data, "article_meta", 0, "article_publisher_id", 0)
+    article.pid = _nestget(data, "article_meta", 0, "article_publisher_id", 1)
+    article.doi = _nestget(data, "article_meta", 0, "article_doi", 0)
+
+    def _get_article_authors(data) -> Generator:
+        """Recupera a lista de autores do artigo"""
+
+        for contrib in _nestget(data, "contrib"):
+            if _nestget(contrib, "contrib_type", 0) in AUTHOR_CONTRIB_TYPES:
+                yield (
+                    "%s, %s"
+                    % (
+                        _nestget(contrib, "contrib_surname", 0),
+                        _nestget(contrib, "contrib_given_names", 0),
+                    )
+                )
+
+    def _get_original_language(data: dict) -> str:
+        return _nestget(data, "article", 0, "lang", 0)
+
+    def _get_languages(data: dict) -> List[str]:
+        """Recupera a lista de idiomas em que o artigo foi publicado"""
+
+        languages = [_get_original_language(data)]
+
+        for sub_article in _nestget(data, "sub_article"):
+            languages.append(_nestget(sub_article, "article", 0, "lang", 0))
+
+        return languages
+
+    def _get_translated_titles(data: dict) -> Generator:
+        """Recupera a lista de títulos do artigo"""
+
+        for sub_article in _nestget(data, "sub_article"):
+            yield models.TranslatedTitle(
+                **{
+                    "name": _nestget(
+                        sub_article, "article_meta", 0, "article_title", 0
+                    ),
+                    "language": _nestget(sub_article, "article", 0, "lang", 0),
+                }
+            )
+
+    def _get_translaed_sections(data: dict) -> List[models.TranslatedSection]:
+        """Recupera a lista de seções traduzidas a partir do document front"""
+
+        sections = [
+            models.TranslatedSection(
+                **{
+                    "name": _nestget(data, "article_meta", 0, "pub_subject", 0),
+                    "language": _get_original_language(data),
+                }
+            )
+        ]
+
+        for sub_article in _nestget(data, "sub_article"):
+            sections.append(
+                models.TranslatedSection(
+                    **{
+                        "name": _nestget(
+                            sub_article, "article_meta", 0, "pub_subject", 0
+                        ),
+                        "language": _nestget(sub_article, "article", 0, "lang", 0),
+                    }
+                )
+            )
+
+        return sections
+
+    def _get_abstracts(data: dict) -> List[models.Abstract]:
+        """Recupera todos os abstracts do artigo"""
+
+        abstracts = [
+            models.Abstract(
+                **{
+                    "text": _nestget(data, "article_meta", 0, "abstract", 0),
+                    "language": _get_original_language(data),
+                }
+            )
+        ]
+
+        for trans_abstract in data.get("trans_abstract", []):
+            abstracts.append(
+                models.Abstract(
+                    **{
+                        "text": _nestget(trans_abstract, "text", 0),
+                        "language": _nestget(trans_abstract, "lang", 0),
+                    }
+                )
+            )
+
+        for sub_article in _nestget(data, "sub_article"):
+            abstracts.append(
+                models.Abstract(
+                    **{
+                        "text": _nestget(sub_article, "article_meta", 0, "abstract", 0),
+                        "language": _nestget(sub_article, "article", 0, "lang", 0),
+                    }
+                )
+            )
+
+        return abstracts
+
+    def _get_keywords(data: dict) -> List[models.ArticleKeyword]:
+        """Retorna a lista de palavras chaves do artigo e dos
+        seus sub articles"""
+
+        keywords = [
+            models.ArticleKeyword(
+                **{
+                    "keywords": _nestget(kwd_group, "kwd", default=[]),
+                    "language": _nestget(kwd_group, "lang", 0),
+                }
+            )
+            for kwd_group in _nestget(data, "kwd_group", default=[])
+        ]
+
+        for sub_article in _nestget(data, "sub_article"):
+            [
+                keywords.append(
+                    models.ArticleKeyword(
+                        **{
+                            "keywords": _nestget(kwd_group, "kwd", default=[]),
+                            "language": _nestget(kwd_group, "lang", 0),
+                        }
+                    )
+                )
+                for kwd_group in _nestget(sub_article, "kwd_group", default=[])
+            ]
+
+        return keywords
+
+    article.authors = list(_get_article_authors(data))
+    article.languages = list(_get_languages(data))
+    article.translated_titles = list(_get_translated_titles(data))
+    article.trans_sections = list(_get_translaed_sections(data))
+    article.abstracts = list(_get_abstracts(data))
+    article.keywords = list(_get_keywords(data))
+
+    article.abstract_languages = [
+        abstract["language"] for abstract in article.abstracts
+    ]
+
+    article.original_language = _get_original_language(data)
+    article.publication_date = _nestget(data, "pub_date", 0, "text", 0)
+
+    article.type = _nestget(data, "article", 0, "type", 0)
+
+    # Dados de localização
+    article.elocation = _nestget(data, "article_meta", 0, "pub_elocation", 0)
+    article.fpage = _nestget(data, "article_meta", 0, "pub_fpage", 0)
+    article.fpage_sequence = _nestget(data, "article_meta", 0, "pub_fpage_seq", 0)
+    article.lpage = _nestget(data, "article_meta", 0, "pub_lpage", 0)
+
+    # Issue vinculada
+    if issue_id:
+        issue = models.Issue.objects.get(_id=issue_id)
+        article.issue = issue
+        article.journal = issue.journal
+
+    if document_order:
+        article.order = int(document_order)
+
+    article.xml = document_xml_url
+
+    return article

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -103,7 +103,7 @@ def ArticleFactory(
                 }
             )
 
-    def _get_translaed_sections(data: dict) -> List[models.TranslatedSection]:
+    def _get_translated_sections(data: dict) -> List[models.TranslatedSection]:
         """Recupera a lista de seções traduzidas a partir do document front"""
 
         sections = [
@@ -195,7 +195,7 @@ def ArticleFactory(
     article.authors = list(_get_article_authors(data))
     article.languages = list(_get_languages(data))
     article.translated_titles = list(_get_translated_titles(data))
-    article.trans_sections = list(_get_translaed_sections(data))
+    article.trans_sections = list(_get_translated_sections(data))
     article.abstracts = list(_get_abstracts(data))
     article.keywords = list(_get_keywords(data))
 

--- a/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621.json
+++ b/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621.json
@@ -1,0 +1,945 @@
+{
+    "article": [
+      {
+        "type": [
+          "research-article"
+        ],
+        "lang": [
+          "en"
+        ]
+      }
+    ],
+    "article_meta": [
+      {
+        "article_doi": [
+          "10.11606/S1518-8787.2019053000621"
+        ],
+        "article_publisher_id": [
+          "67TH7T7CyPPmgtVrGXhWXVs"
+        ],
+        "article_title": [
+          "Validation of an anxiety scale for prenatal diagnostic procedures"
+        ],
+        "article_title_lang": [],
+        "abstract": [
+          "ABSTRACT OBJECTIVE: To perform a cross-cultural adaptation of the Prenatal Diagnostic Procedures Anxiety Scale questionnaire for application in the Brazilian cultural context. METHODS: The translation and back translation processes followed internationally accepted criteria. A committee of experts evaluated the semantic, idiomatic, experimental and conceptual equivalence, proposing a pre-final version that was applied in 10.0% of the final sample. Afterwards, the final version was approved for the psychometric analysis. At that stage, 55 pregnant women participated which responded to the proposed Brazilian version before taking an ultrasound examination at a public hospital in Santa Catarina, in the year of 2017. The Edinburgh Postnatal Depression Scale was used as an external reliability parameter. The internal consistency of the instrument was obtained by Cronbach's alpha. Validation was performed by exploratory factorial analysis with extraction of principal components by the Kaiser-Guttman method and Varimax rotation. RESULTS: The Cronbach's alpha value of the total instrument was 0.886, and only the percentage of variance from item 2 (0.183) was not significant. The Kaiser-Guttman criterion defined three factors responsible for explaining 78.5% of the variance, as well as the Scree plot. Extraction of the main components by the Varimax method presented values from 0.713 to 0.926, with only item 2 being allocated in the third component. CONCLUSIONS: The Brazilian version is reliable and valid for use in the diagnosis of anxiety related to the performance of ultrasound procedures in prenatal care. Due to the lack of correlation with the rest of the construct, it is suggested that item 2 be removed from the final version."
+        ],
+        "abstract_title": [
+          "ABSTRACT",
+          "OBJECTIVE:",
+          "METHODS:",
+          "RESULTS:",
+          "CONCLUSIONS:"
+        ],
+        "abstract_p": [
+          "To perform a cross-cultural adaptation of the Prenatal Diagnostic Procedures Anxiety Scale questionnaire for application in the Brazilian cultural context.",
+          "The translation and back translation processes followed internationally accepted criteria. A committee of experts evaluated the semantic, idiomatic, experimental and conceptual equivalence, proposing a pre-final version that was applied in 10.0% of the final sample. Afterwards, the final version was approved for the psychometric analysis. At that stage, 55 pregnant women participated which responded to the proposed Brazilian version before taking an ultrasound examination at a public hospital in Santa Catarina, in the year of 2017. The Edinburgh Postnatal Depression Scale was used as an external reliability parameter. The internal consistency of the instrument was obtained by Cronbach's alpha. Validation was performed by exploratory factorial analysis with extraction of principal components by the Kaiser-Guttman method and Varimax rotation.",
+          "The Cronbach's alpha value of the total instrument was 0.886, and only the percentage of variance from item 2 (0.183) was not significant. The Kaiser-Guttman criterion defined three factors responsible for explaining 78.5% of the variance, as well as the Scree plot. Extraction of the main components by the Varimax method presented values from 0.713 to 0.926, with only item 2 being allocated in the third component.",
+          "The Brazilian version is reliable and valid for use in the diagnosis of anxiety related to the performance of ultrasound procedures in prenatal care. Due to the lack of correlation with the rest of the construct, it is suggested that item 2 be removed from the final version."
+        ],
+        "abstract_seq": [
+          "OBJECTIVE: To perform a cross-cultural adaptation of the Prenatal Diagnostic Procedures Anxiety Scale questionnaire for application in the Brazilian cultural context.",
+          "METHODS: The translation and back translation processes followed internationally accepted criteria. A committee of experts evaluated the semantic, idiomatic, experimental and conceptual equivalence, proposing a pre-final version that was applied in 10.0% of the final sample. Afterwards, the final version was approved for the psychometric analysis. At that stage, 55 pregnant women participated which responded to the proposed Brazilian version before taking an ultrasound examination at a public hospital in Santa Catarina, in the year of 2017. The Edinburgh Postnatal Depression Scale was used as an external reliability parameter. The internal consistency of the instrument was obtained by Cronbach's alpha. Validation was performed by exploratory factorial analysis with extraction of principal components by the Kaiser-Guttman method and Varimax rotation.",
+          "RESULTS: The Cronbach's alpha value of the total instrument was 0.886, and only the percentage of variance from item 2 (0.183) was not significant. The Kaiser-Guttman criterion defined three factors responsible for explaining 78.5% of the variance, as well as the Scree plot. Extraction of the main components by the Varimax method presented values from 0.713 to 0.926, with only item 2 being allocated in the third component.",
+          "CONCLUSIONS: The Brazilian version is reliable and valid for use in the diagnosis of anxiety related to the performance of ultrasound procedures in prenatal care. Due to the lack of correlation with the rest of the construct, it is suggested that item 2 be removed from the final version."
+        ],
+        "pub_elocation": [],
+        "pub_fpage": [],
+        "pub_fpage_seq": [],
+        "pub_lpage": [],
+        "pub_subject": [
+          "Original Article"
+        ],
+        "pub_volume": [
+          "53"
+        ],
+        "pub_issue": []
+      }
+    ],
+    "journal_meta": [
+      {
+        "issn_epub": [
+          "1518-8787"
+        ],
+        "issn_ppub": [
+          "0034-8910"
+        ],
+        "journal_nlm_ta": [
+          "Rev Saude Publica"
+        ],
+        "journal_publisher_id": [
+          "rsp"
+        ],
+        "journal_title": [
+          "Revista de Saúde Pública"
+        ],
+        "publisher_name": [
+          "Faculdade de Saúde Pública da Universidade de São Paulo"
+        ]
+      }
+    ],
+    "contrib": [
+      {
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Kindermann Lucas"
+        ],
+        "contrib_given_names": [
+          "Lucas"
+        ],
+        "contrib_orcid": [
+          "0000-0002-9789-501X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Kindermann"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [
+          "c1"
+        ],
+        "xref_corresp_text": [
+          ""
+        ],
+        "xref_aff": [
+          "aff1"
+        ],
+        "xref_aff_text": [
+          "I"
+        ]
+      },
+      {
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Traebert Jefferson"
+        ],
+        "contrib_given_names": [
+          "Jefferson"
+        ],
+        "contrib_orcid": [
+          "0000-0002-7389-985X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Traebert"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Nunes Rodrigo Dias"
+        ],
+        "contrib_given_names": [
+          "Rodrigo Dias"
+        ],
+        "contrib_orcid": [
+          "0000-0002-2261-8253"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Nunes"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      }
+    ],
+    "aff": [
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": []
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff2"
+        ],
+        "aff_text": [
+          "II Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Programa de Pós-Graduação em Ciências da Saúde Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Programa de Pós-Graduação em Ciências da Saúde"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "II"
+        ],
+        "phone": []
+      }
+    ],
+    "pub_date": [
+      {
+        "text": [
+          "31 01 2019"
+        ],
+        "pub_type": [
+          "epub"
+        ],
+        "pub_format": [],
+        "date_type": [],
+        "day": [
+          "31"
+        ],
+        "month": [
+          "01"
+        ],
+        "year": [
+          "2019"
+        ],
+        "season": []
+      }
+    ],
+    "history_date": [
+      {
+        "date_type": [
+          "received"
+        ],
+        "day": [
+          "14"
+        ],
+        "month": [
+          "12"
+        ],
+        "year": [
+          "2017"
+        ]
+      },
+      {
+        "date_type": [
+          "accepted"
+        ],
+        "day": [
+          "10"
+        ],
+        "month": [
+          "04"
+        ],
+        "year": [
+          "2018"
+        ]
+      }
+    ],
+    "kwd_group": [
+      {
+        "lang": [
+          "en"
+        ],
+        "title": [
+          "DESCRIPTORS:"
+        ],
+        "kwd": [
+          "Ultrasonography Prenatal, psychology",
+          "Test Anxiety Scale",
+          "Surveys and Questionnaires, utilization",
+          "Translations",
+          "Validation Studies"
+        ]
+      }
+    ],
+    "trans_abstract": [],
+    "sub_article": [
+      {
+        "article": [
+          {
+            "type": [
+              "translation"
+            ],
+            "lang": [
+              "pt"
+            ]
+          }
+        ],
+        "article_meta": [
+          {
+            "article_doi": [],
+            "article_publisher_id": [],
+            "article_title": [
+              "Validação de uma escala de ansiedade para procedimentos diagnósticos prénatais"
+            ],
+            "article_title_lang": [],
+            "abstract": [
+              "RESUMO OBJETIVO: Proceder à adaptação transcultural do questionário Prenatal Diagnostic Procedures Anxiety Scale para aplicação no contexto cultural brasileiro. MÉTODOS: Os processos de tradução e retrotradução seguiram critérios aceitos internacionalmente. Um comitê de especialistas avaliou as equivalências semântica, idiomática, experimental e conceitual, propondo uma versão pré-final que foi aplicada em 10,0% da amostra final. Em seguida, foi aprovada a versão final para a análise psicométrica. Nessa etapa participaram 55 gestantes que responderam à versão brasileira proposta antes de realizarem um exame ultrassonográfico em um hospital público de Santa Catarina, no ano de 2017. A Edinburgh Postnatal Depression Scale foi utilizada como parâmetro de confiabilidade externa. A consistência interna do instrumento foi obtida pelo alfa de Cronbach. A validação foi realizada por análise fatorial exploratória com extração de componentes principais pelo método de Kaiser-Guttman e rotação Varimax. RESULTADOS: O alfa de Cronbach do instrumento total foi 0,886, e apenas o percentual de variância do item 2 (0,183) não foi significativo. O critério de Kaiser-Guttman definiu três fatores responsáveis por explicar 78,5% da variância, assim como o gráfico de Escarpa. A extração dos componentes principais pelo método Varimax apresentou valores de 0,713 a 0,926, sendo apenas o item 2 alocado no terceiro componente. CONCLUSÕES: A versão brasileira é confiável e válida para uso no diagnóstico de ansiedade relacionada à realização de procedimentos ultrassonográficos no pré-natal. Devido à falta de correlação com o restante do construto, sugere-se a retirada do item 2 da versão final."
+            ],
+            "abstract_title": [
+              "RESUMO",
+              "OBJETIVO:",
+              "MÉTODOS:",
+              "RESULTADOS:",
+              "CONCLUSÕES:"
+            ],
+            "abstract_p": [
+              "Proceder à adaptação transcultural do questionário Prenatal Diagnostic Procedures Anxiety Scale para aplicação no contexto cultural brasileiro.",
+              "Os processos de tradução e retrotradução seguiram critérios aceitos internacionalmente. Um comitê de especialistas avaliou as equivalências semântica, idiomática, experimental e conceitual, propondo uma versão pré-final que foi aplicada em 10,0% da amostra final. Em seguida, foi aprovada a versão final para a análise psicométrica. Nessa etapa participaram 55 gestantes que responderam à versão brasileira proposta antes de realizarem um exame ultrassonográfico em um hospital público de Santa Catarina, no ano de 2017. A Edinburgh Postnatal Depression Scale foi utilizada como parâmetro de confiabilidade externa. A consistência interna do instrumento foi obtida pelo alfa de Cronbach. A validação foi realizada por análise fatorial exploratória com extração de componentes principais pelo método de Kaiser-Guttman e rotação Varimax.",
+              "O alfa de Cronbach do instrumento total foi 0,886, e apenas o percentual de variância do item 2 (0,183) não foi significativo. O critério de Kaiser-Guttman definiu três fatores responsáveis por explicar 78,5% da variância, assim como o gráfico de Escarpa. A extração dos componentes principais pelo método Varimax apresentou valores de 0,713 a 0,926, sendo apenas o item 2 alocado no terceiro componente.",
+              "A versão brasileira é confiável e válida para uso no diagnóstico de ansiedade relacionada à realização de procedimentos ultrassonográficos no pré-natal. Devido à falta de correlação com o restante do construto, sugere-se a retirada do item 2 da versão final."
+            ],
+            "abstract_seq": [
+              "OBJETIVO: Proceder à adaptação transcultural do questionário Prenatal Diagnostic Procedures Anxiety Scale para aplicação no contexto cultural brasileiro.",
+              "MÉTODOS: Os processos de tradução e retrotradução seguiram critérios aceitos internacionalmente. Um comitê de especialistas avaliou as equivalências semântica, idiomática, experimental e conceitual, propondo uma versão pré-final que foi aplicada em 10,0% da amostra final. Em seguida, foi aprovada a versão final para a análise psicométrica. Nessa etapa participaram 55 gestantes que responderam à versão brasileira proposta antes de realizarem um exame ultrassonográfico em um hospital público de Santa Catarina, no ano de 2017. A Edinburgh Postnatal Depression Scale foi utilizada como parâmetro de confiabilidade externa. A consistência interna do instrumento foi obtida pelo alfa de Cronbach. A validação foi realizada por análise fatorial exploratória com extração de componentes principais pelo método de Kaiser-Guttman e rotação Varimax.",
+              "RESULTADOS: O alfa de Cronbach do instrumento total foi 0,886, e apenas o percentual de variância do item 2 (0,183) não foi significativo. O critério de Kaiser-Guttman definiu três fatores responsáveis por explicar 78,5% da variância, assim como o gráfico de Escarpa. A extração dos componentes principais pelo método Varimax apresentou valores de 0,713 a 0,926, sendo apenas o item 2 alocado no terceiro componente.",
+              "CONCLUSÕES: A versão brasileira é confiável e válida para uso no diagnóstico de ansiedade relacionada à realização de procedimentos ultrassonográficos no pré-natal. Devido à falta de correlação com o restante do construto, sugere-se a retirada do item 2 da versão final."
+            ],
+            "pub_elocation": [],
+            "pub_fpage": [],
+            "pub_fpage_seq": [],
+            "pub_lpage": [],
+            "pub_subject": [
+              "Artigo Original"
+            ],
+            "pub_volume": [],
+            "pub_issue": []
+          }
+        ],
+        "journal_meta": [
+          {
+            "issn_epub": [],
+            "issn_ppub": [],
+            "journal_nlm_ta": [],
+            "journal_publisher_id": [],
+            "journal_title": [],
+            "publisher_name": []
+          }
+        ],
+        "contrib": [
+          {
+            "contrib_bio": [],
+            "contrib_degrees": [],
+            "contrib_email": [],
+            "contrib_name": [
+              "Kindermann Lucas"
+            ],
+            "contrib_given_names": [
+              "Lucas"
+            ],
+            "contrib_orcid": [
+              "0000-0002-9789-501X"
+            ],
+            "contrib_prefix": [],
+            "contrib_role": [],
+            "contrib_suffix": [],
+            "contrib_surname": [
+              "Kindermann"
+            ],
+            "contrib_type": [
+              "author"
+            ],
+            "xref_corresp": [
+              "c2"
+            ],
+            "xref_corresp_text": [
+              ""
+            ],
+            "xref_aff": [
+              "aff3"
+            ],
+            "xref_aff_text": [
+              "I"
+            ]
+          },
+          {
+            "contrib_bio": [],
+            "contrib_degrees": [],
+            "contrib_email": [],
+            "contrib_name": [
+              "Traebert Jefferson"
+            ],
+            "contrib_given_names": [
+              "Jefferson"
+            ],
+            "contrib_orcid": [
+              "0000-0002-7389-985X"
+            ],
+            "contrib_prefix": [],
+            "contrib_role": [],
+            "contrib_suffix": [],
+            "contrib_surname": [
+              "Traebert"
+            ],
+            "contrib_type": [
+              "author"
+            ],
+            "xref_corresp": [],
+            "xref_corresp_text": [],
+            "xref_aff": [
+              "aff3",
+              "aff4"
+            ],
+            "xref_aff_text": [
+              "I",
+              "II"
+            ]
+          },
+          {
+            "contrib_bio": [],
+            "contrib_degrees": [],
+            "contrib_email": [],
+            "contrib_name": [
+              "Nunes Rodrigo Dias"
+            ],
+            "contrib_given_names": [
+              "Rodrigo Dias"
+            ],
+            "contrib_orcid": [
+              "0000-0002-2261-8253"
+            ],
+            "contrib_prefix": [],
+            "contrib_role": [],
+            "contrib_suffix": [],
+            "contrib_surname": [
+              "Nunes"
+            ],
+            "contrib_type": [
+              "author"
+            ],
+            "xref_corresp": [],
+            "xref_corresp_text": [],
+            "xref_aff": [
+              "aff3",
+              "aff4"
+            ],
+            "xref_aff_text": [
+              "I",
+              "II"
+            ]
+          }
+        ],
+        "aff": [
+          {
+            "addr_city": [
+              "Palhoça"
+            ],
+            "addr_country": [
+              "Brasil"
+            ],
+            "addr_country_code": [
+              "BR"
+            ],
+            "addr_postal_code": [],
+            "addr_state": [
+              "SC"
+            ],
+            "aff_id": [
+              "aff3"
+            ],
+            "aff_text": [
+              "I Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+            ],
+            "aff_email": [],
+            "institution_original": [
+              "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+            ],
+            "institution_orgdiv1": [],
+            "institution_orgdiv2": [],
+            "institution_orgname": [],
+            "institution_orgname_rewritten": [],
+            "label": [
+              "I"
+            ],
+            "phone": []
+          },
+          {
+            "addr_city": [
+              "Palhoça"
+            ],
+            "addr_country": [
+              "Brasil"
+            ],
+            "addr_country_code": [
+              "BR"
+            ],
+            "addr_postal_code": [],
+            "addr_state": [
+              "SC"
+            ],
+            "aff_id": [
+              "aff4"
+            ],
+            "aff_text": [
+              "II Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+            ],
+            "aff_email": [],
+            "institution_original": [
+              "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+            ],
+            "institution_orgdiv1": [],
+            "institution_orgdiv2": [],
+            "institution_orgname": [],
+            "institution_orgname_rewritten": [],
+            "label": [
+              "II"
+            ],
+            "phone": []
+          }
+        ],
+        "pub_date": [],
+        "history_date": [],
+        "kwd_group": [
+          {
+            "lang": [
+              "pt"
+            ],
+            "title": [
+              "DESCRITORES:"
+            ],
+            "kwd": [
+              "Ultrassonografia Pré-Natal, psicologia",
+              "Escala de Ansiedade Frente a Teste",
+              "Inquéritos e Questionários, utilização",
+              "Traduções",
+              "Estudos de Validação"
+            ]
+          }
+        ],
+        "trans_abstract": [],
+        "sub_article": []
+      }
+    ],
+    "aff_contrib_full": [
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Kindermann Lucas"
+        ],
+        "contrib_given_names": [
+          "Lucas"
+        ],
+        "contrib_orcid": [
+          "0000-0002-9789-501X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Kindermann"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [
+          "c1"
+        ],
+        "xref_corresp_text": [
+          ""
+        ],
+        "xref_aff": [
+          "aff1"
+        ],
+        "xref_aff_text": [
+          "I"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Traebert Jefferson"
+        ],
+        "contrib_given_names": [
+          "Jefferson"
+        ],
+        "contrib_orcid": [
+          "0000-0002-7389-985X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Traebert"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Nunes Rodrigo Dias"
+        ],
+        "contrib_given_names": [
+          "Rodrigo Dias"
+        ],
+        "contrib_orcid": [
+          "0000-0002-2261-8253"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Nunes"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff2"
+        ],
+        "aff_text": [
+          "II Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Programa de Pós-Graduação em Ciências da Saúde Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Programa de Pós-Graduação em Ciências da Saúde"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "II"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Traebert Jefferson"
+        ],
+        "contrib_given_names": [
+          "Jefferson"
+        ],
+        "contrib_orcid": [
+          "0000-0002-7389-985X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Traebert"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff2"
+        ],
+        "aff_text": [
+          "II Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Programa de Pós-Graduação em Ciências da Saúde Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Programa de Pós-Graduação em Ciências da Saúde"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "II"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Nunes Rodrigo Dias"
+        ],
+        "contrib_given_names": [
+          "Rodrigo Dias"
+        ],
+        "contrib_orcid": [
+          "0000-0002-2261-8253"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Nunes"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      }
+    ]
+  }

--- a/airflow/tests/test_kernel_changes.py
+++ b/airflow/tests/test_kernel_changes.py
@@ -1,10 +1,13 @@
 import os
 import unittest
+from unittest.mock import patch, MagicMock
 import json
 
 from airflow import DAG
 
 from kernel_changes import JournalFactory
+from operations.kernel_changes_operations import ArticleFactory
+from opac_schema.v1 import models
 
 
 FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
@@ -95,3 +98,107 @@ class JournalFactoryTests(unittest.TestCase):
 
     def test_attribute_updated(self):
         self.assertEqual(self.journal.updated, "2019-07-19T20:33:17.102106Z")
+
+
+class ArticleFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.article_objects = patch(
+            "operations.kernel_changes_operations.models.Article.objects"
+        )
+        self.issue_objects = patch(
+            "operations.kernel_changes_operations.models.Issue.objects"
+        )
+        ArticleObjectsMock = self.article_objects.start()
+        self.issue_objects.start()
+
+        ArticleObjectsMock.get.side_effect = models.Article.DoesNotExist
+
+        self.document_front = load_json_fixture(
+            "kernel-document-front-s1518-8787.2019053000621.json"
+        )
+        self.document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front, "issue-1", "1", ""
+        )
+
+    def tearDown(self):
+        self.article_objects.stop()
+        self.issue_objects.stop()
+
+    def test_has_method_save(self):
+        self.assertTrue(hasattr(self.document, "save"))
+
+    def test_has_title_attribute(self):
+        self.assertTrue(hasattr(self.document, "title"))
+
+    def test_has_section_attribute(self):
+        self.assertTrue(hasattr(self.document, "section"))
+
+    def test_has_abstract_attribute(self):
+        self.assertTrue(hasattr(self.document, "abstract"))
+
+    def test_has_identification_attributes(self):
+        self.assertTrue(hasattr(self.document, "_id"))
+        self.assertTrue(hasattr(self.document, "aid"))
+        self.assertTrue(hasattr(self.document, "pid"))
+        self.assertTrue(hasattr(self.document, "doi"))
+
+        self.assertEqual("67TH7T7CyPPmgtVrGXhWXVs", self.document._id)
+        self.assertEqual("67TH7T7CyPPmgtVrGXhWXVs", self.document.aid)
+        self.assertEqual("10.11606/S1518-8787.2019053000621", self.document.doi)
+
+    def test_has_authors_attribute(self):
+        self.assertTrue(hasattr(self.document, "authors"))
+
+    def test_has_translated_titles_attribute(self):
+        self.assertTrue(hasattr(self.document, "translated_titles"))
+        self.assertEqual(1, len(self.document.translated_titles))
+
+    def test_has_trans_sections_attribute(self):
+        self.assertTrue(hasattr(self.document, "trans_sections"))
+        self.assertEqual(2, len(self.document.trans_sections))
+
+    def test_has_abstracts_attribute(self):
+        self.assertTrue(hasattr(self.document, "abstracts"))
+        self.assertEqual(2, len(self.document.abstracts))
+
+    def test_has_keywords_attribute(self):
+        self.assertTrue(hasattr(self.document, "keywords"))
+        self.assertEqual(2, len(self.document.keywords))
+
+    def test_has_abstract_languages_attribute(self):
+        self.assertTrue(hasattr(self.document, "abstract_languages"))
+        self.assertEqual(2, len(self.document.abstract_languages))
+
+    def test_has_original_language_attribute(self):
+        self.assertTrue(hasattr(self.document, "original_language"))
+        self.assertEqual("en", self.document.original_language)
+
+    def test_has_publication_date_attribute(self):
+        self.assertTrue(hasattr(self.document, "publication_date"))
+        self.assertEqual("31 01 2019", self.document.publication_date)
+
+    def test_has_type_attribute(self):
+        self.assertTrue(hasattr(self.document, "type"))
+        self.assertEqual("research-article", self.document.type)
+
+    def test_has_elocation_attribute(self):
+        self.assertTrue(hasattr(self.document, "elocation"))
+
+    def test_has_fpage_attribute(self):
+        self.assertTrue(hasattr(self.document, "fpage"))
+
+    def test_has_lpage_attribute(self):
+        self.assertTrue(hasattr(self.document, "lpage"))
+
+    def test_has_issue_attribute(self):
+        self.assertTrue(hasattr(self.document, "issue"))
+
+    def test_has_journal_attribute(self):
+        self.assertTrue(hasattr(self.document, "journal"))
+
+    def test_has_order_attribute(self):
+        self.assertTrue(hasattr(self.document, "order"))
+        self.assertEqual(1, self.document.order)
+
+    def test_has_xml_attribute(self):
+        self.assertTrue(hasattr(self.document, "xml"))


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adapta o a leitura dos relacionamentos do Kernel.

#### Onde a revisão poderia começar?
- `airflow/dags/kernel_changes.py` L `413`

#### Como este poderia ser testado manualmente?

Para testar este PR manualmente deve-se:
- Baixar o PR;
- Executar o espelhamento a partir de uma base zerada;
- Registrar no Kernel
  - Periódicos, fascículos e documentos
  - Relacionar as entidades;
    - Mediante ao [bug](https://github.com/scieloorg/opac-airflow/issues/95) o relacionamento entre Issue e Document pode não ocorrer, utilize o `curl` para realizar o relacionamento manualmente se preciso for.
- Verificar a leitura dos dados
- Verificar o registro dos documentos na base do OPAC

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

N/A

#### Quais são tickets relevantes?
closes #80 

### Referências
N/A
