### PR TITLE
Adiciona suporte de registro para as manifestações de documentos na base do OPAC

### DIFF
--- a/airflow/dags/kernel_changes.py
+++ b/airflow/dags/kernel_changes.py
@@ -223,10 +223,19 @@ def parser_endpoint(endpoint):
     Return: (journals, 0000-0000-00-00-2)
 
     """
-    _parsed_endpoint = endpoint.split("/")
+    patterns = [
+        r"^\/(?P<entity>journals)\/(?P<id>[-\w]+)$",
+        r"^\/(?P<entity>bundles)\/(?P<id>[-\w\.]+)$",
+        r"^\/(?P<entity>documents)\/(?P<id>[-\w]+)$",
+        r"^\/documents\/(?P<id>[-\w]+)\/(?P<entity>renditions)$",
+    ]
 
-    return _parsed_endpoint[1:3]
+    for pattern in patterns:
+        matched = re.match(pattern, endpoint)
 
+        if matched:
+            groups = matched.groupdict()
+            return (groups["entity"], groups["id"])
 
 def filter_changes(tasks, entity, action):
     """

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -287,3 +287,32 @@ def try_register_documents(
             )
 
     return list(set(orphans))
+
+
+def ArticleRenditionFactory(article_id: str, data: List[dict]) -> models.Article:
+    """Recupera uma instância de artigo a partir de um article_id e popula seus
+    assets a partir dos dados de entrada.
+
+    A partir do article_id uma instância de Artigo é recuperada da base OPAC e
+    seus assets são populados. Se o Artigo não existir na base OPAC a exceção
+    models.ArticleDoesNotExists é lançada.
+    
+    Args:
+        article_id (str): Identificador do artigo a ser recuperado
+        data (List[dict]): Lista de renditions do artigo
+    
+    Returns:
+        models.Article: Artigo recuperado e atualizado com uma nova lista de assets."""
+
+    article = models.Article.objects.get(_id=article_id)
+
+    def _get_pdfs(data: dict) -> List[dict]:
+        return [
+            {"lang": rendition["lang"], "url": rendition["url"], "type": "pdf"}
+            for rendition in data
+            if rendition["mimetype"] == "application/pdf"
+        ]
+
+    article.pdfs = list(_get_pdfs(data))
+
+    return article

--- a/airflow/tests/test_kernel_changes.py
+++ b/airflow/tests/test_kernel_changes.py
@@ -10,6 +10,7 @@ from operations.kernel_changes_operations import (
     ArticleFactory,
     try_register_documents,
     ArticleRenditionFactory,
+    try_register_documents_renditions,
 )
 from opac_schema.v1 import models
 
@@ -322,3 +323,56 @@ class ArticleRenditionFactoryTests(unittest.TestCase):
             [{"lang": "en", "url": "//object-storage/file.pdf", "type": "pdf"}],
             self.article.pdfs,
         )
+
+
+class RegisterDocumentRenditionsTest(unittest.TestCase):
+    def setUp(self):
+        self.documents = ["67TH7T7CyPPmgtVrGXhWXVs"]
+        self.document_front = load_json_fixture(
+            "kernel-document-front-s1518-8787.2019053000621.json"
+        )
+
+        mk_hooks = patch("operations.kernel_changes_operations.hooks")
+        self.mk_hooks = mk_hooks.start()
+
+        self.renditions = [
+            {
+                "filename": "filename.pdf",
+                "url": "//object-storage/file.pdf",
+                "mimetype": "application/pdf",
+                "lang": "en",
+                "size_bytes": 1,
+            }
+        ]
+
+    def tearDown(self):
+        self.mk_hooks.stop()
+
+    def test_try_register_documents_renditions_call_save_methods_from_article_instance(
+        self
+    ):
+        article_rendition_factory_mock = MagicMock()
+        article_instance_mock = MagicMock()
+        article_rendition_factory_mock.return_value = article_instance_mock
+
+        orphans = try_register_documents_renditions(
+            documents=self.documents,
+            get_rendition_data=lambda document_id: self.renditions,
+            article_rendition_factory=article_rendition_factory_mock,
+        )
+
+        article_instance_mock.save.assert_called()
+
+        self.assertEqual([], orphans)
+
+    def test_has_orphans_when_try_register_an_orphan_rendition(self):
+        article_rendition_factory_mock = MagicMock()
+        article_rendition_factory_mock.side_effect = [models.Article.DoesNotExist]
+
+        orphans = try_register_documents_renditions(
+            documents=self.documents,
+            get_rendition_data=lambda document_id: self.renditions,
+            article_rendition_factory=article_rendition_factory_mock,
+        )
+
+        self.assertEqual(self.documents, orphans)


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request adiciona o suporte ao registro de manifestações de documentos na base do OPAC.

#### Onde a revisão poderia começar?
- `airflow/dags/kernel_changes.py` L `234`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente deve-se:
- Realize o espelhamento das bases title e issue;
- Inicie o pré sync de pacotes;
- Verifique se os documentos e suas manifestações foram cadastradas com sucesso;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#41 

### Referências
N/A

### Anexos
[rsp_v53_1.zip](https://github.com/scieloorg/opac-airflow/files/3605629/rsp_v53_1.zip)
