### PR TITLE
Adiciona log de processamento para registro de documentos e relacionamento de bundles

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -318,6 +318,7 @@ def get_or_create_bundle(bundle_id, is_aop):
 
 
 def update_aop_bundle_items(issn_id, documents_list):
+    executions = []
     try:
         journal_resp = hooks.kernel_connect(f"/journals/{issn_id}", "GET")
     except requests.exceptions.HTTPError as exc:
@@ -343,7 +344,14 @@ def update_aop_bundle_items(issn_id, documents_list):
                             'Movindo ex-Ahead of Print "%s" to bundle',
                             aop_item["id"],
                         )
-                update_documents_in_bundle(
-                    aop_bundle_id,
-                    updated_aop_items
-                )
+                        executions.append(
+                            {
+                                "pid": aop_item["id"],
+                                "bundle_id": aop_bundle_id,
+                                "ex_ahead": True,
+                                "removed": True,
+                            }
+                        )
+
+                update_documents_in_bundle(aop_bundle_id, updated_aop_items)
+    return executions

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -84,9 +84,16 @@ def register_update_documents(dag_run, **kwargs):
     if not _xmls_to_preserve:
         return False
 
-    _documents = sync_documents_to_kernel_operations.register_update_documents(
+    _documents, executions = sync_documents_to_kernel_operations.register_update_documents(
         _sps_package, _xmls_to_preserve
     )
+
+    for execution in executions:
+        execution["dag_run"] = kwargs.get("run_id")
+        execution["pre_sync_dag_run"] = dag_run.conf.get("pre_syn_dag_run_id")
+        execution["package_name"] = os.path.basename(_sps_package)
+        add_execution_in_database(table="xml_documents", data=execution)
+
     if _documents:
         kwargs["ti"].xcom_push(key="documents", value=_documents)
         return True

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -221,6 +221,7 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
     ):
         mk_dag_run = MagicMock()
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_link_documents.return_value = [], []
         link_documents_to_documentsbundle(**kwargs)
         mk_dag_run.conf.get.assert_called_once_with("sps_package")
 
@@ -228,6 +229,7 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
 
         kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
 
