### PR TITLE
Altera GeraPadrao p/ iniciar o Kernel Gate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM scieloorg/airflow:1.10.4
 
 ARG AIRFLOW_HOME=/usr/local/airflow
+ARG PROC_DIR=/usr/local/proc
 
 # Custom Airflow
 COPY --chown=airflow:airflow ./airflow ${AIRFLOW_HOME}
+COPY --chown=airflow:airflow ./proc ${PROC_DIR}
 
 USER root
+RUN chmod +x ${PROC_DIR}/*
+
 RUN apk add --no-cache --virtual .build-deps \
         make gcc g++ libstdc++ libxml2-dev libxslt-dev \
-    && apk add libxml2 libxslt \
+    && apk add libxml2 libxslt curl \
     && pip install --no-cache-dir https://git@github.com/scieloorg/opac_schema/archive/v2.52.tar.gz \
     && pip install --no-cache-dir xylose==1.35.1 \
     && pip install --no-cache-dir 'deepdiff[murmur]' \

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ contento:
 * Python 3.7+
 * Apache Airflow
 * git+https://git@github.com/scieloorg/opac_schema@v2.52#egg=opac_schema
+* curl
 
 ## Implantação local
 

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -1,0 +1,16 @@
+export PATH=$PATH:.
+export TABS=tabs
+rem Este arquivo ?uma chamada para o 
+rem GeraScielo.bat com par?etros STANDARD
+
+clear
+echo === ATENCAO ===
+echo 
+echo Este arquivo executara os seguintes comandos
+echo InitKernelGate.bat
+echo GeraScielo.bat .. /scielo/web log/GeraPadrao.log adiciona
+echo 
+echo Tecle CONTROL-C para sair ou ENTER para continuar...
+
+InitKernelGate.bat
+GeraScielo.bat .. .. log/GeraPadrao.log adiciona

--- a/proc/InitKernelGate.bat
+++ b/proc/InitKernelGate.bat
@@ -1,0 +1,32 @@
+rem Inicia o Kernel Gate
+rem Verifica e Instala o Curl
+rem Faz uma requisição HTTP para o opac-airflow
+
+
+echo "Inicializando InitKernelGate: Sincronizacao com o Kernel..."
+
+export DAGID='kernel-gate'
+export AIRFLOW_HOST=http://0.0.0.0:8080
+export AIRFLOW_API=$AIRFLOW_HOST/api/experimental/dags/$DAGID/dag_runs
+
+echo "Executando InitKernelGate..."
+
+if [ ! -x "$(command -v curl)" ]
+then
+    echo '"curl" e uma dependencia do comando InitKernelGate'
+    echo
+    echo Não foi encontrada curl instalado. Instale curl e tente novamente.
+    echo
+    echo Tecle CONTROL-C para sair ou ENTER para continuar...
+    while [ true ] ; do
+        read -t 10 -n 1
+        if [ $? = 0 ] ; then
+            exit ;
+        else
+            echo "Aguardando tecla para sair"
+        fi
+    done
+else
+    echo Acessando a URL $AIRFLOW_API para iniciar sincronizacao com o Kernel
+    curl -XPOST "$AIRFLOW_API" -H 'Cache-Control: no-cache' -H 'Content-Type: application/json' -d '{}'
+fi


### PR DESCRIPTION
#### O que esse PR faz?
O `GeraPadrao` passa a chamar o script `InitKernelGate`, responsável por executar requisição HTTP para iniciar a DAG `kernel-gate` no OPAC-Airflow. Tanto este `GeraPadrao` como o `InitKernelGate` devem ser atualizados/copiados para o diretório `proc` do servidor onde ele é executado.

#### Onde a revisão poderia começar?
Em `proc/GeraPadrao.bat`, que foi copiado do projeto https://github.com/scieloorg/Web

#### Como este poderia ser testado manualmente?
- Configurar variável `AIRFLOW_HOST` no script `InitKernelGate.bat` com o servidor do opac-airflow
- No Docker container, executar o script `/usr/local/proc/GeraPadrao.bat`
- Verificar se o script `InitKernelGate.bat` é executado
- Verificar se a DAG é executada no opac-airflow

#### Algum cenário de contexto que queira dar?
Nenhum.

### Screenshots
N/A.

#### Quais são tickets relevantes?
scieloorg/gera-padrao/issues/1

### Referências
Nenhuma.
