### PR TITLE
Atribui valores de SciELO PIDs no sync de documentos do Kernel p/ o site

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -65,7 +65,17 @@ def ArticleFactory(
     # Identificadores
     article._id = document_id
     article.aid = document_id
-    article.pid = _nestget(data, "article_meta", 0, "article_publisher_id", 1)
+    # Lista de SciELO PIDs dentro de article_meta
+    scielo_pids = [
+        (
+            f"v{version}",
+            _nestget(data, "article_meta", 0, f"scielo_pid_v{version}", 0, default=None)
+        )
+        for version in range(1, 4)
+    ]
+    article.scielo_pids = {
+        version: value for version, value in scielo_pids if value is not None
+    }
     article.doi = _nestget(data, "article_meta", 0, "article_doi", 0)
 
     def _get_article_authors(data) -> Generator:

--- a/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621.json
+++ b/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621.json
@@ -15,7 +15,17 @@
           "10.11606/S1518-8787.2019053000621"
         ],
         "article_publisher_id": [
-          "67TH7T7CyPPmgtVrGXhWXVs"
+            "S1518-87872019053000621",
+            "67TH7T7CyPPmgtVrGXhWXVs"
+        ],
+        "scielo_pid_v1": [
+            "S1518-8787(19)03000621"
+        ],
+        "scielo_pid_v2": [
+            "S1518-87872019053000621"
+        ],
+        "scielo_pid_v3": [
+            "67TH7T7CyPPmgtVrGXhWXVs"
         ],
         "article_title": [
           "Validation of an anxiety scale for prenatal diagnostic procedures"

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -147,9 +147,14 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertTrue(hasattr(self.document, "pid"))
         self.assertTrue(hasattr(self.document, "doi"))
 
-        self.assertEqual("67TH7T7CyPPmgtVrGXhWXVs", self.document._id)
-        self.assertEqual("67TH7T7CyPPmgtVrGXhWXVs", self.document.aid)
-        self.assertEqual("10.11606/S1518-8787.2019053000621", self.document.doi)
+        self.assertEqual(self.document._id, "67TH7T7CyPPmgtVrGXhWXVs")
+        self.assertEqual(self.document.aid, "67TH7T7CyPPmgtVrGXhWXVs")
+        self.assertEqual(self.document.doi, "10.11606/S1518-8787.2019053000621")
+        self.assertEqual(self.document.scielo_pids, {
+            "v1": "S1518-8787(19)03000621",
+            "v2": "S1518-87872019053000621",
+            "v3": "67TH7T7CyPPmgtVrGXhWXVs",
+        })
 
     def test_has_authors_attribute(self):
         self.assertTrue(hasattr(self.document, "authors"))


### PR DESCRIPTION
#### O que esse PR faz?
Atribui valores de `scielo_pid_v1`, `scielo_pid_v2` e `scielo_pid_v3`, retornados no `front` de documentos do Kernel, a campo `scielo_pids` do Opac_Schema na sincronização dos documentos do Kernel para o site.

#### Onde a revisão poderia começar?
Em `airflow/tests/test_sync_kernel_to_website.py`, para entender o resultado esperado no registro do OPAC.

#### Como este poderia ser testado manualmente?
- Sincronize um novo pacote SPS para o Kernel ou garanta que há documentos com o `/front` retornando `<article-id specific-use="scielo-vn">`
- Execute a DAG `sync_kernel_to_website`
- Verifique o resultado na coleção `article` na base MongoDB OPAC dos documentos sincronizados para o site. Deve existir um campo chamado `scielo_pids` com a mesma estrutura do teste unitário.

#### Algum cenário de contexto que queira dar?
Este PR altera somente o OPAC-Airflow e não garante a atualização do OPAC e, por isso, quebra o site que não estiver rodando com a versão 2.53 do opac_schema.

### Screenshots
N/A.

#### Quais são tickets relevantes?
#138 

### Referências
Nenhuma.