### PR TITLE
Corrige a segmentação incorreta de issues órfãs durante a sincronia do Website

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -395,9 +395,15 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
     issue.spe_text = metadata.get("spe_text", "")
     issue.start_month = metadata.get("publication_month", 0)
     issue.end_month = metadata.get("publication_season", [0])[-1]
-    issue.year = '9999' if _type == 'ahead' else metadata.get("publication_year")
+
+    if _type == "ahead":
+        issue.year = issue.year or "9999"
+        issue.number = issue.number or "ahead"
+    else:
+        issue.year = metadata.get("publication_year", issue.year)
+        issue.number = metadata.get("number", issue.number)
+
     issue.volume = metadata.get("volume", "")
-    issue.number = 'ahead' if _type == 'ahead' else metadata.get("number", "")
     issue.order = metadata.get("order", 0)
     issue.pid = metadata.get("pid", "")
     issue.journal = models.Journal.objects.get(_id=journal_id)


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige a segmentação incorreta de issues órfãs. Quando as mudanças de `DocumentBundle` no `Kernel` não acompanham mudanças de `Journal` a task de registro de issue estava automáticamente determinando que os `bundles` eram órfãs o que não necessariamente é verdade já que a operação pode ser um `update parcial`.

#### Onde a revisão poderia começar?
- `airflow/dags/sync_kernel_to_website.py` L: `488`

#### Como este poderia ser testado manualmente?
Para testar este pr manualmente deve-se:
- Atualizar um bundle no `kernel` que já esteja cadastrado no `opac`;
- Verificar que o bundle não foi classificado como órfã.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #126 

### Referências
N/A