### PR TITLE
Inclui o passo de otimização de pacotes no fluxo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ COPY --chown=airflow:airflow ./proc ${PROC_DIR}
 
 USER root
 RUN chmod +x ${PROC_DIR}/*
+RUN pip install --upgrade pip
 
 RUN apk add --no-cache --virtual .build-deps \
-        make gcc g++ libstdc++ libxml2-dev libxslt-dev \
+        make gcc g++ libstdc++ libxml2-dev libxslt-dev jpeg-dev zlib-dev \
     && apk add libxml2 libxslt curl postgresql-dev \
     && pip install --no-cache-dir -r requirements.txt \
     && apk --purge del .build-deps

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ $ airflow webserver
 * `SCILISTA_FILE_PATH`: Caminho onde o arquivo `scilista` deverá ser lido
 * `XC_SPS_PACKAGES_DIR`: Diretório de origem dos pacotes SPS a serem sincronizados
 * `PROC_SPS_PACKAGES_DIR`: Diretório de destino dos pacotes SPS a serem sincronizados
+* `NEW_SPS_ZIP_DIR`: Diretório de destino dos pacotes SPS otimizados
 
 
 ## Variáveis de ambiente:

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -122,16 +122,21 @@ def delete_documents(
 
 
 def optimize_sps_pkg_zip_file(sps_pkg_zip_file):
+    """
+    Recebe um zip `sps_pkg_zip_file` e
+    Retorna seu zip otimizado `new_sps_pkg_zip_file`
+    """
     Logger.debug("optimize_sps_pkg_zip_file IN")
-    basename = os.path.basename(sps_package)
+    basename = os.path.basename(sps_pkg_zip_file)
     new_sps_pkg_zip_file = os.path.join(mkdtemp(), basename)
 
-    tmp_dir = mkdtemp()
-    package = SPPackage.from_file(sps_pkg_zip_file, tmp_dir)
-    package.optimise(
-        new_package_file_path=new_sps_pkg_zip_file,
-        preserve_files=False
-    )
+    with ZipFile(sps_pkg_zip_file) as zipfile:
+        tmp_dir = mkdtemp()
+        package = SPPackage.from_file(zipfile, tmp_dir)
+        package.optimise(
+            new_package_file_path=new_sps_pkg_zip_file,
+            preserve_files=False
+        )
     Logger.debug("optimize_sps_pkg_zip_file OUT")
     return new_sps_pkg_zip_file
 

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -137,7 +137,8 @@ def optimize_sps_pkg_zip_file(sps_pkg_zip_file):
         preserve_files=False
     )
     Logger.debug("optimize_sps_pkg_zip_file OUT")
-    return new_sps_pkg_zip_file
+    if os.path.isfile(new_sps_pkg_zip_file):
+        return new_sps_pkg_zip_file
 
 
 def register_update_documents(sps_package, xmls_to_preserve):

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -135,9 +135,12 @@ def optimize_sps_pkg_zip_file(sps_pkg_zip_file, new_sps_zip_dir):
         new_package_file_path=new_sps_pkg_zip_file,
         preserve_files=False
     )
-    Logger.debug("optimize_sps_pkg_zip_file OUT")
+
     if os.path.isfile(new_sps_pkg_zip_file):
+        Logger.debug("optimize_sps_pkg_zip_file OUT")
         return new_sps_pkg_zip_file
+
+    Logger.debug("optimize_sps_pkg_zip_file OUT")
 
 
 def register_update_documents(sps_package, xmls_to_preserve):

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -130,13 +130,12 @@ def optimize_sps_pkg_zip_file(sps_pkg_zip_file):
     basename = os.path.basename(sps_pkg_zip_file)
     new_sps_pkg_zip_file = os.path.join(mkdtemp(), basename)
 
-    with ZipFile(sps_pkg_zip_file) as zipfile:
-        tmp_dir = mkdtemp()
-        package = SPPackage.from_file(zipfile, tmp_dir)
-        package.optimise(
-            new_package_file_path=new_sps_pkg_zip_file,
-            preserve_files=False
-        )
+    tmp_dir = mkdtemp()
+    package = SPPackage.from_file(sps_pkg_zip_file, tmp_dir)
+    package.optimise(
+        new_package_file_path=new_sps_pkg_zip_file,
+        preserve_files=False
+    )
     Logger.debug("optimize_sps_pkg_zip_file OUT")
     return new_sps_pkg_zip_file
 

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -121,17 +121,16 @@ def delete_documents(
     return (list(set(xmls_filenames) - set(xmls_to_delete)), executions)
 
 
-def optimize_sps_pkg_zip_file(sps_pkg_zip_file):
+def optimize_sps_pkg_zip_file(sps_pkg_zip_file, new_sps_zip_dir):
     """
     Recebe um zip `sps_pkg_zip_file` e
     Retorna seu zip otimizado `new_sps_pkg_zip_file`
     """
     Logger.debug("optimize_sps_pkg_zip_file IN")
     basename = os.path.basename(sps_pkg_zip_file)
-    new_sps_pkg_zip_file = os.path.join(mkdtemp(), basename)
+    new_sps_pkg_zip_file = os.path.join(new_sps_zip_dir, basename)
 
-    tmp_dir = mkdtemp()
-    package = SPPackage.from_file(sps_pkg_zip_file, tmp_dir)
+    package = SPPackage.from_file(sps_pkg_zip_file, mkdtemp())
     package.optimise(
         new_package_file_path=new_sps_pkg_zip_file,
         preserve_files=False

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -1,6 +1,8 @@
 import os
 import logging
 import json
+from tempfile import mkdtemp
+from packtools import SPPackage
 from zipfile import ZipFile
 from copy import deepcopy
 from typing import Dict, List, Tuple
@@ -119,6 +121,21 @@ def delete_documents(
     return (list(set(xmls_filenames) - set(xmls_to_delete)), executions)
 
 
+def optimize_sps_pkg_zip_file(sps_pkg_zip_file):
+    Logger.debug("optimize_sps_pkg_zip_file IN")
+    basename = os.path.basename(sps_package)
+    new_sps_pkg_zip_file = os.path.join(mkdtemp(), basename)
+
+    tmp_dir = mkdtemp()
+    package = SPPackage.from_file(sps_pkg_zip_file, tmp_dir)
+    package.optimise(
+        new_package_file_path=new_sps_pkg_zip_file,
+        preserve_files=False
+    )
+    Logger.debug("optimize_sps_pkg_zip_file OUT")
+    return new_sps_pkg_zip_file
+
+
 def register_update_documents(sps_package, xmls_to_preserve):
     """
     Registra/atualiza documentos informados e seus respectivos ativos digitais e
@@ -131,6 +148,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
 
     Logger.debug("register_update_documents IN")
     with ZipFile(sps_package) as zipfile:
+
         synchronized_docs_metadata = []
         for i, xml_filename in enumerate(xmls_to_preserve):
             Logger.info(

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -80,13 +80,13 @@ def delete_documents(dag_run, **kwargs):
 
 def optimize_package(dag_run, **kwargs):
     _sps_package = dag_run.conf.get("sps_package")
-    new_sps_zip_dir = Variable.get("NEW_SPS_ZIP_DIR", mkdtemp())
     _xmls_to_preserve = kwargs["ti"].xcom_pull(
         key="xmls_to_preserve", task_ids="delete_docs_task_id"
     )
     if not _xmls_to_preserve:
         return False
 
+    new_sps_zip_dir = Variable.get("NEW_SPS_ZIP_DIR", mkdtemp())
     _optimized_package = sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file(
         _sps_package, new_sps_zip_dir
     )

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -96,6 +96,7 @@ def optimize_package(dag_run, **kwargs):
 
 
 def register_update_documents(dag_run, **kwargs):
+
     _xmls_to_preserve = kwargs["ti"].xcom_pull(
         key="xmls_to_preserve", task_ids="delete_docs_task_id"
     )
@@ -105,11 +106,10 @@ def register_update_documents(dag_run, **kwargs):
     _optimized_package = kwargs["ti"].xcom_pull(
         key="optimized_package", task_ids="optimize_package_task_id"
     )
-    if not _optimized_package:
-        return False
 
+    package = _optimized_package or dag_run.conf.get("sps_package")
     _documents, executions = sync_documents_to_kernel_operations.register_update_documents(
-        _optimized_package, _xmls_to_preserve
+        package, _xmls_to_preserve
     )
 
     for execution in executions:

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -159,4 +159,7 @@ link_documents_task = ShortCircuitOperator(
     dag=dag,
 )
 
-list_documents_task >> delete_documents_task >> register_update_documents_task >> link_documents_task
+list_documents_task >> delete_documents_task
+delete_documents_task >> register_update_documents_task
+register_update_documents_task >> link_documents_task
+

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -186,6 +186,7 @@ link_documents_task = ShortCircuitOperator(
 )
 
 list_documents_task >> delete_documents_task
-delete_documents_task >> register_update_documents_task
+delete_documents_task >> optimize_package_task
+optimize_package_task >> register_update_documents_task
 register_update_documents_task >> link_documents_task
 

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -76,6 +76,25 @@ def delete_documents(dag_run, **kwargs):
         return False
 
 
+def optimize_package(dag_run, **kwargs):
+    _sps_package = dag_run.conf.get("sps_package")
+    _xmls_to_preserve = kwargs["ti"].xcom_pull(
+        key="xmls_to_preserve", task_ids="delete_docs_task_id"
+    )
+    if not _xmls_to_preserve:
+        return False
+
+    _optimized_package = sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file(
+        _sps_package
+    )
+    if _optimized_package:
+        kwargs["ti"].xcom_push(
+            key="optimized_package", value=_optimized_package)
+        return True
+    else:
+        return False
+
+
 def register_update_documents(dag_run, **kwargs):
     _sps_package = dag_run.conf.get("sps_package")
     _xmls_to_preserve = kwargs["ti"].xcom_pull(
@@ -142,6 +161,13 @@ delete_documents_task = ShortCircuitOperator(
     task_id="delete_docs_task_id",
     provide_context=True,
     python_callable=delete_documents,
+    dag=dag,
+)
+
+optimize_package_task = ShortCircuitOperator(
+    task_id="optimize_package_task_id",
+    provide_context=True,
+    python_callable=optimize_package,
     dag=dag,
 )
 

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -370,5 +370,15 @@ class TestOptimizeDocuments(TestCase):
             key="xmls_to_preserve", task_ids="delete_docs_task_id"
         )
 
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
+    def test_optimize_package_does_not_call_optimize_package_operation(self, mk_optimize_package):
+        mk_dag_run = MagicMock()
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = None
+        optimize_package(**kwargs)
+        mk_optimize_package.assert_not_called()
+        kwargs["ti"].xcom_push.assert_not_called()
+
+
 if __name__ == "__main__":
     main()

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -360,6 +360,15 @@ class TestOptimizeDocuments(TestCase):
         optimize_package(**kwargs)
         mk_dag_run.conf.get.assert_called_once_with("sps_package")
 
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
+    def test_optimize_package_gets_ti_xcom_info(self, mk_optimize_package):
+        mk_dag_run = MagicMock()
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_optimize_package.return_value = [], []
+        optimize_package(**kwargs)
+        kwargs["ti"].xcom_pull.assert_called_once_with(
+            key="xmls_to_preserve", task_ids="delete_docs_task_id"
+        )
 
 if __name__ == "__main__":
     main()

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -8,6 +8,7 @@ from sync_documents_to_kernel import (
     delete_documents,
     register_update_documents,
     link_documents_to_documentsbundle,
+    optimize_package,
 )
 
 
@@ -346,6 +347,18 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
         kwargs["ti"].xcom_push.assert_called_once_with(
             key="linked_bundle", value=pushed_documents
         )
+
+
+class TestOptimizeDocuments(TestCase):
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
+    def test_optimize_package_gets_sps_package_from_dag_run_conf(
+        self, mk_optimize_package
+    ):
+        mk_dag_run = MagicMock()
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        mk_optimize_package.return_value = [], []
+        optimize_package(**kwargs)
+        mk_dag_run.conf.get.assert_called_once_with("sps_package")
 
 
 if __name__ == "__main__":

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -398,6 +398,21 @@ class TestOptimizeDocuments(TestCase):
             "path_to_sps_package/package.zip"
         )
 
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
+    def test_optimize_package_does_not_push_if_none_was_optimized(self, mk_optimize_package):
+        xmls_filenames = [
+            "1806-907X-rba-53-01-1-8.xml",
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        mk_dag_run = MagicMock()
+        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_optimize_package.return_value = None
+        optimize_package(**kwargs)
+        kwargs["ti"].xcom_push.assert_not_called()
+
 
 if __name__ == "__main__":
     main()

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -413,6 +413,24 @@ class TestOptimizeDocuments(TestCase):
         optimize_package(**kwargs)
         kwargs["ti"].xcom_push.assert_not_called()
 
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
+    def test_optimize_package_pushes_optimized_package(self, mk_optimize_package):
+        xmls_filenames = [
+            "1806-907X-rba-53-01-1-8.xml",
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        
+        mk_dag_run = MagicMock()
+        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_optimize_package.return_value = "path_to_otimized_package/package.zip"
+        optimize_package(**kwargs)
+        kwargs["ti"].xcom_push.assert_called_once_with(
+            key="optimized_package", value="path_to_otimized_package/package.zip"
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -379,6 +379,25 @@ class TestOptimizeDocuments(TestCase):
         mk_optimize_package.assert_not_called()
         kwargs["ti"].xcom_push.assert_not_called()
 
+    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
+    def test_optimize_package_calls_optimize_package_operation(
+        self, mk_optimize_package
+    ):
+        xmls_filenames = [
+            "1806-907X-rba-53-01-1-8.xml",
+            "1806-907X-rba-53-01-9-18.xml",
+            "1806-907X-rba-53-01-19-25.xml",
+        ]
+        mk_dag_run = MagicMock()
+        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        mk_optimize_package.return_value = "path_to_otimized_package/package.zip"
+        optimize_package(**kwargs)
+        mk_optimize_package.assert_called_once_with(
+            "path_to_sps_package/package.zip"
+        )
+
 
 if __name__ == "__main__":
     main()

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -1030,9 +1030,10 @@ class TestOptimizeSPPackage(TestCase):
         mock_package = Mock("package")
         mock_package.optimise = mock_optimise
         MockSPPackage.from_file.return_value = mock_package
+        new_sps_zip_dir = mkdtemp()
 
-        ret = optimize_sps_pkg_zip_file("dir/destination/rba_v53n1.zip")
-        assert ret.endswith("/rba_v53n1.zip") and ret != "dir/destination/rba_v53n1.zip"
+        ret = optimize_sps_pkg_zip_file("dir/destination/rba_v53n1.zip", new_sps_zip_dir)
+        self.assertEqual(ret, os.path.join(new_sps_zip_dir, "rba_v53n1.zip"))
 
 
 if __name__ == "__main__":

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -1015,12 +1015,15 @@ class TestOptimizeSPPackage(TestCase):
     @patch("operations.sync_documents_to_kernel_operations.ZipFile")
     @patch("operations.sync_documents_to_kernel_operations.Logger")
     @patch("operations.sync_documents_to_kernel_operations.SPPackage")
+    @patch("operations.sync_documents_to_kernel_operations.os.path.isfile")
     def test_optimize_sps_pkg_zip_file_write_log_messages_in_and_out(
         self,
+        mock_isfile,
         MockSPPackage,
         MockLogger,
         MockZipFile,
     ):
+        mock_isfile.return_value = True
         MockZipFile = mock_open
         mock_optimise = Mock("optimise")
         mock_optimise.return_value = None

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 cmd="$@"
 
+
 if [ -z "$POSTGRES_USER" ]; then
     export POSTGRES_USER=postgres_user
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pymongo==3.9.0
 deepdiff[murmur]==4.0.7
 feedparser==5.2.1
 git+https://github.com/scieloorg/opac_schema.git@master#egg=opac_schema
+git+https://github.com/scieloorg/packtools.git@2.6.0#egg=packtools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 apache-airflow[s3,postgres]==01.10.4
-xylose==1.35.1
-lxml==4.3.4
+lxml==4.5
 pymongo==3.9.0
 deepdiff[murmur]==4.0.7
 feedparser==5.2.1
-git+https://github.com/scieloorg/opac_schema.git@master#egg=opac_schema
+git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
+git+https://github.com/scieloorg/opac_schema.git@v2.54#egg=opac_schema
 git+https://github.com/scieloorg/packtools.git@2.6.0#egg=packtools


### PR DESCRIPTION
#### O que esse PR faz?
Inclui o passo de otimização de pacotes no fluxo entre "deletar documentos" e "registrar documentos"

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
1. Passos pré teste:
  - Obtenha um pacote SPS com ativos digitais (imagens) não otimizados [1];
  - Obtenha um pacote SPS com ativos digitais já otimizados [2];
  - Obtenha um pacote SPS contendo apenas documentos para deleção;
  - Crie uma scilista com os dois pacotes obtidos anteriormente;
  - Execute a dag `pre_sync_documents_to_kernel`;
  - Observe as execuções dos dois pacotes na dag `sync_documents_to_kernel`;
2. Teste com o pacote a ser otimizado:
  - Observe que para o pacote não otimizado [1] a task `optimize_package_task_id` é executada e um novo arquivo `zip` é gerado;
  - Observe que após o termino da task `optimize_package_task_id`, o caminho para arquivo `zip` gerado é passado pasado para a task `register_update_documents_task_id`;
  - **Bônus**: Pode-se observar que os ativos digitais otimizados estão registrados no `minio` e também no `kernel`;
3. Teste com pacote sem otimizações:
  - Observe que após o termino da task `optimize_package_task_id` a task de registro de documentos utiliza o caminho do pacote originalmente processado pela task de deleção.
4. Teste com pacote contendo apenas documentos para deleção [3]:
  - Observe que a task de otimização de pacotes não é executada;

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#157

### Referências
n/a