### PR TITLE
Cria índice de ISSNs e utiliza-o no relacionamento de documentos com bundles

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -12,7 +12,7 @@ from operations.exceptions import (
     PutXMLInObjectStoreException,
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
-    RelateDocumentToDocumentsBundleException,
+    LinkDocumentToDocumentsBundleException,
 )
 from common.sps_package import SPS_Package
 
@@ -240,7 +240,7 @@ def register_document_to_documentsbundle(bundle_id, payload):
             "/bundles/%s/documents" % bundle_id, "PUT", payload)
         return response
     except requests.exceptions.HTTPError as exc:
-        raise RelateDocumentToDocumentsBundleException(str(exc)) from None
+        raise LinkDocumentToDocumentsBundleException(str(exc)) from None
 
 
 def issue_id(issn_id, year, volume=None, number=None, supplement=None):

--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -18,5 +18,5 @@ class RegisterUpdateDocIntoKernelException(Exception):
     ...
 
 
-class RelateDocumentToDocumentsBundleException(Exception):
+class LinkDocumentToDocumentsBundleException(Exception):
     ...

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -74,12 +74,21 @@ def register_update_documents(dag_run, **kwargs):
 
 def link_documents_to_documentsbundle(dag_run, **kwargs):
     documents = kwargs["ti"].xcom_pull(key="documents", task_ids="register_update_docs_id")
+    issn_index_json_path = kwargs["ti"].xcom_pull(
+        task_ids="process_journals_task",
+        dag_id="kernel-gate",
+        key="issn_index_json_path",
+        include_prior_dates=True
+    )
 
     if documents:
-        linked_bundle = sync_documents_to_kernel_operations.link_documents_to_documentsbundle(documents)
+        linked_bundle = sync_documents_to_kernel_operations.link_documents_to_documentsbundle(
+            documents, issn_index_json_path
+        )
 
         if linked_bundle:
             kwargs["ti"].xcom_push(key="linked_bundle", value=linked_bundle)
+
 
 list_documents_task = PythonOperator(
     task_id="list_docs_task_id",

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -1,7 +1,6 @@
-import os
 import copy
 import random
-from unittest import TestCase, main, skip
+from unittest import TestCase, main
 from unittest.mock import patch, Mock, MagicMock
 
 import requests
@@ -25,7 +24,7 @@ from operations.exceptions import (
     PutXMLInObjectStoreException,
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
-    RelateDocumentToDocumentsBundleException,
+    LinkDocumentToDocumentsBundleException,
 )
 
 from tests.fixtures import XML_FILE_CONTENT
@@ -761,7 +760,7 @@ class TestRegisterDocumentsToDocumentsBundle(TestCase):
             "Not Found"
         )
 
-        self.assertRaises(RelateDocumentToDocumentsBundleException,
+        self.assertRaises(LinkDocumentToDocumentsBundleException,
                           register_document_to_documentsbundle,
                           "0066-782X-1999-v72-n0",
                           self.payload)
@@ -783,6 +782,7 @@ class TestRegisterDocumentsToDocumentsBundle(TestCase):
         response = register_document_to_documentsbundle("0066-782X-1999-v72-n0", payload)
 
         self.assertEqual(response.status_code, 204)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
#### O que esse PR faz?
Este PR cria um índice de ISSNs de periódicos e utiliza-o para obter o ID de bundles para efetuar o relacionamento de documentos com os `DocumentsBundles`. Para isso:
- Na execução da tarefa `process_journals`, cria um arquivo JSON contendo índice contendo todos os ISSNs registrados na `title`, mapeando para o ISSN ID correspondente.
- Altera a tarefa de relacionamento de documentos com _bundles_ para ler e usar o índice de ISSNs de periódicos para formar o ID do fascículo com o ISSN ID ao invés do ISSN do documento.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
1. Execute a DAG de espelhamento e verifique na task `process_journals_task`:
  * A criação de um arquivo JSON chamado `issn_index.json` no mesmo diretório que os outros JSONs do espelhamento foram gravados. Este deve conter os ISSNs existentes como chave e os valores devem ser os ISSNs IDs de periódicos.
  * Deve existir na XCOM da tarefa uma chave para o path deste arquivo JSON contendo o índice
2. Execute a DAG `pre_sync_documents_to_kernel` com um pacote contendo documentos com ISSN diferente do ISSN do periódico ao qual ele pertence.
3. Ao final da execução da tarefa de relacionamento de documentos com _bundles_, verifique se os documentos foram relacionados corretamente.

#### Algum cenário de contexto que queira dar?
Detalhes no ticket #95

### Screenshots
N/A

#### Quais são tickets relevantes?
#95 

### Referências
Nenhuma.