### PR TITLE
Inclui tratamento de pacotes Ahead of Print no fluxo de sincronização de documentos

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -289,7 +289,7 @@ def get_or_create_bundle(bundle_id, is_aop):
     try:
         return hooks.kernel_connect("/bundles/" + bundle_id, "GET")
     except requests.exceptions.HTTPError as exc:
-        if exc.response.status_code == http.client.NOT_FOUND and is_aop:
+        if is_aop and exc.response.status_code == http.client.NOT_FOUND:
             create_aop_bundle(bundle_id)
             try:
                 return hooks.kernel_connect("/bundles/" + bundle_id, "GET")

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -244,10 +244,13 @@ def register_document_to_documentsbundle(bundle_id, payload):
         raise LinkDocumentToDocumentsBundleException(str(exc)) from None
 
 
-def issue_id(issn_id, year, volume=None, number=None, supplement=None):
+def get_bundle_id(issn_id, year, volume=None, number=None, supplement=None):
     """
         Gera Id utilizado na ferramenta de migração para cadastro do documentsbundle.
     """
+
+    if all(list(map(lambda x: x is None, [volume, number, supplement]))):
+        return issn_id + "-aop"
 
     labels = ["issn_id", "year", "volume", "number", "supplement"]
     values = [issn_id, year, volume, number, supplement]

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -73,6 +73,7 @@ def register_update_documents(dag_run, **kwargs):
 
 
 def link_documents_to_documentsbundle(dag_run, **kwargs):
