### PR TITLE
Ignora comando DEL da scilista na pré sincronização de documentos

### DIFF
--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -27,12 +27,14 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
 
     with open(scilista_file_path) as scilista:
         for acron_issue in scilista.readlines():
-            filename_pattern = "*{}.zip".format("_".join(acron_issue.split()))
-            Logger.info("Reading ZIP files pattern: %s", filename_pattern)
-            for source in sorted(xc_dir_path.glob(filename_pattern)):
-                Logger.info("Moving %s to %s", str(source), str(proc_dir_path))
-                shutil.move(str(source), str(proc_dir_path))
-                sps_packages_list.append(str(proc_dir_path / source.name))
+            # Verifica se comando DEL está indicado no fascículo
+            if not acron_issue.strip().lower().endswith("del"):
+                filename_pattern = "*{}.zip".format("_".join(acron_issue.split()))
+                Logger.info("Reading ZIP files pattern: %s", filename_pattern)
+                for source in sorted(xc_dir_path.glob(filename_pattern)):
+                    Logger.info("Moving %s to %s", str(source), str(proc_dir_path))
+                    shutil.move(str(source), str(proc_dir_path))
+                    sps_packages_list.append(str(proc_dir_path / source.name))
 
     Logger.debug("get_sps_packages OUT")
     return sps_packages_list

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -3,14 +3,12 @@
     DAG responsável por preparar os pacotes SPS vindos do fluxo de ingestão para atualização do Kernel.
 
     Passos:
-        a. Obtém Pacotes SPS através da Scilista
-        b. Ler Pacotes SPS de acordo com a Scilista
-            - Diretório configurável, alimentado pelo XC
-        c. Não conseguiu ler pacotes
-            1. Envio de Email sobre pacote inválido
-            2. Pensar em outras forma de verificar
-        d. Deleta fascículos de acordo com a Scilista
-            1. Deletar o bundle no Kernel
+        a. Ler Scilista e determinar ação de cada fascículo
+        b. Se for comando para deleção de fascículo, ignora comando para fascículo
+        c. Senão
+            1. Move pacotes SPS referentes ao fascículo da Scilista, ordenados pelo nome
+               com data e hora
+            2. Dispara execução de DAG de sincronização para cada pacote
 """
 import os
 import logging


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera o operador executado pela DAG `pre_sync_documents_to_kernel` para efetuar a leitura de pacotes listados na `scilista` somente se estiverem sem o comando `del`.

#### Onde a revisão poderia começar?
Em `airflow/dags/operations/pre_sync_documents_to_kernel_operations.py`.

#### Como este poderia ser testado manualmente?
1. Com pacotes SPS em diretório configurado em variável `XC_SPS_PACKAGES_DIR`, crie uma `scilista` com algum(ns) pacote(s) acompanhados do comando `del` ao final
2. Execute a DAG `pre_sync_documents_to_kernel`
3. A execução de DAGs sem o comando `del` devem ser iniciadas
4. No log da DAG, não deverá haver leitura de pacotes com comando `del`

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#56 

### Referências
.