### PR TITLE
Seta o scielo-id na versão v3 durante a sincronização de documentos

### DIFF
--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -322,7 +322,7 @@ class SPS_Package:
     def scielo_id(self):
         """The scielo id of the main document.
         """
-        return self.xmltree.findtext(".//article-id[@specific-use='scielo']")
+        return self.xmltree.findtext(".//article-id[@specific-use='scielo-v3']")
 
     @property
     def original_language(self):

--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -78,14 +78,6 @@ class SPS_Package:
     def acron(self):
         return self.xmltree.findtext('.//journal-id[@journal-id-type="publisher-id"]')
 
-    @property
-    def publisher_id(self):
-        try:
-            return self.xmltree.xpath(
-                './/article-id[not(@specific-use="scielo") and @pub-id-type="publisher-id"]/text()'
-            )[0]
-        except IndexError:
-            return None
 
     @property
     def journal_meta(self):

--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -319,7 +319,7 @@ class SPS_Package:
         return parse_date(self._match_pubdate(xpaths))
 
     @property
-    def scielo_id(self):
+    def scielo_pid_v3(self):
         """The scielo id of the main document.
         """
         return self.xmltree.findtext(".//article-id[@specific-use='scielo-v3']")

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -37,9 +37,9 @@ def document_to_delete(zipfile, sps_xml_file):
         raise DocumentToDeleteException(str(exc)) from None
     else:
         if metadata.is_document_deletion:
-            if metadata.scielo_id is None:
+            if metadata.scielo_pid_v3 is None:
                 raise DocumentToDeleteException("Missing element in XML")
-            return metadata.scielo_id
+            return metadata.scielo_pid_v3
 
 
 def register_update_doc_into_kernel(xml_data):
@@ -105,7 +105,7 @@ def get_xml_data(xml_content, xml_package_name):
             )
 
         _xml_data = {
-            "scielo_id": metadata.scielo_id,
+            "scielo_id": metadata.scielo_pid_v3,
             "issn": metadata.issn,
             "year": metadata.year,
             "order": metadata.order,

--- a/airflow/tests/fixtures/__init__.py
+++ b/airflow/tests/fixtures/__init__.py
@@ -9,7 +9,7 @@ XML_FILE_CONTENT = b"""<?xml version="1.0" encoding="UTF-8"?>
             <publisher><publisher-name>Sociedade Brasileira de Anestesiologia</publisher-name><publisher-loc>Campinas, SP, Brazil</publisher-loc></publisher>
         </journal-meta>
         <article-meta>
-            <article-id pub-id-type="publisher-id" specific-use="scielo">FX6F3cbyYmmwvtGmMB7WCgr</article-id>
+            <article-id pub-id-type="publisher-id" specific-use="scielo-v3">FX6F3cbyYmmwvtGmMB7WCgr</article-id>
             <pub-date pub-type="epub">
                 <day>31</day>
                 <month>01</month>

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -128,7 +128,7 @@ class TestDocumentsToDelete(TestCase):
         xml_file = etree.XML(XML_FILE_CONTENT)
         am_tag = xml_file.find(".//article-meta")
         am_tag.append(article_id)
-        scielo_id_tag = xml_file.find(".//article-id[@specific-use='scielo']")
+        scielo_id_tag = xml_file.find(".//article-id[@specific-use='scielo-v3']")
         am_tag.remove(scielo_id_tag)
         deleted_xml_file = etree.tostring(xml_file)
         MockZipFile = MagicMock()


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request altera a classe SPS_Package para detectar a versão correta (v3) do
scielo-id (no método `scielo_id`).

#### Onde a revisão poderia começar?
- `airflow/dags/common/sps_package.py` L: `85`
- `airflow/dags/common/sps_package.py` L:  `325`

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente deve-se:
- Baixar o pacote sps [1]; 
- Configurar a scilista para processar o pacote [1];
- Executar a dag de `pre_sync_documents_to_kernel`;
- Verificar que os documentos que possuem o `scielo-v3` foram cadastrados com sucesso;

#### Algum cenário de contexto que queira dar?
A partir deste ponto as dags que processam os documentos não entendem o `specific-use="scielo"` sendo assim os pacotes antigos gerados pelo `xc` ou `ds_migracao` não funcionarão.

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #130

### Referências
N/A

### Anexos
[[1] - 6935_rbpv_2019nahead.zip](https://github.com/scieloorg/opac-airflow/files/3893293/6935_rbpv_2019nahead.zip)