### PR TITLE
Adiciona suporte a sincronização de feeds de notícias com o Website

### DIFF
--- a/airflow/dags/operations/sync_external_content_to_website_operations.py
+++ b/airflow/dags/operations/sync_external_content_to_website_operations.py
@@ -1,0 +1,91 @@
+import uuid
+import logging
+from datetime import datetime
+
+import requests
+import feedparser
+from mongoengine.errors import ValidationError
+from opac_schema.v1 import models
+from tenacity import (
+    retry,
+    wait_exponential,
+    stop_after_attempt,
+    retry_if_exception_type,
+    RetryError,
+)
+
+
+def NewsBuilder(entry: dict, language: str) -> models.News:
+    """Recebe um dicionário contento informações sobre uma notícia e tranaforma
+    em uma instância de opac_schema.v1.models.News.
+
+    Por meio da url é verificado se uma notícia já está cadastrada na base do
+    website, em caso de positivo, a notícia será atualizada."""
+
+    url = entry.get("id")
+
+    try:
+        news = models.News.objects.get(url=url)
+    except models.News.DoesNotExist:
+        news = models.News()
+        news._id = str(uuid.uuid4()).replace("-", "")
+
+    news.url = entry.get("id")
+    news.title = entry.get("title")
+    news.description = entry.get("summary")
+    news.image_url = entry.get("media_content", [{}])[-1].get("url")
+
+    try:
+        news.publication_date = datetime.strptime(
+            entry["published"][5:25], "%d %b %Y %X"
+        )
+    except ValueError:
+        news.publication_date = datetime.now()
+
+    news.language = language
+
+    return news
+
+
+@retry(
+    wait=wait_exponential(),
+    stop=stop_after_attempt(4),
+    retry=retry_if_exception_type((requests.ConnectionError, requests.Timeout)),
+)
+def fetch_rss(url):
+    return requests.get(url, timeout=10)
+
+
+def try_fetch_and_register_feed(rss_news_feeds: dict) -> None:
+    """Obtém as notícias de um feed, realiza o parser do XML para dicionário
+    Python e registra na base de dados do Website."""
+
+    for language, feed in rss_news_feeds.items():
+
+        try:
+            response = fetch_rss(feed["url"])
+        except RetryError as exc:
+            logging.error(
+                "Could not fetch feed from '%s'.", feed["url"],
+            )
+            continue
+        else:
+            content = feedparser.parse(response.content)
+
+        if content.bozo == 1:
+            logging.error(
+                "Could not parse feed content from '%s'. During processing this error '%s' was thrown.",
+                feed["url"],
+                content.bozo_exception,
+            )
+
+        for entry in content.get("entries", []):
+            try:
+                news = NewsBuilder(entry, language)
+                news.save()
+            except ValidationError as exc:
+                logging.error(
+                    "Could not save entry '%s', Please verify '%s'", entry, exc
+                )
+            else:
+                logging.info("News '%s', saved successfully.", news.title)

--- a/airflow/dags/sync_external_content_to_website.py
+++ b/airflow/dags/sync_external_content_to_website.py
@@ -1,0 +1,65 @@
+import logging
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
+
+from common.hooks import mongo_connect
+from operations.sync_exernal_content_to_website_operations import (
+    try_fetch_and_register_feed,
+)
+
+Logger = logging.getLogger(__name__)
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2020, 2, 6),
+}
+
+dag = DAG(
+    dag_id="sync_external_content_to_website",
+    default_args=default_args,
+    schedule_interval="@hourly",
+    catchup=False
+)
+
+RSS_NEWS_FEEDS = {
+    "pt_BR": {
+        "display_name": "SciELO em Perspectiva",
+        "url": "http://blog.scielo.org/feed/",
+    },
+    "es": {
+        "display_name": "SciELO en Perspectiva",
+        "url": "http://blog.scielo.org/es/feed/",
+    },
+    "en": {
+        "display_name": "SciELO in Perspective",
+        "url": "http://blog.scielo.org/en/feed/",
+    },
+}
+
+
+def fetch_and_register_news_feed_callable(**kwargs):
+    """Obtém e registra o feed de notícias do scielo em perspectiva.
+
+    Esta task é responsável por obter o feed de notícias do scielo em perspectiva,
+    transformar e salvar no banco de dados do website."""
+    mongo_connect()
+
+    rss_news_feeds = Variable.get(
+        "RSS_NEWS_FEEDS", default_var=RSS_NEWS_FEEDS, deserialize_json=True
+    )
+
+    try_fetch_and_register_feed(rss_news_feeds)
+
+
+fetch_feed_content_task = PythonOperator(
+    task_id="fetch_feed_content_task",
+    python_callable=fetch_and_register_news_feed_callable,
+    dag=dag,
+)
+
+fetch_feed_content_task

