### PR TITLE
Aumenta timeout padrão da conexão com o Kernel

### DIFF
--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -41,7 +41,7 @@ def http_hook_run(api_hook, method, endpoint, data=None, headers=DEFAULT_HEADER,
     return response
 
 
-def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=1):
+def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=10):
     api_hook = HttpHook(http_conn_id="kernel_conn", method=method)
     response = http_hook_run(
         api_hook=api_hook,


### PR DESCRIPTION
#### O que esse PR faz?
Depois de alguns testes, foi detectado que algumas respostas às requisições HTTP ao Kernel demoraram mais que 1 segundo, timeout configurado anteriormente e, para garantir uma maior probabilidade das respostas chegarem, o timeout para o tempo de resposta foi aumentado para 10 segundos.

#### Onde a revisão poderia começar?
Em `airflow/dags/common/hooks.py`.

#### Como este poderia ser testado manualmente?
- Execute alguma requisição ao Kernel que leva mais de 1 segundo, através da execução de alguma DAG que conecta com o Kernel.
- A execução da DAG deve finalizar com sucesso.

#### Algum cenário de contexto que queira dar?
Este problema foi detectado durante os testes de sincronização dos pacotes SPS no servidor de testes.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A.

### Referências
Nenhuma.
