### PR TITLE
Adiciona log de processamento durante a deleção de documentos

### DIFF
--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -54,7 +54,10 @@ def get_sps_packages(conf, **kwargs):
             run_id="manual__%s_%s" % (os.path.basename(sps_package), now.isoformat()),
             execution_date=now,
             replace_microseconds=False,
-            conf={"sps_package": sps_package},
+            conf={
+                "sps_package": sps_package,
+                "pre_syn_dag_run_id": kwargs.get("run_id"),
+            },
         )
     Logger.debug("create_all_subdags OUT")
 

--- a/airflow/tests/test_pre_sync_documents_to_kernel.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel.py
@@ -54,7 +54,7 @@ class TestGetSPSPackages(TestCase):
                     run_id=ANY,
                     execution_date=ANY,
                     replace_microseconds=False,
-                    conf={"sps_package": mk_sps_package},
+                    conf={"sps_package": mk_sps_package, "pre_syn_dag_run_id": ANY},
                 )
 
 

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -62,6 +62,7 @@ class TestDeleteDocuments(TestCase):
     ):
         mk_dag_run = MagicMock()
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_delete_documents.return_value = [], []
         delete_documents(**kwargs)
         mk_dag_run.conf.get.assert_called_once_with("sps_package")
 
@@ -69,6 +70,7 @@ class TestDeleteDocuments(TestCase):
     def test_delete_documents_gets_ti_xcom_info(self, mk_delete_documents):
         mk_dag_run = MagicMock()
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_delete_documents.return_value = [], []
         delete_documents(**kwargs)
         kwargs["ti"].xcom_pull.assert_called_once_with(
             key="xmls_filenames", task_ids="list_docs_task_id"
@@ -96,6 +98,7 @@ class TestDeleteDocuments(TestCase):
         mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
         kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_delete_documents.return_value = xmls_filenames, []
         delete_documents(**kwargs)
         mk_delete_documents.assert_called_once_with(
             "path_to_sps_package/package.zip", xmls_filenames
@@ -116,7 +119,7 @@ class TestDeleteDocuments(TestCase):
         mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
         kwargs["ti"].xcom_pull.return_value = xmls_filenames
-        mk_delete_documents.return_value = xmls_to_preserve
+        mk_delete_documents.return_value = xmls_to_preserve, []
         delete_documents(**kwargs)
         kwargs["ti"].xcom_push.assert_called_once_with(
             key="xmls_to_preserve", value=xmls_to_preserve

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -210,7 +210,7 @@ class TestDeleteDocuments(TestCase):
         self, MockZipFile, mk_document_to_delete, MockLogger, mk_delete_doc_from_kernel
     ):
         mk_document_to_delete.side_effect = self.docs_to_delete[:2] + [(False, None,)]
-        result = delete_documents(**self.kwargs)
+        result, _ = delete_documents(**self.kwargs)
         self.assertEqual(
             result,
             list(


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request permite que a task `delete_documents` da DAG `sync_documents_to_kernel` registre as operações de remoção de artigos. As operações são executadas durante o processamento de pacotes SPS.

#### Onde a revisão poderia começar?
- `airflow/dags/common/hooks.py` L: `100`

#### Como este poderia ser testado manualmente?
Para testar manualmente este pr, deve-se:
- Configurar a conexão `postgres_report_connection` no painel de administração do Airflow;
- Executar um processamento com pacotes que contenham documentos para deleção [1];
- Verificar na tabela `xml_documents` se as operações foram registradas como esperado.

#### Algum cenário de contexto que queira dar?

Este pull request também sugere um método de implementar os registros das operações. Note que dentro da função que deleta os documentos o código constrói uma lista com informações sobre sucessos e falhas para cada documento processado. O resultado ao fim do processamento é retornado para o invocador da função e neste nível o código chama a função responsável por registrar as operações.

Poderíamos ter usado outras estratégias, como por exemplo, utilizar o `xcom` como área temporária ou injetar a função de registro direto na função `delete_documents`. ~O que você acha?~

### Screenshots
N/A

#### Quais são tickets relevantes?
#77

### Referências
N/A