### PR TITLE
Adiciona a capacidade de identificar os ahead of print no momento de cadastro dos fasciculos

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -524,7 +524,7 @@ def register_issues(ds, **kwargs):
     def _aop_id(issue_id):
         """Obtém o identificador do ahead of print do periódico.
         """
-        return known_issues.get(_journal_id(issue_id), {})['aop']
+        return known_issues.get(_journal_id(issue_id), {}).get('aop', '')
 
     issues_to_get = itertools.chain(
         Variable.get("orphan_issues", default_var=[], deserialize_json=True),


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR tem com objetivo obter os aheads of prints do Kernel e cadastra-los no site

#### Onde a revisão poderia começar?
Indique o caminho do arquivo e o arquivo onde o revisor deve iniciar a leitura do código.

#### Como este poderia ser testado manualmente?
 
Para que seja testado manualmente é necessário que esteja funcionando os seguinte sistemas: opac, opac-airflow e kernel.

Para realizar um cadastro de conteúdo mínino segue: 

Cadastro de um Periódico: 

```shell

curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX -d '{"_id": "0044-5967", "id": "0044-5967", "created": "2019-10-23T17:31:27.442021Z", "updated": "2019-10-23T17:40:12.532839Z", "title": "Acta Amazonica", "mission": [{"language": "es", "value": "Publicar trabajos cient\u00edficos originales sobre Amazonia. "}, {"language": "pt", "value": "Publicar trabalhos cient\u00edficos originais sobre a Amaz\u00f4nia."}, {"language": "en", "value": "To publish original scientific papers about Amazonia"}], "title_iso": "Acta Amaz", "short_title": "Acta Amaz.", "acronym": "aa", "scielo_issn": "0044-5967", "print_issn": "0044-5967", "electronic_issn": "1809-4392", "status": {"status": "current"}, "subject_areas": ["Agricultural Sciences", "Biological Sciences", "Exact and Earth Sciences", "Health Sciences"], "sponsors": [{"name": "Instituto Nacional de Pesquisas da Amaz\u00f4nia"}], "subject_categories": ["AGRONOMY", "BIOLOGY", "ZOOLOGY"], "online_submission_url": "http://mc04.manuscriptcentral.com/aa-scielo", "contact": {"email": "acta@inpa.gov.br", "address": "Av. Andr\u00e9 Araujo, 2936 Aleixo, 69060-001 Manaus AM Brasil, Tel.: +55 92 3643-3030, Fax: +55 92 643-3223"}}'
```

Cadastro de dois fasciculo um regular e outro que será um AOP: 

```shell 
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n0 -d '{"publication_year": "2019"}' -v

curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/bundles/0066-782X-1999-v72-n1 -d '{"publication_year": "2004", "volume": "67", "number": "3", "publication_months": {"range": [5, 6]}}' -v
```

Cadastro de relacionamento entre o periódico e os bundles: 

```shell
curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/issues -d '[{"id": "0066-782X-1999-v72-n0", "year": "2019", "order": "1"}]'

curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/issues -d '[{"id": "0066-782X-1999-v72-n1", "year": "2019", "order": "1"}]'
```

Cadastro de AOP para o periódico: 

```shell
curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/0066-782XX/aop -d '{"aop": "0066-782X-1999-v72-n0"}' -v
```

#### Algum cenário de contexto que queira dar?

Sim é importante que tenhamos em mente que esse PR não resolve o cadastro dos ahead of print no kernel, o tíquete relacionado com essa atividade é: https://github.com/scieloorg/opac-airflow/issues/123

### Screenshots

![Screenshot 2019-11-19 15 42 35](https://user-images.githubusercontent.com/373745/69177071-a168a600-0ae5-11ea-8ec6-639ad6610264.png)

![Screenshot 2019-11-19 14 38 54](https://user-images.githubusercontent.com/373745/69177079-a4639680-0ae5-11ea-8e18-b00f00f0bd44.png)


#### Quais são tickets relevantes?
O tíquete relacionado com esse PR é https://github.com/scieloorg/opac-airflow/issues/124

### Referências
N / A