### PR TITLE
Adiciona tratamento de ex-Ahead of Prints na sincronização dos documentos e site

### DIFF
--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -47,7 +47,7 @@ def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=
         api_hook=api_hook,
         method=method,
         endpoint=endpoint,
-        data=json.dumps(data) if data else None,
+        data=json.dumps(data) if data is not None else None,
         headers=headers,
         timeout=timeout
     )

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -229,7 +229,7 @@ def put_xml_into_object_store(zipfile, xml_filename):
     return xml_data
 
 
-def register_document_to_documentsbundle(bundle_id, payload):
+def update_documents_in_bundle(bundle_id, payload):
     """
         Relaciona documento com seu fascículo(DocumentsBundle).
 
@@ -322,7 +322,7 @@ def update_aop_bundle_items(issn_id, documents_list):
                     for aop_item in aop_bundle_items
                     if aop_item["id"] not in documents_ids
                 ]
-                register_document_to_documentsbundle(
+                update_documents_in_bundle(
                     aop_bundle_id,
                     updated_aop_items
                 )

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -295,9 +295,9 @@ def get_or_create_bundle(bundle_id, is_aop):
             try:
                 return hooks.kernel_connect("/bundles/" + bundle_id, "GET")
             except requests.exceptions.HTTPError as exc:
-                raise LinkDocumentToDocumentsBundleException(str(exc))
+                raise LinkDocumentToDocumentsBundleException(str(exc), response=exc.response)
         else:
-            raise LinkDocumentToDocumentsBundleException(str(exc))
+            raise LinkDocumentToDocumentsBundleException(str(exc), response=exc.response)
 
 
 def update_aop_bundle_items(issn_id, documents_list):

--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -19,4 +19,7 @@ class RegisterUpdateDocIntoKernelException(Exception):
 
 
 class LinkDocumentToDocumentsBundleException(Exception):
-    ...
+    def __init__(self, message, response=None, *args, **kwargs):
+        self.message = message
+        if response is not None:
+            self.response = response

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -21,7 +21,7 @@ from operations.docs_utils import (
     put_assets_and_pdfs_in_object_store,
     put_xml_into_object_store,
     get_bundle_id,
-    register_document_to_documentsbundle,
+    update_documents_in_bundle,
     update_aop_bundle_items,
     get_or_create_bundle,
 )
@@ -257,7 +257,7 @@ def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_pa
                 Logger.info("Registering bundle_id %s with %s", bundle_id, payload)
 
                 if DeepDiff(current_items, payload, ignore_order=True):
-                    response = register_document_to_documentsbundle(bundle_id, payload)
+                    response = update_documents_in_bundle(bundle_id, payload)
                     ret.append({"id": bundle_id, "status": response.status_code})
                     logging.info(
                         "The bundle %s items list has been updated." % bundle_id

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -217,6 +217,14 @@ def ArticleFactory(
     article.fpage_sequence = _nestget(data, "article_meta", 0, "pub_fpage_seq", 0)
     article.lpage = _nestget(data, "article_meta", 0, "pub_lpage", 0)
 
+    if article.issue is not None and article.issue.number == "ahead":
+        if article.aop_url_segs is None:
+            url_segs = {
+                "url_seg_article": article.url_segment,
+                "url_seg_issue": article.issue.url_segment,
+            }
+            article.aop_url_segs = models.AOPUrlSegments(**url_segs)
+
     # Issue vinculada
     issue = models.Issue.objects.get(_id=issue_id)
     article.issue = issue

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -843,6 +843,7 @@ class TestGetOrCreateBundleIssueBundle(TestCase):
         with self.assertRaises(LinkDocumentToDocumentsBundleException) as exc_info:
             get_or_create_bundle(bundle_id, False)
         self.assertEqual(str(exc_info.exception), "Bundle not found")
+        self.assertEqual(exc_info.exception.response, error.response)
         mk_create_aop_bundle.assert_not_called()
 
     def test_returns_kernel_response(self, mk_create_aop_bundle, mk_hooks):
@@ -885,11 +886,11 @@ class TestGetOrCreateBundleAOPBundle(TestCase):
         bundle_id = "0034-8910-aop"
         error = requests.exceptions.HTTPError("Bundle not found")
         error.response = Mock(status_code=http.client.NOT_FOUND)
-        MockResponse = Mock(spec=requests.Response)
         mk_hooks.kernel_connect.side_effect = error
         with self.assertRaises(LinkDocumentToDocumentsBundleException) as exc_info:
             get_or_create_bundle(bundle_id, False)
         self.assertEqual(str(exc_info.exception), "Bundle not found")
+        self.assertEqual(exc_info.exception.response, error.response)
 
 
 @patch("operations.docs_utils.hooks")

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -17,7 +17,7 @@ from operations.docs_utils import (
     put_object_in_object_store,
     put_assets_and_pdfs_in_object_store,
     put_xml_into_object_store,
-    register_document_to_documentsbundle,
+    update_documents_in_bundle,
     get_bundle_id,
     get_or_create_bundle,
     create_aop_bundle,
@@ -743,7 +743,7 @@ class TestRegisterDocumentsToDocumentsBundle(TestCase):
             Verifica se register_document invoca kernel_connect com os parâmetros corretos.
         """
 
