### PR TITLE
TK27 - Task para sincronização do Press Releases

### DIFF
--- a/airflow/dags/operations/sync_external_content_to_website_operations.py
+++ b/airflow/dags/operations/sync_external_content_to_website_operations.py
@@ -47,6 +47,34 @@ def NewsBuilder(entry: dict, language: str) -> models.News:
     return news
 
 
+def PressReleaseBuilder(entry: dict, journal: models.Journal, language: str) -> models.PressRelease:
+    """Recebe um dicionário contento informações sobre um press release e   transforma em uma instância de opac_schema.v1.models.PressRelease.
+    """
+
+    url = entry.get("id")
+
+    try:
+        press_release = models.PressRelease.objects.get(url=url)
+    except models.PressRelease.DoesNotExist:
+        press_release = models.PressRelease()
+        press_release._id = str(uuid.uuid4()).replace("-", "")
+
+    press_release.url = url
+    press_release.title = entry.get("title")
+    press_release.journal = journal
+    press_release.language = language  # esperado: 'en' | 'es' | 'pt_BR'
+    press_release.content = entry.get("summary")
+
+    try:
+        press_release.publication_date = datetime.strptime(
+            entry["published"][5:25], "%d %b %Y %X"
+        )
+    except ValueError:
+        press_release.publication_date = datetime.now()
+
+    return press_release
+
+
 @retry(
     wait=wait_exponential(),
     stop=stop_after_attempt(4),
@@ -56,7 +84,7 @@ def fetch_rss(url):
     return requests.get(url, timeout=10)
 
 
-def try_fetch_and_register_feed(rss_news_feeds: dict) -> None:
+def try_fetch_and_register_news_feed(rss_news_feeds: dict) -> None:
     """Obtém as notícias de um feed, realiza o parser do XML para dicionário
     Python e registra na base de dados do Website."""
 
@@ -89,3 +117,40 @@ def try_fetch_and_register_feed(rss_news_feeds: dict) -> None:
                 )
             else:
                 logging.info("News '%s', saved successfully.", news.title)
+
+
+def try_fetch_and_register_press_release_feed(rss_press_release: dict) -> None:
+    """Obtém os periódicos públicos e correntes na base de dados do OPAC para coleta dos Press Release no Blog.
+    """
+    for journal in models.Journal.objects.filter(is_public=True, current_status='current'):
+        for lang, feed in rss_press_release.items():
+            feed_url_by_lang = feed['url'].format(lang, journal.acronym)
+
+            try:
+                response = fetch_rss(feed_url_by_lang)
+            except RetryError as exc:
+                logging.error(
+                    "Could not fetch feed from '%s'.", feed_url_by_lang,
+                )
+                continue
+            else:
+
+                content = feedparser.parse(response.content)
+
+            if content.bozo == 1:
+                logging.error(
+                    "Could not parse feed content from '%s'. During processing this error '%s' was thrown.",
+                    feed_url_by_lang,
+                    content.bozo_exception,
+                )
+
+            for entry in content.get("entries", []):
+                try:
+                    press_release = PressReleaseBuilder(entry, journal, lang)
+                    press_release.save()
+                except ValidationError as exc:
+                    logging.error(
+                        "Could not save entry '%s', Please verify '%s'", entry, exc
+                    )
+                else:
+                    logging.info("Press Release '%s', saved successfully.", press_release.title)

--- a/airflow/dags/sync_external_content_to_website.py
+++ b/airflow/dags/sync_external_content_to_website.py
@@ -6,8 +6,8 @@ from airflow.models import Variable
 from airflow.operators.python_operator import PythonOperator
 
 from common.hooks import mongo_connect
-from operations.sync_exernal_content_to_website_operations import (
-    try_fetch_and_register_feed,
+from operations.sync_external_content_to_website_operations import (
+    try_fetch_and_register_news_feed, try_fetch_and_register_press_release_feed,
 )
 
 Logger = logging.getLogger(__name__)
@@ -41,6 +41,21 @@ RSS_NEWS_FEEDS = {
     },
 }
 
