### PR TITLE
Adiciona capacidade de atualização de periódicos no sync p/ o site

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -285,7 +285,11 @@ def JournalFactory(data):
     """
     metadata = data["metadata"]
 
-    journal = models.Journal()
+    try:
+        journal = models.Journal.objects.get(_id=data.get("id"))
+    except models.Journal.DoesNotExist:
+        journal = models.Journal()
+
     journal._id = journal.jid = data.get("id")
     journal.title = metadata.get("title", "")
     journal.title_iso = metadata.get("title_iso", "")
@@ -343,7 +347,8 @@ def JournalFactory(data):
             journal.publisher_country = institution.get("country")
 
     journal.online_submission_url = metadata.get("online_submission_url", "")
-    journal.logo_url = metadata.get("logo_url", "")
+    if journal.logo_url is None or len(journal.logo_url) == 0:
+        journal.logo_url = metadata.get("logo_url", "")
     journal.current_status = metadata.get("status", {}).get("status")
 
     journal.created = data.get("created", "")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -25,6 +25,9 @@ def load_json_fixture(filename):
 
 class JournalFactoryTests(unittest.TestCase):
     def setUp(self):
+        self.journal_objects = patch("sync_kernel_to_website.models.Journal.objects")
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.side_effect = models.Journal.DoesNotExist
         self.journal_data = load_json_fixture("kernel-journals-1678-4464.json")
         self.journal = JournalFactory(self.journal_data)
 
@@ -103,6 +106,22 @@ class JournalFactoryTests(unittest.TestCase):
 
     def test_attribute_updated(self):
         self.assertEqual(self.journal.updated, "2019-07-19T20:33:17.102106Z")
+
+
+class JournalFactoryExistsInWebsiteTests(unittest.TestCase):
+    def setUp(self):
+        self.journal_objects = patch(
+            "operations.sync_kernel_to_website_operations.models.Journal.objects"
+        )
+        MockJournal = MagicMock(spec=models.Journal)
+        MockJournal.logo_url = "/media/images/glogo.gif"
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = MockJournal
+        self.journal_data = load_json_fixture("kernel-journals-1678-4464.json")
+        self.journal = JournalFactory(self.journal_data)
+
+    def test_preserves_logo_if_already_set(self):
+        self.assertEqual(self.journal.logo_url, "/media/images/glogo.gif")
 
 
 class ArticleFactoryTests(unittest.TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a capacidade de atualização de periódicos já migrados sincronizados do site. Esta necessidade foi detectada por conta da migração de logos dos periódicos mas há outros campos que podem ser alterados via admin do site. Aqui estamos tratando em específico somente a URL do logo, para que não seja sobrescrito em uma futura atualização dos dados do
periódico.

#### Onde a revisão poderia começar?
Em `airflow/dags/sync_kernel_to_website.py`.

#### Como este poderia ser testado manualmente?
- Execute o `sync_kernel_to_website`
- Acesse o admin do site e altere a URL do logo de um periódico
- Execute o `sync_kernel_to_website` novamente
- O periódico deve estar com a URL do logo sem alteração

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/document-store-migracao/issues/123

### Referências
.