### PR TITLE
Adiciona arquivos base para registar o log de processamento das DAGs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,11 @@ dev_compose_add_kernel_conn:  ## Add default kernel_conn
 	    --conn_host=http://0.0.0.0 \
 	    --conn_port=6543
 
+dev_compose_add_postgres_report_conn:
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow airflow connections \
+	-a --conn_type=Postgres \
+	--conn_id=postgres_report_connection
+
 dev_compose_rm_db:  ## Remove database
 	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow rm airflow.db
 
@@ -88,6 +93,11 @@ compose_add_opac_conn:  ## Add default opac_conn
 	--conn_schema=opac \
 	--conn_port=27017 \
 	--conn_extra='{"authentication_source": "admin"}'
+
+compose_add_postgres_report_conn:
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow airflow connections \
+	-a --conn_type=Postgres \
+	--conn_id=postgres_report_connection
 
 compose_add_kernel_conn:  ## Add default kernel_conn
 	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow airflow connections \

--- a/airflow/migrations/0001-add-execution-report-tables-202002041716.sql
+++ b/airflow/migrations/0001-add-execution-report-tables-202002041716.sql
@@ -1,0 +1,49 @@
+/*
+* A tabela xml_documents guarda o registro de iterações dos xmls que estão dentro 
+* de um pacote SPS.
+* 
+* Para cada artigo registrado ou deletado durante a sincronização, nós adicionamos
+* uma entrada nesta tabela.
+*/ 
+CREATE TABLE IF NOT EXISTS xml_documents (
+  id SERIAL PRIMARY KEY,
+  pid varchar(23) NULL,                             -- scielo-pid-v3 presente no xml
+  package_name varchar(255) null,                   -- Nome do pacote processado ex: `rsp_v53.zip`
+  dag_run varchar(255),                             -- Identificador de execução da dag `sync_documents_to_kernel`
+  pre_sync_dag_run varchar(255) NULL,               -- Identificador de execução da dag `pre_sync_documents_to_kernel` 
+  deletion bool DEFAULT false,
+  file_name varchar(255),                           -- Nome do arquivo xml
+  failed bool DEFAULT false,
+  error text null,                                  -- Erro lançado durante processamento
+  payload json,                                     -- Dado enviado para o Kernel
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS xml_documents_pid ON xml_documents (pid);
+CREATE INDEX IF NOT EXISTS xml_documents_dag_run ON xml_documents (dag_run);
+CREATE INDEX IF NOT EXISTS xml_documents_package_name ON xml_documents (package_name);
+CREATE INDEX IF NOT EXISTS xml_documents_pre_sync_dag_run ON xml_documents (pre_sync_dag_run);
+
+/*
+* A tabela xml_documentsbundle guarda o registro de relacionamento entre
+* os artigos e seus respectivos `documentsbundle`.
+*/
+CREATE TABLE IF NOT EXISTS xml_documentsbundle (
+    id SERIAL PRIMARY KEY,
+    pid varchar(23) NULL,
+    bundle_id varchar(100),
+    package_name varchar(255) null,
+    dag_run varchar(255),
+    pre_sync_dag_run varchar(255) NULL,
+    ex_ahead bool default false,
+    removed bool default false,
+    failed bool DEFAULT false,
+    error text null,
+    payload json null,
+    created_at timestamptz default now()
+);
+
+CREATE INDEX IF NOT EXISTS xml_documentsbundle_pid ON xml_documentsbundle (pid);
+CREATE INDEX IF NOT EXISTS xml_documentsbundle_dag_run ON xml_documentsbundle (dag_run);
+CREATE INDEX IF NOT EXISTS xml_documentsbundle_package_name ON xml_documentsbundle (package_name);
+CREATE INDEX IF NOT EXISTS xml_documentsbundle_pre_sync_dag_run ON xml_documentsbundle (pre_sync_dag_run);

--- a/airflow/migrations/run.py
+++ b/airflow/migrations/run.py
@@ -1,0 +1,41 @@
+import argparse
+import logging
+
+from airflow.hooks.postgres_hook import PostgresHook
+from airflow.exceptions import AirflowException
+from psycopg2 import ProgrammingError, OperationalError
+
+
+def run_sql(sql: str, connection_id: str) -> None:
+    """Executa instruções SQL em uma conexão airflow"""
+
+    hook = PostgresHook(postgres_conn_id=connection_id)
+
+    try:
+        hook.get_conn()
+    except OperationalError:
+        logging.info("Connection `%s` is not configured.", connection_id)
+        return
+
+    try:
+        hook.run(sql)
+    except (AirflowException, ProgrammingError, OperationalError) as exc:
+        logging.error(exc)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="SQL import tool")
+    parser.add_argument("sql", help="SQL file", type=argparse.FileType("r"))
+    parser.add_argument(
+        "connection", help="Airflow connection id, e.g: postgres_report_connection"
+    )
+    parsed = parser.parse_args()
+    sql = "".join(parsed.sql.readlines())
+
+    run_sql(sql, parsed.connection)
+
+    print(os.listdir("./migrations"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona base para registro dos processamentos de documentos via airflow.

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?

Não estou seguro sobre o modo de armazenar os arquivos `sql` que esse projeto pode vir a requerer. De toda forma acabei criando uma pasta que deverá conter os arquivos e um script que pode nos ajudar a executar os arquivos sql.

Dessa forma seria possível executar o import dos arquivos a medida que o airflow inicia. Nada impede que importemos esses arquivos na mão.

Nos próximos PRs adicionarei trechos de códigos que detectam se a conexão está configurada e em caso positivo os registros serão armazenados no banco de dados. A ideia por trás é que o processamento funcione independente de salvarmos os logs de execução ou não.

### Screenshots
N/A

#### Quais são tickets relevantes?
#77 

### Referências
N/A