-        register_document_to_documentsbundle("0066-782X-1999-v72-n0",
+        update_documents_in_bundle("0066-782X-1999-v72-n0",
                                              self.payload)
 
         mk_hooks.kernel_connect.assert_called_once_with(
@@ -766,14 +766,14 @@ class TestRegisterDocumentsToDocumentsBundle(TestCase):
         )
 
         self.assertRaises(LinkDocumentToDocumentsBundleException,
-                          register_document_to_documentsbundle,
+                          update_documents_in_bundle,
                           "0066-782X-1999-v72-n0",
                           self.payload)
 
     @patch("operations.docs_utils.hooks")
     def test_if_register_document_documentsbundle_return_status_code_204_with_correct_params(self, mk_hooks):
         """
-            Verifica se ao invocarmos register_document_to_documentsbundle com o ID do bundle e payload corretos o retorno é o esperado.
+            Verifica se ao invocarmos update_documents_in_bundle com o ID do bundle e payload corretos o retorno é o esperado.
 
             Status code 204 significa que os documentos foram atualizado com sucesso.
         """
@@ -784,7 +784,7 @@ class TestRegisterDocumentsToDocumentsBundle(TestCase):
                     {"id": "0034-8910-rsp-48-2-0348", "order": "02"},
                   ]
 
-        response = register_document_to_documentsbundle("0066-782X-1999-v72-n0", payload)
+        response = update_documents_in_bundle("0066-782X-1999-v72-n0", payload)
 
         self.assertEqual(response.status_code, 204)
 
@@ -917,7 +917,7 @@ class TestCreateAOPBundle(TestCase):
 
 
 @patch("operations.docs_utils.hooks")
-@patch("operations.docs_utils.register_document_to_documentsbundle")
+@patch("operations.docs_utils.update_documents_in_bundle")
 class TestUpdateAOPBundle(TestCase):
     def setUp(self):
         self.documents_list = [
@@ -925,12 +925,12 @@ class TestUpdateAOPBundle(TestCase):
             for number in range(1, 5)
         ]
 
-    def test_gets_journal(self, mk_register_document_to_documentsbundle, mk_hooks):
+    def test_gets_journal(self, mk_update_documents_in_bundle, mk_hooks):
         update_aop_bundle_items("0034-8910", self.documents_list)
         mk_hooks.kernel_connect.assert_any_call("/journals/" + "0034-8910", "GET")
 
     def test_raises_exception_if_journal_get_error(
-        self, mk_register_document_to_documentsbundle, mk_hooks
+        self, mk_update_documents_in_bundle, mk_hooks
     ):
         error = requests.exceptions.HTTPError("Internal Error")
         error.response = Mock(status_code=http.client.NOT_FOUND)