--- a/airflow/tests/fixtures/rss-news-feed.json
+++ b/airflow/tests/fixtures/rss-news-feed.json
@@ -1,0 +1,53 @@
+[
+    {
+        "author": "Author",
+        "author_detail": {
+            "name": "Author"
+        },
+        "authors": [
+            {
+                "name": "Author"
+            }
+        ],
+        "comments": "https://blog.scielo.org/blog/2020/01/29/random-url#comments",
+        "content": [
+            {}
+        ],
+        "guidislink": false,
+        "id": "http://blog.scielo.org/?p=5060",
+        "link": "https://blog.scielo.org/blog/2020/01/29/random-url",
+        "links": [
+            {
+                "href": "https://blog.scielo.org/blog/2020/01/29/random-url",
+                "rel": "alternate",
+                "type": "text/html"
+            }
+        ],
+        "media_content": [
+            {
+                "height": "90",
+                "medium": "image",
+                "url": "https://blog.scielo.org/wp-content/image.jpg",
+                "width": "150"
+            }
+        ],
+        "published": "Wed, 29 Jan 2020 17:45:29 +0000",
+        "slash_comments": "1",
+        "summary": "Summary..",
+        "tags": [
+            {
+                "label": null,
+                "scheme": null,
+                "term": "An\\u00e1lises"
+            }
+        ],
+        "title": "Random title",
+        "title_detail": {
+            "base": "https://blog.scielo.org/feed/",
+            "language": null,
+            "type": "text/plain",
+            "value": "Random title"
+        },
+        "wfw_commentrss": "https://blog.scielo.org/blog/randon-url/feed/"
+    }
+]

--- a/airflow/tests/test_sync_external_content_to_website.py
+++ b/airflow/tests/test_sync_external_content_to_website.py
@@ -1,0 +1,50 @@
+import os
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+from opac_schema.v1 import models
+
+from .test_sync_kernel_to_website import load_json_fixture
+from dags.operations.sync_external_content_to_website_operations import NewsBuilder
+
+FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+
+
+class TestNewsBuilder(unittest.TestCase):
+    def setUp(self):
+        self.news = load_json_fixture("rss-news-feed.json")
+        self.news_objects = patch(
+            "operations.sync_external_content_to_website_operations.models.News.objects"
+        )
+
+        NewsObjectsMock = self.news_objects.start()
+        NewsObjectsMock.get.side_effect = models.News.DoesNotExist
+
+        self.news_instance = NewsBuilder(self.news[0], "en")
+
+    def tearDown(self):
+        self.news_objects.stop()
+
+    def test_news_instance_has_id(self):
+        self.assertIsNotNone(self.news_instance._id)
+
+    def test_news_instance_id_has_32_characters(self):
+        self.assertEqual(32, len(self.news_instance._id))
+
+    def test_news_instance_has_title(self):
+        self.assertEqual("Random title", self.news_instance.title)
+
+    def test_news_instance_has_description(self):
+        self.assertEqual("Summary..", self.news_instance.description)
+
+    def test_news_instance_has_image_url(self):
+        self.assertEqual(
+            "https://blog.scielo.org/wp-content/image.jpg",
+            self.news_instance.image_url,
+        )
+
+    def test_news_instance_has_language(self):
+        self.assertEqual("en", self.news_instance.language)
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ xylose==1.35.1
 lxml==4.3.4
 pymongo==3.9.0
 deepdiff[murmur]==4.0.7
+feedparser==5.2.1
 git+https://github.com/scieloorg/opac_schema.git@master#egg=opac_schema


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request implementa uma nova  DAG responsável por obter as notícias a partir de feeds de notícias (configuráveis via variável do airflow) e registra-las na base de dados do Website.

#### Onde a revisão poderia começar?
- `airflow/dags/sync_external_content_to_website.py`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Configurar a conexão com a base de dados do `website`;
- Executar a dag `sync_external_content_to_website`;
- Verificar se as notícias foram cadastradas na base de dados do website.

#### Algum cenário de contexto que queira dar?

É possível configurar o feed de notícias a partir da variável `RSS_NEWS_FEEDS`, é esperado que esta variável contenha um dicionário no formato:

```python
{
 "idioma": {
    "url": "url do feed"
  }
}
```
### Screenshots
N/A

#### Quais são tickets relevantes?
#26

### Referências
N/A