### PR TITLE
Adiciona operador para iniciar a sincronização de documentos após o espelhamento das bases ISIS

### DIFF
--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -12,6 +12,7 @@ from airflow import DAG
 from airflow.models import Variable
 from airflow.operators.bash_operator import BashOperator
 from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.hooks.http_hook import HttpHook
 from airflow.exceptions import AirflowException
 from xylose.scielodocument import Journal, Issue
@@ -534,6 +535,12 @@ link_journals_and_issues_task = PythonOperator(
 )
 
 
+trigger_pre_sync_documents_to_kernel_dag_task = TriggerDagRunOperator(
+    task_id="trigger_pre_sync_documents_to_kernel_dag_task",
+    trigger_dag_id="pre_sync_documents_to_kernel",
+    dag=dag,
+)
+
 create_work_folders_task >> copy_mst_bases_to_work_folder_task >> extract_title_task
 extract_title_task >> extract_issue_task >> process_journals_task >> process_issues_task
-process_issues_task >> link_journals_and_issues_task
+process_issues_task >> link_journals_and_issues_task >> trigger_pre_sync_documents_to_kernel_dag_task


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request implementa o requisito de funcionalidade descrito pela issue #167.

#### Onde a revisão poderia começar?
- `airflow/dags/sync_isis_to_kernel.py` L: `536`

#### Como este poderia ser testado manualmente?
Para testar este pull request manualmente, deve-se:
- Iniciar a execução da DAG `sync_isis_to_kernel`;
- Observar a execução de `trigger_pre_sync_documents_to_kernel_dag_task` após a task de `link_journals_and_issues_task`;
- Observar que a DAG `pre_sync_documents_to_kernel` foi iniciada;
- SE a SciLISTA possuir pacotes novos, então, a DAG `sync_documents_to_kernel` deve ser executada;

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
closes #167 

### Referências

- [DAG Run Operator](https://github.com/apache/airflow/blob/master/airflow/operators/dagrun_operator.py)