### PR TITLE
Registra nome de PDF legado no Object Store e no Website

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -339,16 +339,16 @@ def ArticleRenditionFactory(article_id: str, data: List[dict]) -> models.Article
         models.Article: Artigo recuperado e atualizado com uma nova lista de assets."""
 
     article = models.Article.objects.get(_id=article_id)
-
-    def _get_pdfs(data: dict) -> List[dict]:
-        return [
-            {"lang": rendition["lang"], "url": rendition["url"], "type": "pdf"}
-            for rendition in data
-            if rendition["mimetype"] == "application/pdf"
-        ]
-
-    article.pdfs = list(_get_pdfs(data))
-
+    article.pdfs = [
+        {
+            "lang": rendition["lang"],
+            "url": rendition["url"],
+            "filename": rendition["filename"],
+            "type": "pdf",
+        }
+        for rendition in data
+        if rendition["mimetype"] == "application/pdf"
+    ]
     return article
 
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -358,7 +358,14 @@ class ArticleRenditionFactoryTests(unittest.TestCase):
 
     def test_pdfs_attr_should_be_populated_with_rendition_pdf_data(self):
         self.assertEqual(
-            [{"lang": "en", "url": "//object-storage/file.pdf", "type": "pdf"}],
+            [
+                {
+                    "lang": "en",
+                    "url": "//object-storage/file.pdf",
+                    "type": "pdf",
+                    "filename": "filename.pdf",
+                }
+            ],
             self.article.pdfs,
         )
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera os seguintes pontos:
- `sync_document_to_kernel`: atualiza os metadados do objeto do PDF criado no Object Store (MinIO) com o nome legado do arquivo. Ex: `en_1983-1447-rgenf-40-spe-e20180114.pdf`
- `sync_kernel_to_website`: obtém os metadados dos objetos PDF do Object Store para armazenar junto com os metadados de PDFs nos documentos de artigo do site novo.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits.

#### Como este poderia ser testado manualmente?
- Obtenha um pacote SPS com documentos que tenham manifestações PDF em mais de um idioma
- Com a syncronização do ISIS -> Kernel feita, sincronize o pacote SPS
- Sincronize o Kernel -> website
- Ao final, é esperado que o documento na coleção `article` do MongoDB do site esteja com o campo `pdfs` contendo uma lista de objetos com seus respectivos nomes legados dos arquivos no campo `origin_name`.

#### Algum cenário de contexto que queira dar?
Como o nome dos arquivos no Object Store são hashes, não é possível identificá-lo no documento pela URL, como implementado no site novo atualmente. Por conta disso, o nome legado do arquivo precisa ser armazenado para que o site possa buscá-lo. Também será necessário alterar o site para que ele seja capaz de ler este campo.

### Screenshots


#### Quais são tickets relevantes?
#115 

### Referências
Nenhuma.