### PR TITLE
Corrige pequenos bugs na sincronização entre o Kernel e o Website

### DIFF
--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -281,11 +281,13 @@ def try_register_documents(
                 document_xml_url,
             )
             document.save()
-        except (models.Issue.DoesNotExist, ValueError):
+        except models.Issue.DoesNotExist:
             orphans.append(document_id)
-            logging.info(
-                "Could not possible to register the document %s. "
-                "Probably the issue that is related to it does not exist." % document_id
+            logging.error(
+                "Could not register document %s. "
+                "Issue '%s' can't be found in the website database.",
+                document_id,
+                issue_id,
             )
 
     return list(set(orphans))
@@ -354,8 +356,8 @@ def try_register_documents_renditions(
             article.save()
         except models.Article.DoesNotExist:
             logging.info(
-                'Could not possible save rendition for document, probably '
-                'document %s isn\'t in OPAC database.' % document
+                "Could not possible save rendition for document, probably "
+                "document %s isn't in OPAC database." % document
             )
             orphans.append(document)
 

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -59,8 +59,8 @@ def ArticleFactory(
     article.abstract = _nestget(data, "article_meta", 0, "abstract", 0)
 
     # Identificadores
-    article._id = _nestget(data, "article_meta", 0, "article_publisher_id", 0)
-    article.aid = _nestget(data, "article_meta", 0, "article_publisher_id", 0)
+    article._id = document_id
+    article.aid = document_id
     article.pid = _nestget(data, "article_meta", 0, "article_publisher_id", 1)
     article.doi = _nestget(data, "article_meta", 0, "article_doi", 0)
 

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -50,6 +50,9 @@ def ArticleFactory(
 
     try:
         article = models.Article.objects.get(_id=document_id)
+
+        if issue_id is None:
+            issue_id = article.issue._id
     except models.Article.DoesNotExist:
         article = models.Article()
 

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -355,9 +355,10 @@ def try_register_documents_renditions(
             article = article_rendition_factory(document, data)
             article.save()
         except models.Article.DoesNotExist:
-            logging.info(
-                "Could not possible save rendition for document, probably "
-                "document %s isn't in OPAC database." % document
+            logging.error(
+                "Could not save renditions for document '%s' because "
+                "it does not exist in website database.",
+                document,
             )
             orphans.append(document)
 

--- a/airflow/dags/operations/kernel_changes_operations.py
+++ b/airflow/dags/operations/kernel_changes_operations.py
@@ -215,10 +215,9 @@ def ArticleFactory(
     article.lpage = _nestget(data, "article_meta", 0, "pub_lpage", 0)
 
     # Issue vinculada
-    if issue_id:
-        issue = models.Issue.objects.get(_id=issue_id)
-        article.issue = issue
-        article.journal = issue.journal
+    issue = models.Issue.objects.get(_id=issue_id)
+    article.issue = issue
+    article.journal = issue.journal
 
     if document_order:
         article.order = int(document_order)

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -76,7 +76,7 @@ def link_documents_to_documentsbundle(dag_run, **kwargs):
     documents = kwargs["ti"].xcom_pull(key="documents", task_ids="register_update_docs_id")
     issn_index_json_path = kwargs["ti"].xcom_pull(
         task_ids="process_journals_task",
-        dag_id="kernel-gate",
+        dag_id="sync_isis_to_kernel",
         key="issn_index_json_path",
         include_prior_dates=True
     )

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -559,7 +559,7 @@ def register_documents(**kwargs):
                 if document_id == item["id"]:
                     return (issue_id, item)
 
-        return ()
+        return (None, {})
 
     def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
         """Recupera a lista de todos os documentos que estão relacionados com

--- a/airflow/tests/test_kernel_changes.py
+++ b/airflow/tests/test_kernel_changes.py
@@ -282,20 +282,6 @@ class RegisterDocumentTests(unittest.TestCase):
             "http://kernel_url/documents/67TH7T7CyPPmgtVrGXhWXVs",
         )
 
-    def test_try_register_document_should_be_orphan_when_issue_was_not_found(self):
-        article_factory_mock = MagicMock()
-
-        orphans = try_register_documents(
-            documents=self.documents,
-            get_relation_data=lambda document_id: (),
-            fetch_document_front=lambda document_id: self.document_front,
-            article_factory=article_factory_mock,
-        )
-
-        self.assertEqual(1, len(orphans))
-        self.assertEqual(["67TH7T7CyPPmgtVrGXhWXVs"], orphans)
-
-
 class ArticleRenditionFactoryTests(unittest.TestCase):
     def setUp(self):
         self.article_objects = patch(

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -228,7 +228,7 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
 
         kwargs["ti"].xcom_pull.assert_any_call(
             task_ids="process_journals_task",
-            dag_id="kernel-gate",
+            dag_id="sync_isis_to_kernel",
             key="issn_index_json_path",
             include_prior_dates=True
         )

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -7,10 +7,10 @@ clear
 echo === ATENCAO ===
 echo 
 echo Este arquivo executara os seguintes comandos
-echo InitKernelGate.bat
+echo SyncIsisToKernel.bat
 echo GeraScielo.bat .. /scielo/web log/GeraPadrao.log adiciona
 echo 
 echo Tecle CONTROL-C para sair ou ENTER para continuar...
 
-InitKernelGate.bat
+SyncIsisToKernel.bat
 GeraScielo.bat .. .. log/GeraPadrao.log adiciona

--- a/proc/SyncIsisToKernel.bat
+++ b/proc/SyncIsisToKernel.bat
@@ -3,17 +3,17 @@ rem Verifica e Instala o Curl
 rem Faz uma requisição HTTP para o opac-airflow
 
 
-echo "Inicializando InitKernelGate: Sincronizacao com o Kernel..."
+echo "Inicializando: Sincronizacao com o Kernel..."
 
-export DAGID='kernel-gate'
+export DAGID='sync_isis_to_kernel'
 export AIRFLOW_HOST=http://0.0.0.0:8080
 export AIRFLOW_API=$AIRFLOW_HOST/api/experimental/dags/$DAGID/dag_runs
 
-echo "Executando InitKernelGate..."
+echo "Executando SyncIsisToKernel..."
 
 if [ ! -x "$(command -v curl)" ]
 then
-    echo '"curl" e uma dependencia do comando InitKernelGate'
+    echo '"curl" e uma dependencia do comando SyncIsisToKernel'
     echo
     echo Não foi encontrada curl instalado. Instale curl e tente novamente.
     echo


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request corrige erros gerais detectados no processamento de testes no dia 17/10/2019. Inicialmente a solução foi concentrada na utilização do `scielo-id` de forma correta durante a sincronização do `kernel` com a base do `website`, a estratégia adotada anteriormente utilizava do campo `article_publisher_id` retornado pelo `/front` da API para capturar  o `scielo-id` dos documentos processados e isso se provou extremamente errado uma vez que nós não temos a garantia que este campo retornará o `scielo-id` do documento.

O PR escalou para consertar problemas de sincronização de documentos nas situações de atualização sem registros de mudanças dos `bundles` relacionados com os documentos (passos detalhados no commit 321e276. Também foram feitas melhorias nas mensagens de erro apresentadas pelo log do Airflow.

#### Onde a revisão poderia começar?

Recomendo fortemente que a revisão seja feita a partir dos commits (do mais antigo para o mais novo).

#### Como este poderia ser testado manualmente?
Para testar este pull request manualnente deve-se:

- Rode todas as sincronizações (isis, kernel, documents, website) ;
- Modifique um XML;
- Rode as sincronizações de documentos e website;
- Verifique no website que o documento foi atualizado;
- Verifique nas variáveis do airflow que o documento não está órfão.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A