### PR TITLE
Adiciona campo htmls a sincronização com o OPAC

### DIFF
--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -225,6 +225,9 @@ def ArticleFactory(
 
     article.xml = document_xml_url
 
+    # Campo de compatibilidade do OPAC
+    article.htmls = [{"lang": lang} for lang in _get_languages(data)]
+
     return article
 
 

--- a/airflow/tests/test_kernel_changes.py
+++ b/airflow/tests/test_kernel_changes.py
@@ -208,6 +208,12 @@ class ArticleFactoryTests(unittest.TestCase):
     def test_has_xml_attribute(self):
         self.assertTrue(hasattr(self.document, "xml"))
 
+    def test_has_htmls_attribute(self):
+        self.assertTrue(hasattr(self.document, "htmls"))
+
+    def test_htmls_attibutes_should_be_populated_with_documents_languages(self):
+        self.assertEqual([{"lang": "en"}, {"lang": "pt"}], self.document.htmls)
+
 
 class RegisterDocumentTests(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request adiciona o campo `htmls` a sincronização dos artigos com o OPAC. O campo `htmls` é importante (por enquanto) para mantermos a compatibilidade entre a versão que hoje está em produção (scielo.br/scielosp) e a versão usada pra testes com o publishing framework.

#### Onde a revisão poderia começar?

- `airflow/dags/operations/kernel_changes_operations.py` L: `229`

#### Como este poderia ser testado manualmente?
Para testar este pull request deve-se:
- Realizar a sincronização da base ISIS;
- Realizar a sincronização de um pacote SPS [anexo 1];
- Verificar o acesso aos artigos e seus pdfs.


#### Algum cenário de contexto que queira dar?
O acesso ao artigo ou ao seu pdf pode não funcionar de acordo com a configuração das URLS do SSM (nosso minio/kernel). Precisei alterar alguns trechos de código no arquivo `views.py` do OPAC.

**Linha 1060**
```python
resource_ssm_full_url = resource_ssm_media_path 
```

**Linha 1144**:
```python
return get_content_from_ssm(pdf_url)
```
### Screenshots
<img width="644" alt="Screen Shot 2019-10-02 at 10 39 51" src="https://user-images.githubusercontent.com/4604104/66049089-203b5c80-e501-11e9-9a80-ba262dffa2fb.png">


#### Quais são tickets relevantes?
#103 

### Referências
N/A