### PR TITLE
Garante que não seja cadastrado XMLs e asset sem scielo_id

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -13,7 +13,6 @@ from operations.exceptions import (
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
-    Pidv3Exception,
 )
 from common.sps_package import SPS_Package
 
@@ -221,12 +220,7 @@ def put_xml_into_object_store(zipfile, xml_filename):
                 xml_filename, zipfile, exc
             )
         ) from None
-
     xml_data = get_xml_data(xml_file, os.path.splitext(xml_filename)[-2])
-
-    if not xml_data.get("scielo_id"):
-        raise Pidv3Exception('Could not get scielo id v3') from None
-
     Logger.info('Putting XML file "%s" to Object Store', xml_filename)
     xml_data["xml_url"] = put_object_in_object_store(
         xml_file, xml_data["issn"], xml_data["scielo_id"], xml_filename

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -13,6 +13,7 @@ from operations.exceptions import (
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
+    Pidv3Exception,
 )
 from common.sps_package import SPS_Package
 
@@ -220,7 +221,12 @@ def put_xml_into_object_store(zipfile, xml_filename):
                 xml_filename, zipfile, exc
             )
         ) from None
+
     xml_data = get_xml_data(xml_file, os.path.splitext(xml_filename)[-2])
+
+    if not xml_data.get("scielo_id"):
+        raise Pidv3Exception('Could not get scielo id v3') from None
+
     Logger.info('Putting XML file "%s" to Object Store', xml_filename)
     xml_data["xml_url"] = put_object_in_object_store(
         xml_file, xml_data["issn"], xml_data["scielo_id"], xml_filename

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -14,6 +14,7 @@ from operations.exceptions import (
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
+    Pidv3Exception,
 )
 from common.sps_package import SPS_Package
 
@@ -221,7 +222,12 @@ def put_xml_into_object_store(zipfile, xml_filename):
                 xml_filename, zipfile, exc
             )
         ) from None
+
     xml_data = get_xml_data(xml_file, os.path.splitext(xml_filename)[-2])