+RSS_PRESS_RELEASES_FEEDS_BY_CATEGORY = {
+    'pt_BR': {
+        'display_name': 'SciELO em Perspectiva Press Releases',
+        'url': 'http://pressreleases.scielo.org/blog/category/{1}/feed/'
+    },
+    'es': {
+        'display_name': 'SciELO en Perspectiva Press Releases',
+        'url': 'http://pressreleases.scielo.org/{0}/category/press-releases/{1}/feed/',
+    },
+    'en': {
+        'display_name': 'SciELO in Perspective Press Releases',
+        'url': 'http://pressreleases.scielo.org/{0}/category/press-releases/{1}/feed/',
+    },
+}
+
 
 def fetch_and_register_news_feed_callable(**kwargs):
     """Obtém e registra o feed de notícias do scielo em perspectiva.
@@ -53,13 +68,44 @@ def fetch_and_register_news_feed_callable(**kwargs):
         "RSS_NEWS_FEEDS", default_var=RSS_NEWS_FEEDS, deserialize_json=True
     )
 
-    try_fetch_and_register_feed(rss_news_feeds)
+    try_fetch_and_register_news_feed(rss_news_feeds)
 
 
-fetch_feed_content_task = PythonOperator(
-    task_id="fetch_feed_content_task",
+fetch_news_feed_content_task = PythonOperator(
+    task_id="fetch_news_feed_content_task",
     python_callable=fetch_and_register_news_feed_callable,
     dag=dag,
 )
 
-fetch_feed_content_task
+
+def fetch_and_register_press_release_feed_callable(**kwargs):
+    """Recupera os registros de Press Releases.
+
+    Armazena na base de dados do OPAC no modelo PressRelease.
+
+    Para obter os registro do Press Release é necessário os acrônimos dos periódicos, exemplo: ['rae', 'tce', 'acta'....].
+
+    Link do Blog do SciELO para obter os dados: https://pressreleases.scielo.org/.
+
+    Em definição com a equipe que faz a entrada dos Press Releases no Blog, será identificado os períodicos pelo acrômino e este será uma categoria no blog.
+
+    Exemplo de URL para obter o feed do periódico com acrônimo ``rae``: https://pressreleases.scielo.org/blog/category/rae/feed/
+
+    Essa tarefa garante a criação e atualização dos registro, porém não realiza qualquer deleção, portanto, é possível que tenhamos registros no site que não existam na fonte.
+    """
+    mongo_connect()
+
+    rss_press_release_feeds = Variable.get(
+        "RSS_PRESS_RELEASES_FEEDS_BY_CATEGORY", default_var=RSS_PRESS_RELEASES_FEEDS_BY_CATEGORY, deserialize_json=True
+    )
+
+    try_fetch_and_register_press_release_feed(rss_press_release_feeds)
+
+fetch_press_release_content_task = PythonOperator(
+    task_id="fetch_press_release_feed_content_task",
+    python_callable=fetch_and_register_press_release_feed_callable,
+    dag=dag,
+)
+
+
+fetch_news_feed_content_task >> fetch_press_release_content_task

--- a/airflow/tests/fixtures/rss-press-release-feed.json
+++ b/airflow/tests/fixtures/rss-press-release-feed.json
@@ -1,0 +1,86 @@
+[
+    {
+        "title": "Como os memes da internet conectam diferentes mundos?",
+        "title_detail":
+        {
+            "type": "text/plain",
+            "language": null,
+            "base": "",
+            "value": "Como os memes da internet conectam diferentes mundos?"
+        },
+        "links": [
+        {
+            "rel": "alternate",
+            "type": "text/html",
+            "href": "https://humanas.blog.scielo.org/blog/2019/11/26/como-os-memes-da-internet-conectam-diferentes-mundos/"
+        }],
+        "link": "https://humanas.blog.scielo.org/blog/2019/11/26/como-os-memes-da-internet-conectam-diferentes-mundos/",
+        "comments": "https://humanas.blog.scielo.org/blog/2019/11/26/como-os-memes-da-internet-conectam-diferentes-mundos/#respond",
+        "published": "Tue, 26 Nov 2019 17:00:40 +0000",
+        "published_parsed": [2019, 11, 26, 17, 0, 40, 1, 330, 0],
+        "authors": [
+        {
+            "name": "Maria Carolina Zanette"
+        }],
+        "author": "Maria Carolina Zanette",
+        "author_detail":
+        {
+            "name": "Maria Carolina Zanette"
+        },
+        "tags": [
+        {
+            "term": "Ci\u00eancias Sociais Aplicadas",
+            "scheme": null,
+            "label": null
+        },
+        {
+            "term": "Press Releases",
+            "scheme": null,
+            "label": null
+        },
+        {
+            "term": "RAE",
+            "scheme": null,
+            "label": null
+        },
+        {
+            "term": "Ci\u00eancias sociais",
+            "scheme": null,
+            "label": null
+        },
+        {
+            "term": "Comunica\u00e7\u00e3o",
+            "scheme": null,
+            "label": null
+        },
+        {
+            "term": "Internet",
+            "scheme": null,
+            "label": null
+        },
+        {
+            "term": "Revista de Administra\u00e7\u00e3o de Empresas",
+            "scheme": null,
+            "label": null
+        }],
+        "id": "http://pressreleases.scielo.org/?p=2246",
+        "guidislink": false,
+        "summary": "Que se destacou na internet e outras....",
+        "summary_detail":
+        {
+            "type": "text/html",
+            "language": null,
+            "base": "",
+            "value": "Fen\u00f4meno que se destacou na internet e outras m\u00eddias devido a sua populariza\u00e7\u00e3o, os memes s\u00e3o tidos como ferramenta de humor e at\u00e9 mesmo de provoca\u00e7\u00e3o. Estudo apresenta a origem e a influ\u00eancia dos memes na cultura popular e na rela\u00e7\u00e3o dos consumidores com as marcas. <span class=\"ellipsis\">&#8230;</span> <span class=\"more-link-wrap\"><a href=\"https://humanas.blog.scielo.org/blog/2019/11/26/como-os-memes-da-internet-conectam-diferentes-mundos/\" class=\"more-link\"><span>Read More &#8594;</span></a></span>"
+        },
+        "wfw_commentrss": "https://humanas.blog.scielo.org/blog/2019/11/26/como-os-memes-da-internet-conectam-diferentes-mundos/feed/",
+        "slash_comments": "0",
+        "media_content": [
+        {
+            "medium": "image",
+            "url": "https://pressreleases.scielo.org/wp-content/uploads/2017/09/rae_logo_thumb.jpg",
+            "width": "150",
+            "height": "90"
+        }]
+    }
+]

--- a/airflow/tests/test_sync_external_content_to_website.py
+++ b/airflow/tests/test_sync_external_content_to_website.py
@@ -1,12 +1,11 @@
 import os
-import json
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from opac_schema.v1 import models
 
 from .test_sync_kernel_to_website import load_json_fixture
-from dags.operations.sync_external_content_to_website_operations import NewsBuilder
+from dags.operations.sync_external_content_to_website_operations import NewsBuilder, PressReleaseBuilder
 
 FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
 
@@ -48,3 +47,36 @@ class TestNewsBuilder(unittest.TestCase):
         self.assertEqual("en", self.news_instance.language)
 
 
+class TestPressReleaseBuilder(unittest.TestCase):
+    def setUp(self):
+        self.press_release = load_json_fixture("rss-press-release-feed.json")
+        self.press_release_objects = patch(
+            "operations.sync_external_content_to_website_operations.models.PressRelease.objects"
+        )
+
+        self.new_journal = patch("operations.sync_external_content_to_website_operations.models.Journal")
+
+        PressReleaseObjectsMock = self.press_release_objects.start()
+        PressReleaseObjectsMock.get.side_effect = models.PressRelease.DoesNotExist
+
+        JournalObjectsMock = self.new_journal.start()
+        JournalObjectsMock._id = "J00001"
+        self.news_instance = PressReleaseBuilder(self.press_release[0], JournalObjectsMock, "pt_BR")
+
+    def tearDown(self):
+        self.press_release_objects.stop()
+
+    def test_press_release_instance_has_id(self):
+        self.assertIsNotNone(self.news_instance._id)
+
+    def test_press_release_instance_id_has_32_characters(self):
+        self.assertEqual(32, len(self.news_instance._id))
+
+    def test_press_release_instance_has_title(self):
+        self.assertEqual("Como os memes da internet conectam diferentes mundos?", self.news_instance.title)
+
+    def test_press_release_instance_has_description(self):
+        self.assertEqual("Que se destacou na internet e outras....", self.news_instance.content)
+
+    def test_press_release_instance_has_language(self):
+        self.assertEqual("pt_BR", self.news_instance.language)


### PR DESCRIPTION
#### O que esse PR faz?
Esse **PR** adiciona a capacidade de coletar os Press Releases do Blog do SciELO. 

#### Onde a revisão poderia começar?

Para visualizar as alteração, sugiro os seguintes módulos: 

- airflow/dags/operations/sync_external_content_to_website_operations.py
- airflow/dags/sync_external_content_to_website.py
- airflow/tests/fixtures/rss-press-release-feed.json
- airflow/tests/test_sync_external_content_to_website.py

#### Como este poderia ser testado manualmente?
É possível executando a tarefa pela interface do airflow, vejam: 

![Screenshot 2020-02-10 15 08 33](https://user-images.githubusercontent.com/373745/74176818-3972b900-4c17-11ea-9634-2b1be7995b50.png)
 
Executando os testes, estamos testando um contrutor de Press Releases(PressReleaseBuilder).

Utiliza a seguinte linha de comando para rodar os teste: 

`docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest -v`

#### Algum cenário de contexto que queira dar?

É importante ter em mente que o acrônimo é a categoria do post que identifica o periódico.

Para essa atividade a fonte dos dados é o link no seguinte formado: 

https://pressreleases.scielo.org/blog/category/rae/feed/

Aonde o segmento ``rae`` é o acrônimo do periódico.

### Screenshots

Dados já processados no **dsteste**: http://dsteste.scielo.br/journal/rae

#### Quais são tíquetes relevantes?
#27 

### Referências

Utilizei como referência a solução do tíquete: #26 