### PR TITLE
Corrige erro durante atualização dos bundles no Website

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -428,10 +428,12 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
         issue.number = metadata.get("number", issue.number)
 
     issue.volume = metadata.get("volume", "")
-    issue.order = metadata.get("order", 0)
+
+    if issue_order:
+        issue.order = issue_order
+
     issue.pid = metadata.get("pid", "")
     issue.journal = models.Journal.objects.get(_id=journal_id)
-    issue.order = issue_order
 
     def _get_issue_label(metadata: dict) -> str:
         """Produz o label esperado pelo OPAC de acordo com as regras aplicadas


### PR DESCRIPTION
#### O que esse PR faz?

Corrige a atualização do campo `order` dos bundles durante a execução da dag `sync_kernel_to_website`.

#### Onde a revisão poderia começar?

- `airflow/dags/sync_kernel_to_website.py` L: `431`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Crie um journal `curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json' http://0.0.0.0:6543/journals/journal-de-teste -d {}`
- Crie um bundle `curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json'  http://0.0.0.0:6543/bundles/bundle-de-teste -d '{}'`;
- Relacione o bundle com o journal `curl -X PUT -H 'Accept: application/json' -H 'Content-Type: application/json'  http://0.0.0.0:6543/journals/journal-de-teste/issues -d '[{"id": "bundle-de-teste", "year": "2020", "order": "1"}]'`;
- Execute a dag `sync_kernel_to_website`;
- Verifique que na base do `opac` a issue criada com o order `1`;
- Atualize o issue `curl -X PATCH -H 'Accept: application/json' -H 'Content-Type: application/json'  http://0.0.0.0:6543/bundles/bundle-de-teste -d '{"volume": "1"}' `;
- Execute a dag `sync_kernel_to_website`;
- Verifique que o `order` foi mantido na base `opac`;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A