+
+    if not xml_data.get("scielo_id"):
+        raise Pidv3Exception('Could not get scielo id v3') from None
+
     Logger.info('Putting XML file "%s" to Object Store', xml_filename)
     xml_data["xml_url"] = put_object_in_object_store(
         xml_file, xml_data["issn"], xml_data["scielo_id"], xml_filename

--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -14,10 +14,6 @@ class ObjectStoreError(Exception):
     ...
 
 
-class Pidv3Exception(Exception):
-    ...
-
-
 class RegisterUpdateDocIntoKernelException(Exception):
     ...
 

--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -14,6 +14,10 @@ class ObjectStoreError(Exception):
     ...
 
 
+class Pidv3Exception(Exception):
+    ...
+
+
 class RegisterUpdateDocIntoKernelException(Exception):
     ...
 

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -14,6 +14,7 @@ from operations.exceptions import (
     PutXMLInObjectStoreException,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
+    Pidv3Exception,
 )
 
 from operations.docs_utils import (
@@ -102,6 +103,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
     Registra/atualiza documentos informados e seus respectivos ativos digitais e
     renditions no Minio e no Kernel.
      list docs_to_preserve: lista de XMLs para manter no Kernel (Registrar ou atualizar)
+     Não deve cadastrar documentos que não tenha ``scielo-id``
     """
     Logger.debug("register_update_documents IN")
     with ZipFile(sps_package) as zipfile:
@@ -116,8 +118,8 @@ def register_update_documents(sps_package, xmls_to_preserve):
             )
             try:
                 xml_data = put_xml_into_object_store(zipfile, xml_filename)
-            except PutXMLInObjectStoreException as exc:
-                Logger.info(
+            except (PutXMLInObjectStoreException, Pidv3Exception) as exc:
+                Logger.error(
                     'Could not put document "%s" in object store: %s',
                     xml_filename,
                     str(exc),
@@ -130,7 +132,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
                     register_update_doc_into_kernel(_document_metadata)
 
                 except RegisterUpdateDocIntoKernelException as exc:
-                    Logger.info(
+                    Logger.error(
                         'Could not register or update document "%s" in Kernel: %s',
                         xml_filename,
                         str(exc),
@@ -141,7 +143,6 @@ def register_update_documents(sps_package, xmls_to_preserve):
     Logger.debug("register_update_documents OUT")
 
     return synchronized_docs_metadata
-
 
 def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_path):
     """

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -14,6 +14,7 @@ from operations.exceptions import (
     PutXMLInObjectStoreException,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
+    Pidv3Exception,
 )
 
 from operations.docs_utils import (
@@ -101,6 +102,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
     Registra/atualiza documentos informados e seus respectivos ativos digitais e
     renditions no Minio e no Kernel.
      list docs_to_preserve: lista de XMLs para manter no Kernel (Registrar ou atualizar)
+     Não deve cadastrar documentos que não tenha ``scielo-id``
     """
     Logger.debug("register_update_documents IN")
     with ZipFile(sps_package) as zipfile:
@@ -115,8 +117,8 @@ def register_update_documents(sps_package, xmls_to_preserve):
             )
             try:
                 xml_data = put_xml_into_object_store(zipfile, xml_filename)
-            except PutXMLInObjectStoreException as exc:
-                Logger.info(
+            except (PutXMLInObjectStoreException, Pidv3Exception) as exc:
+                Logger.error(
                     'Could not put document "%s" in object store: %s',
                     xml_filename,
                     str(exc),
@@ -129,7 +131,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
                     register_update_doc_into_kernel(_document_metadata)
 
                 except RegisterUpdateDocIntoKernelException as exc:
-                    Logger.info(
+                    Logger.error(
                         'Could not register or update document "%s" in Kernel: %s',
                         xml_filename,
                         str(exc),

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -14,7 +14,6 @@ from operations.exceptions import (
     PutXMLInObjectStoreException,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
-    Pidv3Exception,
 )
 
 from operations.docs_utils import (
@@ -102,7 +101,6 @@ def register_update_documents(sps_package, xmls_to_preserve):
     Registra/atualiza documentos informados e seus respectivos ativos digitais e
     renditions no Minio e no Kernel.
      list docs_to_preserve: lista de XMLs para manter no Kernel (Registrar ou atualizar)
-     Não deve cadastrar documentos que não tenha ``scielo-id``
     """
     Logger.debug("register_update_documents IN")
     with ZipFile(sps_package) as zipfile:
@@ -117,8 +115,8 @@ def register_update_documents(sps_package, xmls_to_preserve):
             )
             try:
                 xml_data = put_xml_into_object_store(zipfile, xml_filename)
-            except (PutXMLInObjectStoreException, Pidv3Exception) as exc:
-                Logger.error(
+            except PutXMLInObjectStoreException as exc:
+                Logger.info(
                     'Could not put document "%s" in object store: %s',
                     xml_filename,
                     str(exc),
@@ -131,7 +129,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
                     register_update_doc_into_kernel(_document_metadata)
 
                 except RegisterUpdateDocIntoKernelException as exc:
-                    Logger.error(
+                    Logger.info(
                         'Could not register or update document "%s" in Kernel: %s',
                         xml_filename,
                         str(exc),

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -25,6 +25,7 @@ from operations.exceptions import (
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
+    Pidv3Exception,
 )
 
 from tests.fixtures import XML_FILE_CONTENT
@@ -679,6 +680,25 @@ class TestPutXMLIntoObjectStore(TestCase):
             str(exc_info.exception),
             'Could not read file "1806-907X-rba-53-01-1-8.xml" from zipfile "MockZipFile": '
             "'File not found in the archive'",
+        )
+
+    @patch("operations.docs_utils.put_object_in_object_store")
+    @patch("operations.docs_utils.get_xml_data")
+    def test_put_xml_into_object_store_error_if_empty_scielo_id(
+        self, mk_get_xml_data, mk_put_object_in_object_store
+    ):
+        xml = self.xml_data
+        del(xml['scielo_id'])
+
+        MockZipFile = Mock()
+        MockZipFile.read.return_value = b""
+        mk_get_xml_data.return_value = xml
+
+        with self.assertRaises(Pidv3Exception) as exc_info:
+            put_xml_into_object_store(MockZipFile, "1806-907X-rba-53-01-1-8.xml")
+        self.assertEqual(
+            str(exc_info.exception),
+            'Could not get scielo id v3',
         )
 
     @patch("operations.docs_utils.put_object_in_object_store")

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -29,6 +29,7 @@ from operations.exceptions import (
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
+    Pidv3Exception,
 )
 
 from tests.fixtures import XML_FILE_CONTENT

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -25,7 +25,6 @@ from operations.exceptions import (
     ObjectStoreError,
     RegisterUpdateDocIntoKernelException,
     LinkDocumentToDocumentsBundleException,
-    Pidv3Exception,
 )
 
 from tests.fixtures import XML_FILE_CONTENT

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -684,25 +684,6 @@ class TestPutXMLIntoObjectStore(TestCase):
 
     @patch("operations.docs_utils.put_object_in_object_store")
     @patch("operations.docs_utils.get_xml_data")
-    def test_put_xml_into_object_store_error_if_empty_scielo_id(
-        self, mk_get_xml_data, mk_put_object_in_object_store
-    ):
-        xml = self.xml_data
-        del(xml['scielo_id'])
-
-        MockZipFile = Mock()
-        MockZipFile.read.return_value = b""
-        mk_get_xml_data.return_value = xml
-
-        with self.assertRaises(Pidv3Exception) as exc_info:
-            put_xml_into_object_store(MockZipFile, "1806-907X-rba-53-01-1-8.xml")
-        self.assertEqual(
-            str(exc_info.exception),
-            'Could not get scielo id v3',
-        )
-
-    @patch("operations.docs_utils.put_object_in_object_store")
-    @patch("operations.docs_utils.get_xml_data")
     def test_put_xml_into_object_store_puts_xml_in_object_store(
         self, mk_get_xml_data, mk_put_object_in_object_store
     ):
@@ -732,6 +713,25 @@ class TestPutXMLIntoObjectStore(TestCase):
         result = put_xml_into_object_store(MockZipFile, "1806-907X-rba-53-01-1-8.xml")
         self.assertEqual(
             "http://minio/documentstore/1806-907X-rba-53-01-1-8.xml", result["xml_url"]
+        )
+
+    @patch("operations.docs_utils.put_object_in_object_store")
+    @patch("operations.docs_utils.get_xml_data")
+    def test_put_xml_into_object_store_error_if_empty_scielo_id(
+        self, mk_get_xml_data, mk_put_object_in_object_store
+    ):
+        xml = self.xml_data
+        del(xml['scielo_id'])
+
+        MockZipFile = Mock()
+        MockZipFile.read.return_value = b""
+        mk_get_xml_data.return_value = xml
+
+        with self.assertRaises(Pidv3Exception) as exc_info:
+            put_xml_into_object_store(MockZipFile, "1806-907X-rba-53-01-1-8.xml")
+        self.assertEqual(
+            str(exc_info.exception),
+            'Could not get scielo id v3',
         )
 
 

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -20,7 +20,8 @@ from operations.exceptions import (
     DocumentToDeleteException,
     PutXMLInObjectStoreException,
     RegisterUpdateDocIntoKernelException,
-    LinkDocumentToDocumentsBundleException
+    LinkDocumentToDocumentsBundleException,
+    Pidv3Exception
 )
 
 
@@ -395,10 +396,40 @@ class TestRegisterUpdateDocuments(TestCase):
             {},
         ]
         register_update_documents(**self.kwargs)
-        MockLogger.info.assert_any_call(
+        MockLogger.error.assert_any_call(
             'Could not put document "%s" in object store: %s',
             self.kwargs["xmls_to_preserve"][1],
             "Put Doc in Object Store Error",
+        )
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_logs_error_if_put_xml_into_object_store_return_pidv3exception(
+        self,
+        MockZipFile,
+        MockLogger,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        MockZipFile.return_value.__enter__.return_value.read.return_value = b""
+        mk_put_xml_into_object_store.side_effect = [
+            {},
+            Pidv3Exception("Could not get scielo id v3"),
+            {},
+        ]
+        register_update_documents(**self.kwargs)
+        MockLogger.error.assert_any_call(
+            'Could not put document "%s" in object store: %s',
+            self.kwargs["xmls_to_preserve"][1],
+            "Could not get scielo id v3",
         )
 
     @patch(
@@ -477,7 +508,7 @@ class TestRegisterUpdateDocuments(TestCase):
         ]
 
         register_update_documents(**self.kwargs)
-        MockLogger.info.assert_any_call(
+        MockLogger.error.assert_any_call(
             'Could not register or update document "%s" in Kernel: %s',
             self.kwargs["xmls_to_preserve"][1],
             "Register Doc in Kernel Error",

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -407,36 +407,6 @@ class TestRegisterUpdateDocuments(TestCase):
         "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
     )
     @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
-    @patch("operations.sync_documents_to_kernel_operations.Logger")
-    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
-    def test_register_update_documents_logs_error_if_put_xml_into_object_store_return_pidv3exception(
-        self,
-        MockZipFile,
-        MockLogger,
-        mk_put_xml_into_object_store,
-        mk_put_assets_and_pdfs_in_object_store,
-        mk_register_update_doc_into_kernel,
-    ):
-        MockZipFile.return_value.__enter__.return_value.read.return_value = b""
-        mk_put_xml_into_object_store.side_effect = [
-            {},
-            Pidv3Exception("Could not get scielo id v3"),
-            {},
-        ]
-        register_update_documents(**self.kwargs)
-        MockLogger.error.assert_any_call(
-            'Could not put document "%s" in object store: %s',
-            self.kwargs["xmls_to_preserve"][1],
-            "Could not get scielo id v3",
-        )
-
-    @patch(
-        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
-    )
-    @patch(
-        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
-    )
-    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
     @patch("operations.sync_documents_to_kernel_operations.ZipFile")
     def test_register_update_documents_puts_each_doc_in_object_store(
         self,
@@ -537,6 +507,36 @@ class TestRegisterUpdateDocuments(TestCase):
 
         result = register_update_documents(**self.kwargs)
         self.assertEqual(result, expected)
+
+    @patch(
+        "operations.sync_documents_to_kernel_operations.register_update_doc_into_kernel"
+    )
+    @patch(
+        "operations.sync_documents_to_kernel_operations.put_assets_and_pdfs_in_object_store"
+    )
+    @patch("operations.sync_documents_to_kernel_operations.put_xml_into_object_store")
+    @patch("operations.sync_documents_to_kernel_operations.Logger")
+    @patch("operations.sync_documents_to_kernel_operations.ZipFile")
+    def test_register_update_documents_logs_error_if_put_xml_into_object_store_return_pidv3exception(
+        self,
+        MockZipFile,
+        MockLogger,
+        mk_put_xml_into_object_store,
+        mk_put_assets_and_pdfs_in_object_store,
+        mk_register_update_doc_into_kernel,
+    ):
+        MockZipFile.return_value.__enter__.return_value.read.return_value = b""
+        mk_put_xml_into_object_store.side_effect = [
+            {},
+            Pidv3Exception("Could not get scielo id v3"),
+            {},
+        ]
+        register_update_documents(**self.kwargs)
+        MockLogger.error.assert_any_call(
+            'Could not put document "%s" in object store: %s',
+            self.kwargs["xmls_to_preserve"][1],
+            "Could not get scielo id v3",
+        )
 
 
 class TestLinkDocumentToDocumentsbundle(TestCase):

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -19,7 +19,6 @@ from operations.exceptions import (
     DocumentToDeleteException,
     PutXMLInObjectStoreException,
     RegisterUpdateDocIntoKernelException,
-    Pidv3Exception,
 )
 
 
@@ -394,7 +393,7 @@ class TestRegisterUpdateDocuments(TestCase):
             {},
         ]
         register_update_documents(**self.kwargs)
-        MockLogger.error.assert_any_call(
+        MockLogger.info.assert_any_call(
             'Could not put document "%s" in object store: %s',
             self.kwargs["xmls_to_preserve"][1],
             "Put Doc in Object Store Error",
@@ -476,7 +475,7 @@ class TestRegisterUpdateDocuments(TestCase):
         ]
 
         register_update_documents(**self.kwargs)
-        MockLogger.error.assert_any_call(
+        MockLogger.info.assert_any_call(
             'Could not register or update document "%s" in Kernel: %s',
             self.kwargs["xmls_to_preserve"][1],
             "Register Doc in Kernel Error",


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR garante que não seja cadastrado XMLs e asset sem **scielo_id**.

#### Onde a revisão poderia começar?

airflow/dags/operations/docs_utils.py
airflow/dags/operations/exceptions.py
airflow/dags/operations/sync_documents_to_kernel_operations.py
airflow/tests/test_docs_utils.py
airflow/tests/test_sync_documents_to_kernel_operations.py

#### Como este poderia ser testado manualmente?

Para testar manualmente é necessário as seguintes instâncias rodando: 

- opac-airflow
- kernel
- minio

Utiliza o pacote: 
[7665_ag_2019nahead.zip](https://github.com/scieloorg/opac-airflow/files/3903036/7665_ag_2019nahead.zip)

Rodar a dag: pre_sync_documents_to_kernel, verificar que a dag: sync_documents_to_kernel também é executada 

O resultado será uma linha no log do ariflow informando que o XML não pode ser depositado, pois não pode obter o **scielo id v3**.

#### Algum cenário de contexto que queira dar?

Estamos levantando uma exceção de erro para esses casos de documentos XMLs sem scielo_id.

Nesse PR também foi ajustado alguns **logger/info** para **logger/error**

### Screenshots

Nova mensagem retornada no log: 

![Screenshot 2019-11-28 18 35 27](https://user-images.githubusercontent.com/373745/69832580-eb503b00-120d-11ea-813f-c22fe313d27f.png)

#### Quais são tickets relevantes?

#120 

### Referências

N/A