### PR TITLE
Atualiza versão do Packtools para 2.6.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ deepdiff[murmur]==4.0.7
 feedparser==5.2.1
 git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
 git+https://github.com/scieloorg/opac_schema.git@v2.54#egg=opac_schema
-git+https://github.com/scieloorg/packtools.git@2.6.0#egg=packtools
+git+https://github.com/scieloorg/packtools.git@2.6.4#egg=packtools


### PR DESCRIPTION
#### O que esse PR faz?
Este PR atualiza a versão do Packtools para a última (2.6.4), que corrige problema na leitura do XML.

#### Onde a revisão poderia começar?
Em `requirements.txt`

#### Como este poderia ser testado manualmente?
Para instalação em virtualenv, execute `pip install -r requirements.txt`

OU

Para instalação em Docker, recrie o container para instalar a nova versão do Packtools.

Com o Airflow atualizado, tente sincronizar pacotes SPS.

#### Algum cenário de contexto que queira dar?
Ocorreu um problema durante os testes do fluxo de ingestão direta utilizando a nova plataforma e não foi possível ler alguns documentos XMLs que apresentaram o seguinte erro na leitura do arquivo: `PCDATA invalid Char value 3, line 1, column ???? (<string>, line 1)`. Estes pacotes foram otimizados para WEB pelo Packtools e, com a versão mais nova, o problema não ocorre.

### Screenshots
.

#### Quais são tickets relevantes?
.

### Referências
.