### PR TITLE
[sync_kernel_to_website] Altera tipo de AOP quando não tiver nenhum documento

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -474,6 +474,12 @@ def IssueFactory(data, journal_id, issue_order=None, _type="regular"):
         issue.type = "volume_issue"
     elif issue.number and "spe" in issue.number:
         issue.type = "special"
+    elif _type == "ahead" and not data.get("items"):
+        """
+        Caso não haja nenhum artigo no bundle de ahead, ele é definido como
+        ``outdated_ahead``, para que não apareça na grade de fascículos
+        """
+        issue.type = "outdated_ahead"
     else:
         issue.type = _type
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera a sincronização de Bundles do Kernel para o site para que bundles de _Ahead of Print_ não apareçam no site quando não houverem documentos. Para isso, o valor de `Issue.type` precisa ser definido como `outdated_ahead` e, assim, manter compatibilidade com o antigo processamento.

#### Onde a revisão poderia começar?
Em `airflow/dags/sync_kernel_to_website.py`

#### Como este poderia ser testado manualmente?

- Adicione um bundle de AOP em um periódico no Kernel
- Sincronize os dados do Kernel para o site
- Observe que na grade de números do periódico no site não aparece o bundle de AOP
- Adicione documentos no bundle de AOP
- Sincronize os dados do Kernel para o site
- Observe que na grade de números do periódico no site aparece o bundle de AOP
- Mova ou remova os documentos do bundle de AOP no Kernel
- Sincronize os dados do Kernel para o site
- Observe que na grade de números do periódico no site não aparece o bundle de AOP

#### Algum cenário de contexto que queira dar?
Este erro foi detectado durante os testes do XC no ambiente de testes com a entrada de ex-AOPs

### Screenshots
N/A

#### Quais são tickets relevantes?
.

### Referências
Código do antigo processamento que altera o tipo do Issue: https://github.com/scieloorg/opac_proc/blob/a3ee441dac0223023f6fb8991a2b1c2ab002a237/opac_proc/loaders/lo_issues.py#L73-L86