+        mk_link_documents.return_value = [], []
         link_documents_to_documentsbundle(**kwargs)
 
         kwargs["ti"].xcom_pull.assert_any_call(
@@ -237,7 +239,7 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
     def test_link_documents_to_documentsbundle_gets_ti_xcom_title_json_path(self, mk_link_documents):
 
         kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
-
+        mk_link_documents.return_value = [], []
         link_documents_to_documentsbundle(**kwargs)
 
         kwargs["ti"].xcom_pull.assert_any_call(
@@ -289,6 +291,7 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
 
         kwargs["ti"].xcom_pull.side_effect = [documents, "/json/title.json"]
 
+        mk_link_documents.return_value = [], []
         link_documents_to_documentsbundle(**kwargs)
 
         mk_link_documents.assert_called_once_with(
@@ -336,7 +339,7 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
 
         kwargs["ti"].xcom_pull.return_value = documents
 
-        mk_link_documents.return_value = pushed_documents
+        mk_link_documents.return_value = pushed_documents, []
 
         link_documents_to_documentsbundle(**kwargs)
 

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -133,6 +133,7 @@ class TestRegisterUpdateDocuments(TestCase):
     ):
         mk_dag_run = MagicMock()
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_register_update_documents.return_value = [], []
         register_update_documents(**kwargs)
         mk_dag_run.conf.get.assert_called_once_with("sps_package")
 
@@ -140,6 +141,7 @@ class TestRegisterUpdateDocuments(TestCase):
     def test_register_update_documents_gets_ti_xcom_info(self, mk_register_update_documents):
         mk_dag_run = MagicMock()
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_register_update_documents.return_value = [], []
         register_update_documents(**kwargs)
         kwargs["ti"].xcom_pull.assert_called_once_with(
             key="xmls_to_preserve", task_ids="delete_docs_task_id"
@@ -167,6 +169,7 @@ class TestRegisterUpdateDocuments(TestCase):
         mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
         kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_register_update_documents.return_value = [], []
         register_update_documents(**kwargs)
         mk_register_update_documents.assert_called_once_with(
             "path_to_sps_package/package.zip", xmls_filenames
@@ -183,7 +186,7 @@ class TestRegisterUpdateDocuments(TestCase):
         mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
         kwargs["ti"].xcom_pull.return_value = xmls_filenames
-        mk_register_update_documents.return_value = []
+        mk_register_update_documents.return_value = [], []
         register_update_documents(**kwargs)
         kwargs["ti"].xcom_push.assert_not_called()
 
@@ -202,7 +205,7 @@ class TestRegisterUpdateDocuments(TestCase):
         mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
         kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
         kwargs["ti"].xcom_pull.return_value = xmls_filenames
-        mk_register_update_documents.return_value = documents
+        mk_register_update_documents.return_value = documents, []
         register_update_documents(**kwargs)
         kwargs["ti"].xcom_push.assert_called_once_with(
             key="documents", value=documents

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -554,7 +554,7 @@ class TestRegisterUpdateDocuments(TestCase):
             None,
         ]
 
-        result = register_update_documents(**self.kwargs)
+        result, _ = register_update_documents(**self.kwargs)
         self.assertEqual(result, expected)
 
     @patch(

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -715,12 +715,11 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
             with open(issn_index_json_path, "w") as index_file:
                 index_file.write(self.issn_index_json)
 
+            result, _ = link_documents_to_documentsbundle(
+                "path_to_sps_package/package.zip", self.documents, issn_index_json_path
+            )
             self.assertEqual(
-                link_documents_to_documentsbundle(
-                    "path_to_sps_package/package.zip",
-                    self.documents,
-                    issn_index_json_path
-                ),
+                result,
                 [
                     {'id': '0034-8910-2014-v48-n2', 'status': 204},
                     {'id': '0034-8910-2014-v2-n2', 'status': 204},
@@ -753,12 +752,11 @@ class TestLinkDocumentToDocumentsbundle(TestCase):
             with open(issn_index_json_path, "w") as index_file:
                 index_file.write(self.issn_index_json)
 
+            result, _ = link_documents_to_documentsbundle(
+                "path_to_sps_package/package.zip", self.documents, issn_index_json_path
+            )
             self.assertEqual(
-                link_documents_to_documentsbundle(
-                    "path_to_sps_package/package.zip",
-                    self.documents,
-                    issn_index_json_path
-                ),
+                result,
                 [
                     {'id': '0034-8910-2014-v48-n2', 'status': 204},
                     {'id': '0034-8910-2014-v2-n2', 'status': 422},
@@ -982,7 +980,7 @@ class TestLinkDocumentToDocumentsbundleAOPs(TestCase):
         )
         mk_get_bundle_id.return_value = "0101-0101-aop"
         mk_get_or_create_bundle.side_effect = raise_exception
-        result = link_documents_to_documentsbundle(
+        result, _ = link_documents_to_documentsbundle(
             "path_to_sps_package/2019nahead.zip", self.documents[:1], "/json/index.json"
         )
         self.assertEqual(result, [{'id': '0101-0101-aop', 'status': 404}])


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request habilita o registro de log para cadastro e atualização de documentos durante a sincronização de pacotes entre o airflow e o Kernel. Também registra os vínculos entre os documentos e os documentbundles.

#### Onde a revisão poderia começar?
- c8f127814382f76cff6d8ee11bbd63da4f4f1e5e - `airflow/dags/sync_documents_to_kernel.py` L`87`
- 18bf38fd3ec40d5ccf4441374e66ae4809006db1 - `airflow/dags/sync_documents_to_kernel.py` L`117`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:

- Crie um pacote SPS com documentos mal formados (sem pid, tags quebradas, etc);
- Crie um pacote SPS com documentos bem formados;
- Registre a conexão `postgres_report_connection` no airflow;
- Crie o banco de dados e importe o sql `airflow/migrations/0001-add-execution-report-tables-202002041716.sql`;
- Execute a primeira sincronização com o pacote defeituoso;
- Execute a segunda verificação com o pacote saudável;
- Verifique no banco de dados os registros de execução para os documentos com falhas e sem falhas;

#### Algum cenário de contexto que queira dar?

Conferir o resultado após as execuções pode ser bem chato, uma maneira eficiente de conferir a quantidade de entradas de log por cada processamento é executando os SLQ:

[1] - Verifica a quantidade de execuções que não falharam (todos os pacotes);
```sql
SELECT count(id), pre_sync_dag_run
FROM xml_documents
WHERE
    failed IS false
GROUP BY pre_sync_dag_run
ORDER BY count DESC;
```

[2] - Verifica a quantidade de execuções que falharam;
```sql
SELECT count(id), pre_sync_dag_run
FROM xml_documents
WHERE
    failed IS true
GROUP BY pre_sync_dag_run
ORDER BY count DESC;
```

[3] - Verifica a quantidade de execuções por pacotes;
```sql
SELECT COUNT(id), package_name
FROM xml_documents
GROUP BY package_name ORDER BY COUNT DESC;
```

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #77

### Referências
N/A