@@ -940,7 +940,7 @@ class TestUpdateAOPBundle(TestCase):
         self.assertEqual(str(exc_info.exception), "Internal Error")
 
     def test_gets_aop_bundle_data(
-        self, mk_register_document_to_documentsbundle, mk_hooks
+        self, mk_update_documents_in_bundle, mk_hooks
     ):
         MockJournalResponse = Mock(spec=requests.Response)
         MockJournalResponse.json.return_value = {
@@ -957,7 +957,7 @@ class TestUpdateAOPBundle(TestCase):
         mk_hooks.kernel_connect.assert_any_call("/bundles/" + "0034-8910-aop", "GET")
 
     def test_raises_exception_if_bundle_get_error(
-        self, mk_register_document_to_documentsbundle, mk_hooks
+        self, mk_update_documents_in_bundle, mk_hooks
     ):
         MockJournalResponse = Mock(spec=requests.Response)
         MockJournalResponse.json.return_value = {
@@ -971,8 +971,8 @@ class TestUpdateAOPBundle(TestCase):
             update_aop_bundle_items("0034-8910", self.documents_list)
         self.assertEqual(str(exc_info.exception), "Internal Error")
 
-    def test_calls_register_document_to_documentsbundle(
-        self, mk_register_document_to_documentsbundle, mk_hooks
+    def test_calls_update_documents_in_bundle(
+        self, mk_update_documents_in_bundle, mk_hooks
     ):
         MockJournalResponse = Mock(spec=requests.Response)
         MockJournalResponse.json.return_value = {
@@ -998,7 +998,7 @@ class TestUpdateAOPBundle(TestCase):
             {"id": "ahead-3", "order": "3"},
             {"id": "ahead-3", "order": "5"},
         ]
-        mk_register_document_to_documentsbundle.assert_called_once_with(
+        mk_update_documents_in_bundle.assert_called_once_with(
             "0034-8910-aop", updated_docs_list
         )
 

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -512,7 +512,7 @@ class TestRegisterUpdateDocuments(TestCase):
 
 @patch("operations.sync_documents_to_kernel_operations.Logger")
 @patch(
-    "operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle"
+    "operations.sync_documents_to_kernel_operations.update_documents_in_bundle"
 )
 @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
 @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")
@@ -830,7 +830,7 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
 
 @patch("operations.sync_documents_to_kernel_operations.Logger")
 @patch(
-    "operations.sync_documents_to_kernel_operations.register_document_to_documentsbundle"
+    "operations.sync_documents_to_kernel_operations.update_documents_in_bundle"
 )
 @patch("operations.sync_documents_to_kernel_operations.get_bundle_id")
 @patch("operations.sync_documents_to_kernel_operations.get_or_create_bundle")


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o tratamento de ex-Ahead of Prints desde o fluxo de ingestão direta até a atualização do site. Executando as DAGs `sync_documents_to_kernel` e `sync_kernel_to_website`, deve:
- atualizar o documento no Kernel
- atualizar o bundle do fascículo regular com o documento ex-AOP no Kernel
- atualizar o bundle de AOP para a retirada do documento em AOP no Kernel
- atualizar o artigo no OPAC, com os `url_segment`s do documento em AOP
- inserir o artigo no fascículo regular
- retirar o artigo do ahead of print

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits ou que inicie pelo arquivo `airflow/dags/operations/sync_documents_to_kernel_operations.py`, L269

#### Como este poderia ser testado manualmente?
- Execute as DAGs `sync_documents_to_kernel` e `sync_kernel_to_website` com um pacote SPS contendo AOPs ou selecione um documento AOP já existente no site no Kernel e OPAC
- Simule a entrada de pacotes SPS contendo XMLs ex-AOPs, criando-os manualmente.
- Execute as DAGs `sync_documents_to_kernel` e `sync_kernel_to_website` com o pacote SPS com ex-AOPs
- O Kernel e o site devem ser atualizados conforme descrito anteriormente.

#### Algum cenário de contexto que queira dar?
Nenhum.

### Screenshots
N/A

#### Quais são tickets relevantes?
#48 

### Referências
Nenhuma.