### PR TITLE
Adequa relacionamento de fascículo com periódico

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -443,15 +443,10 @@ def register_issues(ds, **kwargs):
 
     def _journal_id(issue_id):
         """Obtém o identificador do periódico onde `issue_id` está contido."""
-        j = [
-            journal_id
-            for journal_id, issues in known_issues.items()
-            if issue_id in issues
-        ]
-        try:
-            return j[0]
-        except IndexError:
-            return None
+        for journal_id, items in known_issues.items():
+            for item in items:
+                if issue_id == item["id"]:
+                    return journal_id
 
     def _issue_order(issue_id):
         """A posição em relação aos demais fascículos do periódico.
@@ -459,7 +454,10 @@ def register_issues(ds, **kwargs):
         Pode levantar `ValueError` caso `issue_id` não conste na relação de 
         fascículos do periódico `journal_id`.
         """
-        return known_issues.get(_journal_id(issue_id), []).index(issue_id)
+        issues = known_issues.get(_journal_id(issue_id), [])
+        for issue in issues:
+            if issue_id == issue["id"]:
+                return issue["order"]
 
     issues_to_get = itertools.chain(
         Variable.get("orphan_issues", default_var=[], deserialize_json=True),

--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -1,4 +1,5 @@
 import os
+import re
 import json
 import logging
 from datetime import timedelta
@@ -27,6 +28,8 @@ EMIAL_ON_FAILURE_RECIPIENTS = (
     failure_recipients.split(",") if failure_recipients else []
 )
 
+EMAIL_SPLIT_REGEX = re.compile("[;\\/]+")
+
 default_args = {
     "owner": "airflow",
     "start_date": airflow.utils.dates.days_ago(2),
@@ -40,7 +43,7 @@ default_args = {
 dag = DAG(
     dag_id="kernel_changes",
     default_args=default_args,
-    schedule_interval=timedelta(minutes=1),
+    schedule_interval=None,
 )
 
 api_hook = HttpHook(http_conn_id="kernel_conn", method="GET")
@@ -232,9 +235,9 @@ def parser_endpoint(endpoint):
     Return: (journals, 0000-0000-00-00-2)
 
     """
-    _, _entity, _id = endpoint.split("/")
+    _parsed_endpoint = endpoint.split("/")
 
-    return (_entity, _id)
+    return _parsed_endpoint[1:3]
 
 
 def filter_changes(tasks, entity, action):
@@ -310,7 +313,9 @@ def JournalFactory(data):
     # Editor mail
     if metadata.get("contact", ""):
         contact = metadata.get("contact")
-        journal.editor_email = contact.get("email", "").split(";")[0].strip()
+        journal.editor_email = EMAIL_SPLIT_REGEX.split(contact.get("email", ""))[
+            0
+        ].strip()
 
     journal.online_submission_url = metadata.get("online_submission_url", "")
     journal.logo_url = metadata.get("logo_url", "")
@@ -406,21 +411,23 @@ def try_register_issues(
     orphans = []
 
     for issue_id in issues:
-        if get_journal_id(issue_id) is not None:
+        journal_id = get_journal_id(issue_id)
+        logging.info('Registering issue "%s" to journal "%s"', issue_id, journal_id)
+        if journal_id is not None:
             data = fetch_data(issue_id)
             try:
                 issue = issue_factory(
-                    data, get_journal_id(issue_id), get_issue_order(issue_id)
+                    data, journal_id, get_issue_order(issue_id)
                 )
                 issue.save()
             except models.Journal.DoesNotExist:
-                orphan_issues.append(issue_id)
+                orphans.append(issue_id)
             else:
                 known_documents[issue_id] = data.get("items", [])
         else:
             orphans.append(issue_id)
 
-    return orphans, known_documents
+    return list(set(orphans)), known_documents
 
 
 def register_issues(ds, **kwargs):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera o callable da tarefa `register_issues_task`, adequando a leitura dos dados de relacionamento de fascículos com periódicos, que foram alterados no _Kernel_. Assim, é possível registrar os fascículos em seus respectivos periódicos corretamente no OPAC.
Também foram corrigidos o parser de endpoints dos registros de mudança, `JournalFactory` por conta de email do editor e duplicação nos registros de fascículos órfãos.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commit.

#### Como este poderia ser testado manualmente?
- Com registros de relacionamentos entre fascículos e periódicos atualizados com os dados novos no _Kernel_, executar a DAG `kernel_changes`
- Após a execução da task `register_issues_task`, os fascículos devem ser cadastrados com sucesso no OPAC

#### Algum cenário de contexto que queira dar?
Os fascículos estão sendo registrados como "regular" no OPAC e, por isso, não é possível visualizar no site os volume issues e os suplementos.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#79 e #89

### Referências
Nenhuma.