### PR TITLE
Corrige registro e deleção de documentos durante sincronia do Website

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Iterable, Generator, Dict, List, Tuple
 
+import requests
 from opac_schema.v1 import models
 
 import common.hooks as hooks
@@ -299,6 +300,14 @@ def try_register_documents(
                 "Issue '%s' can't be found in the website database.",
                 document_id,
                 issue_id,
+            )
+        except requests.exceptions.HTTPError as exc:
+            logging.error(
+                "Could not register document '%s'. "
+                "The code '%s' was returned during the request to '%s'.",
+                document_id,
+                exc.response.status_code,
+                exc.response.url,
             )
 
     return list(set(orphans))


### PR DESCRIPTION
#### O que esse PR faz?

Corrige problemas no processamento de sincronização `Kernel -> Website` onde documentos deletados e marcados para deleção quebram a execução das tasks de `registro de documentos`  e `deleção de documentos`.

Os problemas ocorrem quando numa mesma leitura da API de mudanças nós temos:
1) Documento `X` registrado no Kernel mas não registrado no `Website` (ex: às 00:00);
2) Documento `X` removido no Kernel (ex: às 00:01);
3) A task de registro não conseguirá acessar o `/front` do documento que não existe mais no `kernel` já que ele foi removido às `00:01`;

#### Onde a revisão poderia começar?
- `airflow/dags/sync_kernel_to_website.py` L: `116`
- `airflow/dags/operations/sync_kernel_to_website_operations.py` L: `304`

#### Como este poderia ser testado manualmente?

Para testar este PR manualmente deve-se:
- Registrar um novo documento no Kernel;
- Remover o documento do Kernel;
- Executar a DAG `sync_kernel_to_website`;
- Verificar que não houve lançamento de exceção e a consequente quebra do processamento;

#### Algum cenário de contexto que queira dar?

Este problema foi recente descoberto no processamento de testes no dia 03/12/2019.

### Screenshots
N/A

#### Quais são tickets relevantes?
Tem referência com #132 

### Referências
N/A