### PR TITLE
Altera dados do relacionamento entre periódico e fascículos

### DIFF
--- a/airflow/dags/kernel_gate.py
+++ b/airflow/dags/kernel_gate.py
@@ -195,10 +195,20 @@ def issue_as_kernel(issue: dict) -> dict:
     return _payload
 
 
+def issue_data_to_link(issue: dict) -> dict:
+    _issue_data = issue_as_kernel(issue)
+    _issue_info_to_link = {
+        "id": _issue_data["_id"],
+        "year": _issue_data["publication_year"],
+    }
+    for attr in ("volume", "number", "supplement"):
+        if attr in _issue_data.keys() and _issue_data.get(attr):
+            _issue_info_to_link[attr] = _issue_data.get(attr)
+    return _issue_info_to_link
+
+
 def register_or_update(_id: str, payload: dict, entity_url: str):
     """Cadastra ou atualiza uma entidade no Kernel a partir de um payload"""
-
-
 
     try:
         response = hooks.kernel_connect(
@@ -349,13 +359,13 @@ def mount_journals_issues_link(issues: List[dict]) -> dict:
     issues = filter_issues(issues)
 
     for issue in issues:
-        issue_id = issue_as_kernel(issue).pop("_id")
-        issue_position = int(issue.data["issue"]["v36"][0]["_"])
+        issue_to_link = issue_data_to_link(issue)
+        issue_to_link["order"] = issue.data["issue"]["v36"][0]["_"]
         journal_id = issue.data.get("issue").get("v35")[0]["_"]
         journal_issues.setdefault(journal_id, [])
 
-        if not issue_id in journal_issues[journal_id]:
-            journal_issues[journal_id].insert(issue_position, issue_id)
+        if not issue_to_link in journal_issues[journal_id]:
+            journal_issues[journal_id].append(issue_to_link)
 
     return journal_issues
 

--- a/airflow/dags/kernel_gate.py
+++ b/airflow/dags/kernel_gate.py
@@ -113,18 +113,7 @@ def journal_as_kernel(journal: Journal) -> dict:
         if _status[2]:
             _payload["status"]["reason"] = _status[2]
 
-    _payload["subject_areas"] = []
-    if journal.subject_areas:
-
-        for subject_area in journal.subject_areas:
-            # TODO: Algumas áreas estão em caixa baixa, o que devemos fazer?
-
-            # A Base MST possui uma grande área que é considerada errada
-            # é preciso normalizar o valor
-            if subject_area.upper() == "LINGUISTICS, LETTERS AND ARTS":
-                subject_area = "LINGUISTIC, LITERATURE AND ARTS"
-
-            _payload["subject_areas"].append(subject_area.upper())
+    _payload["subject_areas"] = journal.subject_areas or []
 
     _payload["sponsors"] = []
     if journal.sponsors:
@@ -200,6 +189,7 @@ def issue_as_kernel(issue: dict) -> dict:
         issue.number,
         _payload.get("supplement"),
     )
+    _payload["publication_year"] = str(_creation_date.year)
 
     return _payload
 

--- a/airflow/tests/test_kernel_gate.py
+++ b/airflow/tests/test_kernel_gate.py
@@ -6,11 +6,59 @@ import unittest
 from unittest import mock
 
 from airflow import DAG
+from xylose.scielodocument import Issue
 
-from kernel_gate import mount_journals_issues_link
+from kernel_gate import mount_journals_issues_link, issue_data_to_link
 from .test_kernel_changes import load_json_fixture
 
 FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+
