### PR TITLE
Atribuição de datas de criação e atualização de Fascículos e Artigos p/ o site

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Iterable, Generator, Dict, List, Tuple
 
 import requests
@@ -248,6 +249,9 @@ def ArticleFactory(
 
     # Campo de compatibilidade do OPAC
     article.htmls = [{"lang": lang} for lang in _get_languages(data)]
+
+    article.created = article.created or datetime.utcnow().isoformat()
+    article.updated = datetime.utcnow().isoformat()
 
     return article
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -477,6 +477,9 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
     else:
         issue.type = _type
 
+    issue.created = data.get("created", "")
+    issue.updated = data.get("updated", "")
+
     return issue
 
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -285,8 +285,12 @@ def JournalFactory(data):
     """
     metadata = data["metadata"]
 
-    journal = models.Journal()
-    journal._id = journal.jid = data.get("id")
+    try:
+        journal = models.Journal.objects.get(_id=data.get("id"))
+    except models.Journal.DoesNotExist:
+        journal = models.Journal()
+        journal._id = journal.jid = data.get("id")
+
     journal.title = metadata.get("title", "")
     journal.title_iso = metadata.get("title_iso", "")
     journal.short_title = metadata.get("short_title", "")
@@ -343,7 +347,8 @@ def JournalFactory(data):
             journal.publisher_country = institution.get("country")
 
     journal.online_submission_url = metadata.get("online_submission_url", "")
-    journal.logo_url = metadata.get("logo_url", "")
+    if journal.logo_url is None or len(journal.logo_url) == 0:
+        journal.logo_url = metadata.get("logo_url", "")
     journal.current_status = metadata.get("status", {}).get("status")
 
     journal.created = data.get("created", "")

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -417,8 +417,8 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
 
     issue._id = issue.iid = data["id"]
     issue.spe_text = metadata.get("spe_text", "")
-    issue.start_month = metadata.get("publication_month", 0)
-    issue.end_month = metadata.get("publication_season", [0])[-1]
+    issue.start_month = metadata.get("publication_months", {"range": [0, 0]}).get("range", [0])[0]
+    issue.end_month = metadata.get("publication_months", {"range": [0, 0]}).get("range", [0])[-1]
 
     if _type == "ahead":
         issue.year = issue.year or "9999"

--- a/airflow/tests/fixtures/kernel-issues-0001-3714-1998-v29-n3.json
+++ b/airflow/tests/fixtures/kernel-issues-0001-3714-1998-v29-n3.json
@@ -1,0 +1,84 @@
+{
+    "_id": "0001-3714-1998-v29-n3",
+    "created": "1998-09-01T00:00:00.000000Z",
+    "updated": "2020-04-28T20:16:24.459467Z",
+    "items": [
+        {
+            "id": "bZX7rgXBcGQvrnDTmzbWzcT",
+            "order": "00208"
+        },
+        {
+            "id": "ccR6t3WVJ5zBjF8rjHHNF3y",
+            "order": "00228"
+        },
+        {
+            "id": "jNwCMvMDT9ZNKLKwKDd6pSJ",
+            "order": "00164"
+        },
+        {
+            "id": "dYJ4tzVhD3sNsbkRV6GgWHB",
+            "order": "00222"
+        },
+        {
+            "id": "8zSJvZ4fvBcFyn594CwyHQG",
+            "order": "00187"
+        },
+        {
+            "id": "MP6KG3V8rMsPwFKr4XPyCfG",
+            "order": "00197"
+        },
+        {
+            "id": "ycHKbKpGhmVbM3fjT8xLXHQ",
+            "order": "00213"
+        },
+        {
+            "id": "yMbDgprf3JrhS3fckGndyhy",
+            "order": "00183"
+        },
+        {
+            "id": "SDqNBws9vPCNxfNcsJfpqKL",
+            "order": "00167"
+        },
+        {
+            "id": "bYyxrmzfVh6PdMkp7vDBPwg",
+            "order": "00159"
+        },
+        {
+            "id": "NyQMYVKpfqQwyYjt7cm69jz",
+            "order": "00202"
+        },
+        {
+            "id": "Q7dtb49KL5S4KfrQKqPh7hc",
+            "order": "00219"
+        },
+        {
+            "id": "HsThZj7D5dNP55tRQwq8ynf",
+            "order": "00193"
+        },
+        {
+            "id": "k54PVgjsVYS4rwLXnhxQcZN",
+            "order": "00174"
+        },
+        {
+            "id": "zg9M58b9Z7bCQ9hwMjSdx6B",
+            "order": "00170"
+        },
+        {
+            "id": "gZ4wYHT3rDDxTvfk9hKmvTJ",
+            "order": "00179"
+        }
+    ],
+    "metadata": {
+        "publication_year": "1998",
+        "volume": "29",
+        "number": "3",
+        "publication_months": {
+            "range": [
+                9,
+                9
+            ]
+        },
+        "pid": "0001-371419980003"
+    },
+    "id": "0001-3714-1998-v29-n3"
+}

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -190,6 +190,12 @@ class IssueFactoryTests(unittest.TestCase):
     def test_attribute_type(self):
         self.assertEqual(self.issue.type, "regular")
 
+    def test_attribute_created(self):
+        self.assertEqual(self.issue.created, "1998-09-01T00:00:00.000000Z")
+
+    def test_attribute_updated(self):
+        self.assertEqual(self.issue.updated, "2020-04-28T20:16:24.459467Z")
+
     def test_attribute_is_public(self):
         self.assertTrue(self.issue.is_public)
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -25,6 +25,11 @@ def load_json_fixture(filename):
 
 class JournalFactoryTests(unittest.TestCase):
     def setUp(self):
+        self.journal_objects = patch(
+            "operations.sync_kernel_to_website_operations.models.Journal.objects"
+        )
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.side_effect = models.Journal.DoesNotExist
         self.journal_data = load_json_fixture("kernel-journals-1678-4464.json")
         self.journal = JournalFactory(self.journal_data)
 
@@ -103,6 +108,22 @@ class JournalFactoryTests(unittest.TestCase):
 
     def test_attribute_updated(self):
         self.assertEqual(self.journal.updated, "2019-07-19T20:33:17.102106Z")
+
+
+class JournalFactoryExistsInWebsiteTests(unittest.TestCase):
+    def setUp(self):
+        self.journal_objects = patch(
+            "operations.sync_kernel_to_website_operations.models.Journal.objects"
+        )
+        MockJournal = MagicMock(spec=models.Journal)
+        MockJournal.logo_url = "/media/images/glogo.gif"
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = MockJournal
+        self.journal_data = load_json_fixture("kernel-journals-1678-4464.json")
+        self.journal = JournalFactory(self.journal_data)
+
+    def test_preserves_logo_if_already_set(self):
+        self.assertEqual(self.journal.logo_url, "/media/images/glogo.gif")
 
 
 class ArticleFactoryTests(unittest.TestCase):

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -314,6 +314,14 @@ class ArticleFactoryTests(unittest.TestCase):
     def test_htmls_attibutes_should_be_populated_with_documents_languages(self):
         self.assertEqual([{"lang": "en"}, {"lang": "pt"}], self.document.htmls)
 
+    def test_has_created_attribute(self):
+        self.assertTrue(hasattr(self.document, "created"))
+        self.assertIsNotNone(self.document.created)
+
+    def test_has_updated_attribute(self):
+        self.assertTrue(hasattr(self.document, "updated"))
+        self.assertIsNotNone(self.document.updated)
+
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -124,6 +124,76 @@ class JournalFactoryExistsInWebsiteTests(unittest.TestCase):
         self.assertEqual(self.journal.logo_url, "/media/images/glogo.gif")
 
 
+class IssueFactoryTests(unittest.TestCase):
+    def setUp(self):
+        self.mongo_connect_mock = patch(
+            "sync_kernel_to_website.mongo_connect"
+        )
+        self.mongo_connect_mock.start()
+        self.journal_objects = patch(
+            "sync_kernel_to_website.models.Journal.objects"
+        )
+        self.MockJournal = MagicMock(spec=models.Journal)
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = self.MockJournal
+        self.issue_objects = patch("sync_kernel_to_website.models.Issue.objects")
+        IssueObjectsMock = self.issue_objects.start()
+        IssueObjectsMock.get.side_effect = models.Issue.DoesNotExist
+
+        self.issue_data = load_json_fixture("kernel-issues-0001-3714-1998-v29-n3.json")
+        self.issue = IssueFactory(self.issue_data, "0001-3714", "12345")
+
+    def tearDown(self):
+        self.mongo_connect_mock.stop()
+        self.journal_objects.stop()
+        self.issue_objects.stop()
+
+    def test_has_method_save(self):
+        self.assertTrue(hasattr(self.issue, "save"))
+
+    def test_attribute_mongodb_id(self):
+        self.assertEqual(self.issue._id, "0001-3714-1998-v29-n3")
+
+    def test_attribute_journal(self):
+        self.assertEqual(self.issue.journal, self.MockJournal)
+
+    def test_attribute_spe_text(self):
+        self.assertEqual(self.issue.spe_text, "")
+
+    def test_attribute_start_month(self):
+        self.assertEqual(self.issue.start_month, 9)
+
+    def test_attribute_end_month(self):
+        self.assertEqual(self.issue.end_month, 9)
+
+    def test_attribute_year(self):
+        self.assertEqual(self.issue.year, "1998")
+
+    def test_attribute_number(self):
+        self.assertEqual(self.issue.number, "3")
+
+    def test_attribute_volume(self):
+        self.assertEqual(self.issue.volume, "29")
+
+    def test_attribute_order(self):
+        self.assertEqual(self.issue.order, "12345")
+
+    def test_attribute_pid(self):
+        self.assertEqual(self.issue.pid, "0001-371419980003")
+
+    def test_attribute_label(self):
+        self.assertEqual(self.issue.label, "v29n3")
+
+    def test_attribute_suppl_text(self):
+        self.assertIsNone(self.issue.suppl_text)
+
+    def test_attribute_type(self):
+        self.assertEqual(self.issue.type, "regular")
+
+    def test_attribute_is_public(self):
+        self.assertTrue(self.issue.is_public)
+
+
 class ArticleFactoryTests(unittest.TestCase):
     def setUp(self):
         self.article_objects = patch(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona a atribuição das datas de criação e atualização em metadados sincronizados de Fascículos e Artigos do Kernel para o site.
Também foi corrigida atribuição de período de publicação do fascículo, que foi alterado no Kernel.

#### Onde a revisão poderia começar?
Em `airflow/dags/sync_kernel_to_website.py`, L480, na atribuição das datas em fascículos.

#### Como este poderia ser testado manualmente?
1. Execute a DAG `sync_isis_to_kernel`
2. Execute a sincronização de documentos para o Kernel
3. Execute a DAG `sync_kernel_to_website`
4. Verifique os dados da coleção `issue` e `article` na base `opac` do MongoDB. Os campos `created` e `updated` devem estar preenchidos
5. Acesse o `admin` da instância do site novo. Os catálogos `Números` e `Artigo` devem ser acessados sem problema.

#### Algum cenário de contexto que queira dar?
Apesar dos campos não serem obrigatórios no OPAC_SCHEMA, são usados hoje na renderização das páginas do admin, que serão acessadas para a administração das publicações no site.

### Screenshots
n/a

#### Quais são tickets relevantes?
#163 

### Referências
.