### PR TITLE
Corrige marcação dos documentos sem scielo-id para deleção

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -323,11 +323,15 @@ def update_aop_bundle_items(issn_id, documents_list):
             else:
                 aop_bundle_items = aop_bundle_resp.json()["items"]
                 documents_ids = [document["id"] for document in documents_list]
-                updated_aop_items = [
-                    aop_item
-                    for aop_item in aop_bundle_items
-                    if aop_item["id"] not in documents_ids
-                ]
+                updated_aop_items = []
+                for aop_item in aop_bundle_items:
+                    if aop_item["id"] not in documents_ids:
+                        updated_aop_items.append(aop_item)
+                    else:
+                        Logger.info(
+                            'Movindo ex-Ahead of Print "%s" to bundle',
+                            aop_item["id"],
+                        )
                 update_documents_in_bundle(
                     aop_bundle_id,
                     updated_aop_items

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -28,7 +28,7 @@ def delete_doc_from_kernel(doc_to_delete):
         raise DeleteDocFromKernelException(str(exc)) from None
 
 
-def document_to_delete(zipfile, sps_xml_file):
+def is_document_to_delete(zipfile, sps_xml_file):
     parser = etree.XMLParser(remove_blank_text=True, no_network=True)
     try:
         metadata = SPS_Package(
@@ -37,10 +37,7 @@ def document_to_delete(zipfile, sps_xml_file):
     except (etree.XMLSyntaxError, TypeError, KeyError) as exc:
         raise DocumentToDeleteException(str(exc)) from None
     else:
-        if metadata.is_document_deletion:
-            if metadata.scielo_pid_v3 is None:
-                raise DocumentToDeleteException("Missing element in XML")
-            return metadata.scielo_pid_v3
+        return metadata.is_document_deletion, metadata.scielo_pid_v3
 
 
 def register_update_doc_into_kernel(xml_data):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige a marcação dos documentos sem `scielo-id` para deleção que estavam seguindo como documentos a preservar. Foi alterada a forma como os documentos para deleção são informados na leitura dos dados do XML e, independentemente do documento ter ou não o
`scielo-id`, ele é informado como um documento para deleção e, assim, é possível retirá-lo da lista dos documentos a serem preservados.

Também foram feitas melhorias na execução das tarefas da DAG de sincronização: a otimização da execução das tarefas e o log da entrada de documentos ex-Ahead of Prints.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
Tendo o Airflow configurado:
- Sincronize um pacote SPS contendo documentos para deleção (com `<article-id specific-use="delete">`) e que não tenham `scielo-v3`
- A mensagem de erro da ausencia do scielo-id deve aparecer no log de execução da tarefa de deleção
- Os documentos para deleção, com ou sem `scielo-v3`, não devem estar presentes na lista de documentos para preservar

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#121 

### Referências
- Operador do Airflow p/ determinar a execução da tarefa: https://airflow.apache.org/docs/stable/_api/airflow/operators/python_operator/#airflow.operators.python_operator.ShortCircuitOperator
