### PR TITLE
Altera espelhamento ISIS2Kernel para gerar PID dos fascículos

### DIFF
--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -170,10 +170,14 @@ def issue_as_kernel(issue: dict) -> dict:
 
         return _date
 
+    def generate_scielo_issue_pid(issn_id, v36_field):
+        year = v36_field[0:4]
+        order = v36_field[4:].zfill(4)
+        return issn_id + year + order
+
     _payload = {}
     _payload["volume"] = issue.volume or ""
     _payload["number"] = issue.number or ""
-    _payload["pid"] = issue.publisher_id
 
     suppl = issue.supplement_volume or issue.supplement_number
     if suppl or issue.type is "supplement":
@@ -205,6 +209,9 @@ def issue_as_kernel(issue: dict) -> dict:
         _payload.get("supplement"),
     )
     _payload["publication_year"] = str(_creation_date.year)
+    _payload["pid"] = generate_scielo_issue_pid(
+        issn_id, issue.data.get("issue").get("v36")[0]["_"]
+    )
 
     return _payload
 

--- a/airflow/tests/test_sync_isis_to_kernel.py
+++ b/airflow/tests/test_sync_isis_to_kernel.py
@@ -1,10 +1,10 @@
 import os
 import json
 import unittest
-
 from unittest.mock import Mock
 import tempfile
 
+from airflow import DAG
 from xylose.scielodocument import Issue
 
 from sync_isis_to_kernel import (
@@ -160,7 +160,9 @@ class TestIssueAsKernel(unittest.TestCase):
         self.mocked_issue = Mock()
         self.mocked_issue.start_month = None
         self.mocked_issue.end_month = None
-        self.mocked_issue.data = {"issue": {"v35": [{"_": "1234-0987"}]}}
+        self.mocked_issue.data = {
+            "issue": {"v35": [{"_": "1234-0987"}], "v36": [{"_": "20171001"}]}
+        }
         self.mocked_issue.publication_date = "2017-09"
         self.mocked_issue.volume = None
         self.mocked_issue.number = None
@@ -262,15 +264,19 @@ class TestIssueAsKernel(unittest.TestCase):
         mocked_issue.volume = "3"
         mocked_issue.supplement_volume = "0"
         mocked_issue.publication_date = "2013-09"
-        mocked_issue.data = {"issue": {"v35": [{"_": "1234-0987"}]}}
+        mocked_issue.data = {
+            "issue": {"v35": [{"_": "1234-0987"}], "v36": [{"_": "20131001"}]}
+        }
         result = issue_as_kernel(mocked_issue)
         self.assertIsNotNone(result["_id"])
 
     def test_issue_as_kernel_returns_pid(self):
         mocked_issue = self.mocked_issue
-        mocked_issue.publisher_id = "0074-027619980002"
+        mocked_issue.data = {
+            "issue": {"v35": [{"_": "1234-0987"}], "v36": [{"_": "201310"}]}
+        }
         result = issue_as_kernel(mocked_issue)
-        self.assertEqual("0074-027619980002", result["pid"])
+        self.assertEqual("1234-098720130010", result["pid"])
 
 
 class TestJournalAsKernel(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera o espelhamento do ISIS para o Kernel dos fascículos. Como a base ISIS de `issue` pode não conter o SciELO PID dos fascículos, não é possível simplesmente obtê-lo através do acesso aos dados da base via Xylose. Pelo fato de ser possível gerar o PID com os dados que sempre estão presentes na base `issue`, este código altera o preenchimento do campo para envio ao Kernel da forma como o processamento do site faz.

#### Onde a revisão poderia começar?
Em `airflow/dags/sync_isis_to_kernel.py`.

#### Como este poderia ser testado manualmente?
- Execute a DAG de espelhamento (`sync_isis_to_kernel`) com as bases ISIS do *serial_proc*.
- A tarefa `process_issues_task` deve ser concluída sem erros
- Os fascículos no Kernel devem estar registrados com o SciELO PID.

#### Algum cenário de contexto que queira dar?
Detalhes no ticket: https://github.com/scieloorg/opac-airflow/issues/142#issuecomment-571585147

### Screenshots
N/A

#### Quais são tickets relevantes?
#142

### Referências
Nenhuma.