### PR TITLE
Corrige pequenos bugs durente a execução das dags de sincronização 

### DIFF
--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -149,7 +149,7 @@ def journal_as_kernel(journal: Journal) -> dict:
                 item["country_code"] = country_code
                 item["country"] = country_name
             institution_responsible_for.append(item)
-    _payload["institution_responsible_for"] = tuple(institution_responsible_for)
+    _payload["institution_responsible_for"] = institution_responsible_for
 
     return _payload
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -408,9 +408,9 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
         issue = models.Issue()
     else:
         journal_id = journal_id or issue.journal._id
+        _type = "ahead" if _type == "ahead" or data["id"].endswith("-aop") else _type
 
     issue._id = issue.iid = data["id"]
-    issue.type = metadata.get("type", _type)
     issue.spe_text = metadata.get("spe_text", "")
     issue.start_month = metadata.get("publication_month", 0)
     issue.end_month = metadata.get("publication_season", [0])[-1]
@@ -467,6 +467,8 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
         issue.type = "volume_issue"
     elif issue.number and "spe" in issue.number:
         issue.type = "special"
+    else:
+        issue.type = _type
 
     return issue
 


### PR DESCRIPTION
#### O que esse PR faz?
Este pull request corrige pequenos bugs durante a sincronização entre o `Kernel->Website` e `Isis->Kernel`.

#### Onde a revisão poderia começar?
- `airflow/dags/sync_isis_to_kernel.py` L: `152`
- `airflow/dags/sync_kernel_to_website.py` L: `411`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:

- **Primeiro caso**:
    - Execute a sincronização `isis_to_kernel`;
    - Verifique que os `journals` foram cadastrados com sucesso;
    - Execute novamente a sincronização `isis_to_kernel`;
    - Verifique que não foram enviados `PATCH` massivamente durante a task `process_journals`;
- **Segundo caso**:
    - Execute todo o stack de sincronização do `opac-airflow`;
    - Atualize um `bundle` do tipo `aop` (pode ser qualquer dado):
        - ex: `curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json'  http://0.0.0.0:6543/bundles/1984-2961-aop -d '{"titles": [{"language": "pt", "value": "Update"}]}' -v`
    - Execute a sincronização `kernel->site`;
    - Verifique que o bundle de ahead continua com o seu tipo preservado;
    - Verifique que o bundle atualizado continua sendo exibido como `ahead of print` na grade de issues;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots

Diferença entre payload e resposta do `kernel` para os tipos `list` e `tuple`
![Screen Shot 2019-12-16 at 16 11 49](https://user-images.githubusercontent.com/4604104/70935365-c8e85b00-201e-11ea-8339-edde2a878556.png)


#### Quais são tickets relevantes?
N/A

### Referências
N/A