+
+class TestIssueToLink(unittest.TestCase):
+    def setUp(self):
+        self.issues = load_json_fixture("isis-issues.json")
+
+    def test_issue_data_to_link_with_supplement(self):
+        suppl_field_expected = (
+            ("v131", u"2", "2"),
+            ("v132", u"2", "2"),
+            ("v131", u"0", "0"),
+            ("v132", u"0", "0"),
+        )
+        data = self.issues[-1]
+        for field, value, expected in suppl_field_expected:
+            with self.subTest(field=field, value=value, expected=expected):
+                data[field] = [{u'_': value}]
+                issue = Issue({"issue": data})
+                result = issue_data_to_link(issue)
+                self.assertEqual(result["supplement"], expected)
+
+    def test_issue_data_to_link_without_volume(self):
+        data = self.issues[-1]
+        del data["v31"]
+        issue = Issue({"issue": data})
+        result = issue_data_to_link(issue)
+        self.assertIsNone(result.get("volume"))
+
+    def test_issue_data_to_link_without_number(self):
+        data = self.issues[-1]
+        del data["v32"]
+        issue = Issue({"issue": data})
+        result = issue_data_to_link(issue)
+        self.assertIsNone(result.get("number"))
+
+    def test_issue_data_to_link_without_supplement(self):
+        issue = Issue({"issue": self.issues[-1]})
+        result = issue_data_to_link(issue)
+        self.assertIsNone(result.get("supplement"))
+
+    def test_issue_data_to_link_returns_issue_data_to_link_to_journal(self):
+        issue = Issue({"issue": self.issues[-1]})
+        result = issue_data_to_link(issue)
+        self.assertEqual(result["id"], "1678-4464-2018-v1-n1")
+        self.assertEqual(result["number"], "1")
+        self.assertEqual(result["volume"], "1")
+        self.assertEqual(result["year"], "2018")
 
 
 class UpdateJournalAndIssueLink(unittest.TestCase):
@@ -19,13 +67,35 @@ class UpdateJournalAndIssueLink(unittest.TestCase):
 
     def test_mount_journals_issues_link(self):
         journals_issues_link = mount_journals_issues_link(self.issues)
-        self.assertEqual(journals_issues_link["1678-4464"], ["1678-4464-2018-v1-n1"])
+        self.assertEqual(
+            journals_issues_link["1678-4464"],
+            [
+                {
+                    'id': '1678-4464-2018-v1-n1',
+                    'order': '1001',
+                    'year': '2018',
+                    'volume': '1',
+                    'number': '1'
+                }
+            ]
+        )
 
     def test_mount_journals_issues_link_should_not_contains_duplicates_issues_ids(self):
         issues = self.issues * 3
         journals_issues_link = mount_journals_issues_link(issues)
 
-        self.assertEqual(journals_issues_link["1678-4464"], ["1678-4464-2018-v1-n1"])
+        self.assertEqual(
+            journals_issues_link["1678-4464"],
+            [
+                {
+                    'id': '1678-4464-2018-v1-n1',
+                    'order': '1001',
+                    'year': '2018',
+                    'volume': '1',
+                    'number': '1'
+                }
+            ]
+        )
         self.assertEqual(len(journals_issues_link["1678-4464"]), 1)
 
     def test_mount_journals_issues_link_should_not_contains_pressrelease(self):


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR altera o _callable_ da tarefa `link_journals_and_issues_task`. Ao invés do ID do fascículo, agora o relacionamento de cada fascículo com o periódico recebe também o ano de publicação, volume, número, suplemento e ordem/número sequencial. Como a ordem não é mais determinada pela lista no periódico, os dados de cada fascículo são somente adicionados ao final da lista.

Também foram feitos ajustes para que essa tarefa fosse concluída:
- Correção de dados do periódico
- Alteração no envio dos dados para o Kernel

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commit.

#### Como este poderia ser testado manualmente?
- Executar a DAG `kernel_gate` completa
- Verificar no _Kernel_ o conteúdo do campo `items` no periódico
- Deve conter os dados do fascículo, não somente o ID

#### Algum cenário de contexto que queira dar?
Detalhes no ticket #89 

### Screenshots
N/A

#### Quais são tickets relevantes?
#89 

### Referências
Nenhuma.
