### PR TITLE
Altera pré sync de documentos p/ considerar timestamp em nomes de pacote

### DIFF
--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -8,7 +8,9 @@ Logger = logging.getLogger(__name__)
 
 def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
     """
-    Obtém Pacotes SPS através da Scilista, movendo os pacotes para o diretório de processamento do Airflow e gera lista dos paths dos pacotes SPS no diretório de processamento.
+    Obtém Pacotes SPS através da Scilista, movendo os pacotes para o diretório de 
+    processamento do Airflow e gera lista dos paths dos pacotes SPS no diretório de 
+    processamento.
 
     list scilista: lista com as linhas do arquivo scilista.lst
         rsp v10n4
@@ -25,14 +27,12 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
 
     with open(scilista_file_path) as scilista:
         for acron_issue in scilista.readlines():
-            zip_filename = "{}.zip".format("_".join(acron_issue.split()))
-            source = xc_dir_path / zip_filename
-            destination = proc_dir_path / zip_filename
-            Logger.info("Reading ZIP file: %s" % str(source))
-            if os.path.exists(str(source)):
-                Logger.info("Moving %s to %s" % (str(source), str(destination)))
-                shutil.move(str(source), str(destination))
-                sps_packages_list.append(str(destination))
+            filename_pattern = "*{}.zip".format("_".join(acron_issue.split()))
+            Logger.info("Reading ZIP files pattern: %s", filename_pattern)
+            for source in sorted(xc_dir_path.glob(filename_pattern)):
+                Logger.info("Moving %s to %s", str(source), str(proc_dir_path))
+                shutil.move(str(source), str(proc_dir_path))
+                sps_packages_list.append(str(proc_dir_path / source.name))
 
     Logger.debug("get_sps_packages OUT")
     return sps_packages_list

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -39,13 +39,16 @@ class TestGetSPSPackages(TestCase):
         with scilista_file_path.open("w") as scilista_file:
             for line in scilista_lines:
                 scilista_file.write(line + "\n")
-                source_filenames.append("_".join(line.split()) + ".zip")
+                source_filenames += [
+                    "_".join([f"2020-01-01-00-0{i}-09090901"] + line.split()) + ".zip"
+                    for i in range(1, 4)
+                ]
         for filename in source_filenames:
             zip_filename = pathlib.Path(self.xc_dir_name) / filename
             with zipfile.ZipFile(zip_filename, "w") as zip_file:
                 zip_file.write(self.test_filepath)
 
-        get_sps_packages(**self.kwargs)
+        sps_packages = get_sps_packages(**self.kwargs)
         for filename in source_filenames:
             with self.subTest(filename=filename):
                 self.assertTrue(
@@ -53,6 +56,13 @@ class TestGetSPSPackages(TestCase):
                     .joinpath(filename)
                     .exists()
                 )
+        self.assertEqual(
+            sps_packages,
+            [
+                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
+                for filename in source_filenames
+            ],
+        )
 
     def test_get_sps_packages_moves_anything_if_no_source_file(self):
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -1,4 +1,7 @@
 import tempfile
+import shutil
+import pathlib
+import zipfile
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock
 
@@ -9,63 +12,66 @@ from operations.pre_sync_documents_to_kernel_operations import get_sps_packages
 
 class TestGetSPSPackages(TestCase):
     def setUp(self):
+        self.xc_dir_name = tempfile.mkdtemp()
+        self.proc_dir_name = tempfile.mkdtemp()
         self.kwargs = {
-            "scilista_file_path": "dir/path/scilista.lst",
-            "xc_dir_name": "dir/source",
-            "proc_dir_name": "dir/destination",
+            "scilista_file_path": str(pathlib.Path(self.xc_dir_name) / "scilista.lst"),
+            "xc_dir_name": self.xc_dir_name,
+            "proc_dir_name": self.proc_dir_name,
         }
+        self.test_filepath = pathlib.Path(self.xc_dir_name) / "test.txt"
+        with self.test_filepath.open("w") as test_file:
+            test_file.write("Text test file")
 
-    @patch("operations.pre_sync_documents_to_kernel_operations.Path")
-    @patch("operations.pre_sync_documents_to_kernel_operations.open")
-    def test_get_sps_packages_creates_path_dirs(self, mk_open, MockPath):
-        get_sps_packages(**self.kwargs)
-        MockPath.assert_any_call(self.kwargs["xc_dir_name"])
-        MockPath.assert_any_call(self.kwargs["proc_dir_name"])
-
-    @patch("operations.pre_sync_documents_to_kernel_operations.open")
-    def test_read_scilista_from_file(self, mk_open):
-        get_sps_packages(**self.kwargs)
-        mk_open.assert_called_once_with("dir/path/scilista.lst")
+    def tearDown(self):
+        shutil.rmtree(self.xc_dir_name)
+        shutil.rmtree(self.proc_dir_name)
 
     @patch("operations.pre_sync_documents_to_kernel_operations.open")
     def test_get_sps_packages_raises_error_if_scilista_open_error(self, mk_open):
         mk_open.side_effect = FileNotFoundError
         self.assertRaises(FileNotFoundError, get_sps_packages, *self.kwargs)
 
-    @patch("operations.pre_sync_documents_to_kernel_operations.shutil")
-    @patch("operations.pre_sync_documents_to_kernel_operations.os.path.exists")
-    @patch("operations.pre_sync_documents_to_kernel_operations.open")
-    def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(
-        self, mk_open, mk_path_exists, mk_shutil
-    ):
-        mk_path_exists.return_value = True
+    def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(self):
         scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
-        mk_open.return_value.__enter__.return_value.readlines.return_value = (
-            scilista_lines
-        )
+        source_filenames = []
+        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        with scilista_file_path.open("w") as scilista_file:
+            for line in scilista_lines:
+                scilista_file.write(line + "\n")
+                source_filenames.append("_".join(line.split()) + ".zip")
+        for filename in source_filenames:
+            zip_filename = pathlib.Path(self.xc_dir_name) / filename
+            with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                zip_file.write(self.test_filepath)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            self.kwargs["proc_dir_name"] = tmpdirname
-            get_sps_packages(**self.kwargs)
-            for scilista_line in scilista_lines:
-                with self.subTest(scilista_line=scilista_line):
-                    filename = "/{}_{}.zip".format(*scilista_line.split())
-                    mk_shutil.move.assert_any_call(
-                        self.kwargs["xc_dir_name"] + filename, tmpdirname + filename
-                    )
-
-    @patch("operations.pre_sync_documents_to_kernel_operations.shutil")
-    @patch("operations.pre_sync_documents_to_kernel_operations.os.path.exists")
-    @patch("operations.pre_sync_documents_to_kernel_operations.open")
-    def test_get_sps_packages_moves_anything_if_no_source_file(
-        self, mk_open, mk_path_exists, mk_shutil
-    ):
-        mk_path_exists.return_value = False
-        mk_open.return_value.__enter__.return_value.readlines.return_value = [
-            "rba v53n1"
-        ]
         get_sps_packages(**self.kwargs)
-        mk_shutil.move.assert_not_called()
+        for filename in source_filenames:
+            with self.subTest(filename=filename):
+                self.assertTrue(
+                    pathlib.Path(self.kwargs["proc_dir_name"])
+                    .joinpath(filename)
+                    .exists()
+                )
+
+    def test_get_sps_packages_moves_anything_if_no_source_file(self):
+        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        package = "rba v53n2"
+        scilista_file_path.write_text(package)
+        source_filenames = [
+            "rba_v53n1", "rba_2019nahead", "rsp_v10n4s1"
+        ]
+        for filename in source_filenames:
+            zip_filename = pathlib.Path(self.xc_dir_name) / filename
+            with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                zip_file.write(self.test_filepath)
+
+        get_sps_packages(**self.kwargs)
+        self.assertFalse(
+            pathlib.Path(self.kwargs["proc_dir_name"])
+            .joinpath("_".join(package.split()) + ".zip")
+            .exists()
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera leitura de pacotes gerados pelo XC com data e hora no nome. Ao ler a scilista, somente o acrônimo e fascículo serão informados mas a DAG de pré sincronização deverá copiar para o diretório de trabalho do airflow todos os pacotes para os fascículos relacionados na scilista. Também garante que a ordem dos pacotes dos fascículos se mantenham ordenados de acordo com a data e hora do nome.

#### Onde a revisão poderia começar?
Em `airflow/dags/operations/pre_sync_documents_to_kernel_operations.py`, L30

#### Como este poderia ser testado manualmente?
Com diretório origem contendo pacotes SPS gerados pelo XC e scilista com pacotes relacionados:
1. Configure o airflow, apontando para o diretório origem, um diretório destino de trabalho e o caminho da scilista
2. Execute a DAG `pre_sync_documents_to_kernel`
3. Verifique se os pacotes de todos os fascículos relacionados na scilista existentes no diretório origem foram copiados
3. Verifique se a ordem de execução das dags `sync_documents_to_kernel` está correta, respeitando a data e hora do nome dos pacotes SPS.

#### Algum cenário de contexto que queira dar?
A scilista virá somente com o acrônimo e o label do fascículo e, como podem existir vários pacotes para um único fascículo, é necessário copiar todos eles e mantê-los na ordem em que foram criados, evitando que uma versão antiga de documento sobrescreva uma nova.

### Screenshots
N/A

#### Quais são tickets relevantes?
#168 

### Referências
.