+    _sps_package = dag_run.conf.get("sps_package")
     documents = kwargs["ti"].xcom_pull(key="documents", task_ids="register_update_docs_id")
     issn_index_json_path = kwargs["ti"].xcom_pull(
         task_ids="process_journals_task",
@@ -83,7 +84,7 @@ def link_documents_to_documentsbundle(dag_run, **kwargs):
 
     if documents:
         linked_bundle = sync_documents_to_kernel_operations.link_documents_to_documentsbundle(
-            documents, issn_index_json_path
+            _sps_package, documents, issn_index_json_path
         )
 
         if linked_bundle:

--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta
 from deepdiff import DeepDiff
 
 from common import hooks
-from operations.docs_utils import issue_id
+from operations.docs_utils import get_bundle_id
 
 """
 Para o devido entendimento desta DAG pode-se ter como base a seguinte explicação.
@@ -182,7 +182,7 @@ def issue_as_kernel(issue: dict) -> dict:
     issn_id = issue.data.get("issue").get("v35")[0]["_"]
     _creation_date = parse_date(issue.publication_date)
 
-    _payload["_id"] = issue_id(
+    _payload["_id"] = get_bundle_id(
         issn_id,
         str(_creation_date.year),
         issue.volume,

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -18,6 +18,7 @@ from operations.docs_utils import (
     put_assets_and_pdfs_in_object_store,
     put_xml_into_object_store,
     register_document_to_documentsbundle,
+    get_bundle_id,
     get_or_create_bundle,
     create_aop_bundle,
 )
@@ -785,6 +786,44 @@ class TestRegisterDocumentsToDocumentsBundle(TestCase):
         response = register_document_to_documentsbundle("0066-782X-1999-v72-n0", payload)
 
         self.assertEqual(response.status_code, 204)
+
+
+class TestGetBundleId(TestCase):
+    def test_returns_aop_bundle_id_if_no_volume_number_and_supplement(self):
+        self.assertEqual(
+            get_bundle_id("0101-0202", "2019"),
+            "0101-0202-aop"
+        )
+
+    def test_returns_issue_bundle_id_with_year_and_volume(self):
+        self.assertEqual(
+            get_bundle_id("0101-0202", "2019", "53"),
+            "0101-0202-2019-v53"
+        )
+
+    def test_returns_issue_bundle_id_with_year_and_supplement_volume(self):
+        self.assertEqual(
+            get_bundle_id("0101-0202", "2019", "53", supplement="1"),
+            "0101-0202-2019-v53-s1"
+        )
+
+    def test_returns_issue_bundle_id_with_year_volume_and_number(self):
+        self.assertEqual(
+            get_bundle_id("0101-0202", "2019", "53", number="2"),
+            "0101-0202-2019-v53-n2"
+        )
+
+    def test_returns_issue_bundle_id_with_year_volume_and_special_number(self):
+        self.assertEqual(
+            get_bundle_id("0101-0202", "2019", "53", number="spe3"),
+            "0101-0202-2019-v53-nspe3"
+        )
+
+    def test_returns_issue_bundle_id_with_year_volume_and_supplement_number(self):
+        self.assertEqual(
+            get_bundle_id("0101-0202", "2019", "53", number="3", supplement="1"),
+            "0101-0202-2019-v53-n3-s1"
+        )
 
 
 @patch("operations.docs_utils.hooks")

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -4,8 +4,9 @@ import tempfile
 import builtins
 import json
 from unittest import TestCase, main
-from unittest.mock import patch, Mock
+from unittest.mock import patch, Mock, MagicMock
 
+import requests
 from airflow import DAG
 
 from operations.sync_documents_to_kernel_operations import (
@@ -19,6 +20,7 @@ from operations.exceptions import (
     DocumentToDeleteException,
     PutXMLInObjectStoreException,
     RegisterUpdateDocIntoKernelException,
+    LinkDocumentToDocumentsBundleException
 )
 
 
@@ -552,31 +554,39 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
 
     def test_if_link_documents_to_documentsbundle_return_none_when_param_document_empty(self):
 
-        self.assertIsNone(link_documents_to_documentsbundle([], None), None)
+        self.assertIsNone(link_documents_to_documentsbundle(
+            "path_to_sps_package/package.zip", [], None),
+            None
+        )
 
     @patch.object(builtins, "open")
     @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
     @patch("operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle")
-    @patch("operations.sync_documents_to_kernel_operations.issue_id")
+    @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
     def test_link_documents_to_documentsbundle_logs_journal_issn_id_error(
-        self, mk_issue_id,  mk_regdocument, MockLogger, mk_open
+        self, mk_get_bundle_id,  mk_regdocument, mk_get_or_create_bundle, MockLogger, mk_open
     ):
-        mk_open.return_value.__enter__.return_value.read.return_value = "{}"
-        link_documents_to_documentsbundle(self.documents[:1], "/json/index.json")
+        mk_open.return_value.__enter__.return_value.read.return_value = '{}'
+        link_documents_to_documentsbundle(
+            "path_to_sps_package/package.zip", self.documents[:1], "/json/index.json"
+        )
         MockLogger.info.assert_any_call(
             'Could not get journal ISSN ID: ISSN id "%s" not found', "0034-8910"
         )
 
     @patch.object(builtins, "open")
-    @patch("operations.sync_documents_to_kernel_operations.kernel_connect")
+    @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
     @patch("operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle")
-    @patch("operations.sync_documents_to_kernel_operations.issue_id")
-    def test_link_documents_to_documentsbundle_calls_issue_id_with_issn_id(
-        self, mk_issue_id,  mk_regdocument, mk_kernel_connect, mk_open
+    @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
+    def test_link_documents_to_documentsbundle_calls_get_bundle_id_with_issn_id(
+        self, mk_get_bundle_id,  mk_regdocument, mk_get_or_create_bundle, mk_open
     ):
         mk_open.return_value.__enter__.return_value.read.return_value = '{"0034-8910": "0101-0101"}'
-        link_documents_to_documentsbundle(self.documents[:1], "/json/index.json")
-        mk_issue_id.assert_called_once_with(
+        link_documents_to_documentsbundle(
+            "path_to_sps_package/package.zip", self.documents[:1], "/json/index.json"
+        )
+        mk_get_bundle_id.assert_called_once_with(
             issn_id="0101-0101",
             year=self.documents[0]["year"],
             volume=self.documents[0].get("volume", None),
@@ -584,17 +594,17 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
             supplement=self.documents[0].get("supplement", None)
         )
 
-    @patch("operations.sync_documents_to_kernel_operations.kernel_connect")
+    @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
     @patch("operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle")
-    @patch("operations.sync_documents_to_kernel_operations.issue_id")
+    @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
     def test_if_link_documents_to_documentsbundle_register_on_document_store(
-        self, mk_issue_id,  mk_regdocument, mk_kernel_connect
+        self, mk_get_bundle_id,  mk_regdocument, mk_get_or_create_bundle
     ):
         mock_response = Mock(status_code=204)
 
         mk_regdocument.return_value = mock_response
 
-        mk_issue_id.side_effect = [
+        mk_get_bundle_id.side_effect = [
                                    '0034-8910-2014-v48-n2',
                                    '0034-8910-2014-v48-n2',
                                    '1518-8787-2014-v2-n2',
@@ -607,18 +617,22 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
                 index_file.write(self.issn_index_json)
 
             self.assertEqual(
-                link_documents_to_documentsbundle(self.documents, issn_index_json_path),
+                link_documents_to_documentsbundle(
+                    "path_to_sps_package/package.zip",
+                    self.documents,
+                    issn_index_json_path
+                ),
                 [
                     {'id': '0034-8910-2014-v48-n2', 'status': 204},
                     {'id': '1518-8787-2014-v2-n2', 'status': 204},
                     {'id': '1518-8787-2014-v2-n2-s1', 'status': 204}
                 ])
 
-    @patch("operations.sync_documents_to_kernel_operations.kernel_connect")
+    @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
     @patch("operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle")
-    @patch("operations.sync_documents_to_kernel_operations.issue_id")
+    @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
     def test_if_some_documents_are_not_register_on_document_store(
-        self, mk_issue_id,  mk_regdocument, mk_kernel_connect
+        self, mk_get_bundle_id,  mk_regdocument, mk_get_or_create_bundle
     ):
         mk_regdocument.side_effect = [
                                       Mock(status_code=204),
@@ -626,7 +640,7 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
                                       Mock(status_code=404)
                                       ]
 
-        mk_issue_id.side_effect = [
+        mk_get_bundle_id.side_effect = [
                                    '0034-8910-2014-v48-n2',
                                    '0034-8910-2014-v48-n2',
                                    '1518-8787-2014-v2-n2',
@@ -639,7 +653,11 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
                 index_file.write(self.issn_index_json)
 
             self.assertEqual(
-                link_documents_to_documentsbundle(self.documents, issn_index_json_path),
+                link_documents_to_documentsbundle(
+                    "path_to_sps_package/package.zip",
+                    self.documents,
+                    issn_index_json_path
+                ),
                 [
                     {'id': '0034-8910-2014-v48-n2', 'status': 204},
                     {'id': '1518-8787-2014-v2-n2', 'status': 422},
@@ -650,11 +668,11 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
     @patch(
         "operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle"
     )
-    @patch("operations.sync_documents_to_kernel_operations.kernel_connect")
-    @patch("operations.sync_documents_to_kernel_operations.issue_id")
+    @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
+    @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
     @patch.object(builtins, "open")
     def test_link_documents_to_documentsbundle_should_not_emit_an_update_call_if_the_payload_wont_change(
-        self, mk_open, mk_issue_id, mk_kernel_connect, mk_register_document_to_bundle
+        self, mk_open, mk_get_bundle_id, mk_get_or_create_bundle, mk_register_document_to_bundle
     ):
         new_document_to_link = self.documents[0]
         current_bundle_item_list = [
@@ -670,13 +688,15 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
         )
 
         # Bundle_id traduzido a partir do journal_issn_map
-        mk_issue_id.side_effect = ["0034-8910-2014-v48-n2"]
-        mk_kernel_connect.return_value.json.return_value.__getitem__.return_value = (
+        mk_get_bundle_id.side_effect = ["0034-8910-2014-v48-n2"]
+        mk_get_or_create_bundle.return_value.json.return_value.__getitem__.return_value = (
             current_bundle_item_list
         )
 
         link_documents_to_documentsbundle(
-            [new_document_to_link], "/some/random/json/path.json"
+            "path_to_sps_package/package.zip",
+            [new_document_to_link],
+            "/some/random/json/path.json"
         )
 
         # Não emita uma atualização do bundle se a nova lista for idêntica a atual
@@ -685,11 +705,11 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
     @patch(
         "operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle"
     )
-    @patch("operations.sync_documents_to_kernel_operations.kernel_connect")
-    @patch("operations.sync_documents_to_kernel_operations.issue_id")
+    @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
+    @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
     @patch.object(builtins, "open")
     def test_link_documents_to_documentsbundle_should_not_reset_item_list_when_new_documents_arrives(
-        self, mk_open, mk_issue_id, mk_kernel_connect, mk_register_document_to_bundle
+        self, mk_open, mk_get_bundle_id, mk_get_or_create_bundle, mk_register_document_to_bundle
     ):
         new_documents_to_link = self.documents[0:2]
         current_bundle_item_list = [
@@ -705,13 +725,15 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
         )
 
         # Bundle_id traduzido a partir do journal_issn_map
-        mk_issue_id.return_value = "0034-8910-2014-v48-n2"
-        mk_kernel_connect.return_value.json.return_value.__getitem__.return_value = (
+        mk_get_bundle_id.return_value = "0034-8910-2014-v48-n2"
+        mk_get_or_create_bundle.return_value.json.return_value.__getitem__.return_value = (
             current_bundle_item_list
         )
 
         link_documents_to_documentsbundle(
-            new_documents_to_link, "/some/random/json/path.json"
+            "path_to_sps_package/package.zip",
+            new_documents_to_link,
+            "/some/random/json/path.json"
         )
 
         # Lista produzida a partir dos documentos existes e dos novos
@@ -725,6 +747,88 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
 
         mk_register_document_to_bundle.assert_called_with(
             "0034-8910-2014-v48-n2", new_payload_list
+        )
+
+
+@patch("operations.sync_documents_to_kernel_operations.Logger")
+@patch(
+    "operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle"
+)
+@patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
+@patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
+class TestLinkDocumentToDocumentsbundleAOPs(TestCase):
+    def setUp(self):
+        self.documents = [
+            {
+                "scielo_id": "S0034-8910.2014048004923",
+                "issn": "0034-8910",
+                "order": "347",
+             },
+            {
+                "scielo_id": "S0034-8910.2014048004924",
+                "issn": "0034-8910",
+                "order": "348",
+             },
+            {
+                "scielo_id": "S0034-8910.20140078954641",
+                "issn": "1518-8787",
+                "order": "978",
+             },
+            {
+                "scielo_id": "S0034-8910.20140078954641",
+                "issn": "1518-8787",
+                "order": "979",
+             }
+        ]
+        self.issn_index_json = json.dumps({
+            "0034-8910": "0034-8910",
+            "1518-8787": "1518-8787",
+        })
+
+    @patch.object(builtins, "open")
+    def test_calls_get_or_create_bundle(
+        self,
+        mk_open,
+        mk_get_or_create_bundle,
+        mk_get_bundle_id,
+        mk_regdocument,
+        MockLogger
+    ):
+        mk_open.return_value.__enter__.return_value.read.return_value = (
+            '{"0034-8910": "0101-0101"}'
+        )
+        mk_get_bundle_id.return_value = "0101-0101-aop"
+        mk_get_or_create_bundle.return_value = MagicMock()
+        link_documents_to_documentsbundle(
+            "path_to_sps_package/2019nahead.zip", self.documents[:1], "/json/index.json"
+        )
+        mk_get_or_create_bundle.assert_called_with("0101-0101-aop", is_aop=True)
+
+    @patch.object(builtins, "open")
+    def test_get_or_create_bundle_raises_exception(
+        self,
+        mk_open,
+        mk_get_or_create_bundle,
+        mk_get_bundle_id,
+        mk_regdocument,
+        MockLogger
+    ):
+        def raise_exception(*args, **kwargs):
+            exc = LinkDocumentToDocumentsBundleException("Bundle not found")
+            exc.response = Mock(status_code=404)
+            raise exc
+
+        mk_open.return_value.__enter__.return_value.read.return_value = (
+            '{"0034-8910": "0101-0101"}'
+        )
+        mk_get_bundle_id.return_value = "0101-0101-aop"
+        mk_get_or_create_bundle.side_effect = raise_exception
+        result = link_documents_to_documentsbundle(
+            "path_to_sps_package/2019nahead.zip", self.documents[:1], "/json/index.json"
+        )
+        self.assertEqual(result, [{'id': '0101-0101-aop', 'status': 404}])
+        MockLogger.info.assert_called_with(
+            "Could not get bundle %: Bundle not found", "0101-0101-aop"
         )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR inclui o tratamento de pacotes Ahead of Print no fluxo de sincronização de documentos.

Na prática, a única diferença entre a sincronização de pacotes de fascículos regulares é que o bundle de Ahead of Print pode não existir no momento em que os documentos estão sendo incluídos no Kernel. Diferentemente dos fascículos regulares, que são espelhados para o Kernel antes da sincronização dos documentos, os bundles de AOP, caso não existam, precisam ser criados e vinculados ao periódico de publicação dos documentos antes do relacionamento dos documentos. Assim, é verificado se o pacote a ser sincronizado contém documentos AOP, verifica a existência do bundle de Ahead of Print e, caso não exista, trata de criá-lo adequadamente.

#### Onde a revisão poderia começar?
Em `airflow/dags/operations/sync_documents_to_kernel_operations.py`, onde a lógica do relacionamento do documento com o bundle foi alterada, e em `airflow/dags/operations/docs_utils.py`, onde é obtido ou criado o bundle de AOP.

#### Como este poderia ser testado manualmente?
- Coloque pacotes SPS para serem sincronizados no diretório de leitura, incluindo pacotes com Ahead of Prints
- Atualize a `scilista` com os pacotes a serem sincronizados
- Rodar as DAGs `sync_isis_to_kernel` e `pre_sync_documents_to_kernel`. Esta última executará a DAG `sync_documents_to_kernel`
- Todas as DAGs devem ser executadas com sucesso, os documentos devem ser criados no Kernel e vinculadas a um bundle de AOP, que também deve estar vinculado ao periódico

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#123

### Referências
Nenhuma
