### PR TITLE
Adiciona a capacidade de utilizar o postgres como banco de dados.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 
 services:
 - docker
-- postgresql
 
 before_install:
 - pip install docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 
 services:
 - docker
+- postgresql
 
 before_install:
 - pip install docker-compose

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 before_install:
 - pip install docker-compose
 - docker --version
+- sudo service postgresql stop
 
 script:
 - make travis_compose_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,10 @@ RUN apk add --no-cache --virtual .build-deps \
     && pip install --no-cache-dir lxml==4.3.4 \
     && apk --purge del .build-deps
 
+COPY ./entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
 USER airflow
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN chmod +x /start_airflow.sh
 
 USER airflow
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ RUN apk add --no-cache --virtual .build-deps \
     && apk --purge del .build-deps
 
 COPY ./entrypoint.sh /entrypoint.sh
+COPY ./start_airflow.sh /start_airflow.sh
 
 RUN chmod +x /entrypoint.sh
+RUN chmod +x /start_airflow.sh
 
 USER airflow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,10 @@ RUN chmod +x ${PROC_DIR}/*
 
 RUN apk add --no-cache --virtual .build-deps \
         make gcc g++ libstdc++ libxml2-dev libxslt-dev \
-    && apk add libxml2 libxslt curl \
+    && apk add libxml2 libxslt curl postgresql-dev \
     && pip install --no-cache-dir https://git@github.com/scieloorg/opac_schema/archive/v2.52.tar.gz \
     && pip install --no-cache-dir xylose==1.35.1 \
+    && pip install --no-cache-dir psycopg2-binary \
     && pip install --no-cache-dir 'deepdiff[murmur]' \
     && pip install --no-cache-dir lxml==4.3.4 \
     && apk --purge del .build-deps

--- a/airflow/airflow.cfg
+++ b/airflow/airflow.cfg
@@ -50,7 +50,7 @@ executor = SequentialExecutor
 # The SqlAlchemy connection string to the metadata database.
 # SqlAlchemy supports many different database engine, more information
 # their website
-sql_alchemy_conn = sqlite:////usr/local/airflow/airflow.db
+sql_alchemy_conn = postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
 
 # The encoding for the databases
 sql_engine_encoding = utf-8

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -41,6 +41,7 @@ services:
         environment:
           - POSTGRES_USER=postgres_user
           - POSTGRES_PASSWORD=postgres_pass
+          - POSTGRES_DB=opac_airflow
         volumes:
           - ./data_dev/pg_data:/var/lib/postgresql/data
         ports:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,7 @@ services:
         build: ./
         ports:
           - "8080:8080"
-        command: airflow webserver
+        command: /start_airflow.sh
         volumes:
             - ./airflow:/usr/local/airflow
             - ./data:/usr/local/airflow/data

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -31,7 +31,7 @@ services:
           - POSTGRES_PORT=5432
           - POSTGRES_DB=opac_airflow
         links:
-            - postgres
+            - postgres:postgres
 
     postgres:
         image: postgres:9.6-alpine

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -32,6 +32,8 @@ services:
           - POSTGRES_DB=opac_airflow
         links:
             - postgres:postgres
+        depends_on:
+            - postgres
 
     postgres:
         image: postgres:9.6-alpine

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -12,7 +12,7 @@ services:
         build: ./
         ports:
           - "8080:8080"
-        command: webserver
+        command: airflow webserver
         volumes:
             - ./airflow:/usr/local/airflow
             - ./data:/usr/local/airflow/data

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -25,3 +25,28 @@ services:
           - AIRFLOW__SMTP__SMTP_MAIL_FROM=${AIRFLOW__SMTP__SMTP_MAIL_FROM}
           - AIRFLOW__SMTP__SMTP_SSL=${AIRFLOW__SMTP__SMTP_SSL}
           - AIRFLOW__SMTP__SMTP_PORT=${AIRFLOW__SMTP__SMTP_PORT}
+          - POSTGRES_USER=postgres_user
+          - POSTGRES_PASSWORD=postgres_pass
+          - POSTGRES_HOST=postgres
+          - POSTGRES_PORT=5432
+          - POSTGRES_DB=opac_airflow
+        links:
+            - postgres
+
+    postgres:
+        image: postgres:9.6-alpine
+        restart: always
+        environment:
+          - POSTGRES_USER=postgres_user
+          - POSTGRES_PASSWORD=postgres_pass
+        volumes:
+          - ./data_dev/pg_data:/var/lib/postgresql/data
+        ports:
+          - "5432:5432"
+
+    adminer:
+        image: adminer
+        restart: always
+        ports:
+          - 8081:8080
+

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -15,7 +15,7 @@ services:
         command: /start_airflow.sh
         volumes:
             - ./airflow:/usr/local/airflow
-            - ./data:/usr/local/airflow/data
+            - ./data_dev:/usr/local/airflow/data_dev
         environment:
           - AIRFLOW_HOME=/usr/local/airflow
           - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org
@@ -43,7 +43,7 @@ services:
           - POSTGRES_PASSWORD=postgres_pass
           - POSTGRES_DB=opac_airflow
         volumes:
-          - ./data_dev/pg_data:/var/lib/postgresql/data
+          - ./data_dev/pg_data:/var/lib/postgresql/data_dev
         ports:
           - "5432:5432"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,6 @@ services:
           - POSTGRES_PASSWORD=postgres_pass
           - POSTGRES_DB=opac_airflow
         volumes:
-          - ./data_dev/pg_data:/var/lib/postgresql/data
+          - ./data/pg_data:/var/lib/postgresql/data
         ports:
           - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         build: ./
         ports:
           - "8080:8080"
-        command: webserver
+        command: airflow webserver
         environment:
           - AIRFLOW_HOME=/usr/local/airflow
           - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
           - POSTGRES_DB=opac_airflow
         links:
             - postgres:postgres
+        depends_on:
+            - postgres
 
     postgres:
         image: postgres:9.6-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         build: ./
         ports:
           - "8080:8080"
-        command: airflow webserver
+        command: /start_airflow.sh
         environment:
           - AIRFLOW_HOME=/usr/local/airflow
           - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
           - POSTGRES_PORT=5432
           - POSTGRES_DB=opac_airflow
         links:
-            - postgres
+            - postgres:postgres
 
     postgres:
         image: postgres:9.6-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,4 +15,21 @@ services:
           - AIRFLOW__SMTP__SMTP_MAIL_FROM=${AIRFLOW__SMTP__SMTP_MAIL_FROM}
           - AIRFLOW__SMTP__SMTP_SSL=${AIRFLOW__SMTP__SMTP_SSL}
           - AIRFLOW__SMTP__SMTP_PORT=${AIRFLOW__SMTP__SMTP_PORT}
+          - POSTGRES_USER=postgres_user
+          - POSTGRES_PASSWORD=postgres_pass
+          - POSTGRES_HOST=postgres
+          - POSTGRES_PORT=5432
+          - POSTGRES_DB=opac_airflow
+        links:
+            - postgres
 
+    postgres:
+        image: postgres:9.6-alpine
+        restart: always
+        environment:
+          - POSTGRES_USER=postgres_user
+          - POSTGRES_PASSWORD=postgres_pass
+        volumes:
+          - ./data_dev/pg_data:/var/lib/postgresql/data
+        ports:
+          - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
         environment:
           - POSTGRES_USER=postgres_user
           - POSTGRES_PASSWORD=postgres_pass
+          - POSTGRES_DB=opac_airflow
         volumes:
           - ./data_dev/pg_data:/var/lib/postgresql/data
         ports:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+cmd="$@"
+
+if [ -z "$POSTGRES_USER" ]; then
+    export POSTGRES_USER=postgres_user
+fi
+
+export AIRFLOW__CORE__SQL_ALCHEMY_CONN=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:$POSTGRES_PORT/$POSTGRES_DB
+
+function postgres_ready(){
+python << END
+import sys
+import psycopg2
+try:
+    conn = psycopg2.connect(dbname="$POSTGRES_DB", user="$POSTGRES_USER", password="$POSTGRES_PASSWORD", host="$POSTGRES_HOST", port="$POSTGRES_PORT")
+except psycopg2.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+END
+}
+
+until postgres_ready; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+>&2 echo "Postgres is up - continuing..."
+exec $cmd

--- a/start_airflow.sh
+++ b/start_airflow.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 airflow initdb
-airflow scheduler
+airflow scheduler &
 airflow webserver

--- a/start_airflow.sh
+++ b/start_airflow.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+airflow initdb
+airflow scheduler
+airflow webserver


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona os ajustes necessários para utilizarmos o **Postgres** como banco de dados. 

#### Onde a revisão poderia começar?

Para revisar esse PR é necessário verificar os seguintes arquivos:

 * Dockerfile
 * ariflow.cfg
 * docker-compose-dev.yml
 * docker-compose.yml

#### Como este poderia ser testado manualmente?

Para realizar o teste é necessário reconstruir a imagem do docker, seguindo os seguintes passos:

```docker-compose -f docker-compose-dev.yml build``` 
```docker-compose -f docker-compose-dev.yml up -d```

Acessar o admin do airflow: http://localhost:8080

Seguir os mesmos comandos para o arquivo ```docker-compose.yml```

#### Algum cenário de contexto que queira dar?

No arquivo de docker-compose-dev.yml, foi adicionado o adminer uma interface web para visualizar banco de dados. 

Para ter acesso a esse interface: http://localhost:8081
