### PR TITLE
Modifica o uso do campo `status_history` ao sincronizar o periódicos

### DIFF
--- a/airflow/dags/operations/sync_isis_to_kernel.py
+++ b/airflow/dags/operations/sync_isis_to_kernel.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+
+def parse_date_to_iso_format(date: str) -> str:
+    """Traduz datas em formato simples ano-mes-dia, ano-mes para
+    o formato iso utilizado durantr a persistência do Kernel"""
+
+    formats = ["%Y-%m-%d", "%Y-%m", "%Y"]
+
+    for format in formats:
+        try:
+            _date = (
+                datetime.strptime(date, format).isoformat(timespec="microseconds") + "Z"
+            )
+        except ValueError:
+            continue
+        else:
+            return _date
+
+    raise ValueError("Could not parse date '%s' to iso format" % date)

--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -21,6 +21,7 @@ from deepdiff import DeepDiff
 
 from common import hooks
 from operations.docs_utils import get_bundle_id
+from operations.sync_isis_to_kernel import parse_date_to_iso_format
 
 """
 Para o devido entendimento desta DAG pode-se ter como base a seguinte explicação.
@@ -106,13 +107,15 @@ def journal_as_kernel(journal: Journal) -> dict:
     _payload["print_issn"] = journal.print_issn or ""
     _payload["electronic_issn"] = journal.electronic_issn or ""
 
-    _payload["status"] = {}
-    if journal.status_history:
-        _status = journal.status_history[-1]
-        _payload["status"]["status"] = _status[1]
+    _payload["status_history"] = []
 
-        if _status[2]:
-            _payload["status"]["reason"] = _status[2]
+    for status in journal.status_history:
+        _status = {"status": status[1], "date": parse_date_to_iso_format(status[0])}
+
+        if status[2]:
+            _status["reason"] = status[2]
+
+        _payload["status_history"].append(_status)
 
     _payload["subject_areas"] = journal.subject_areas or []
 

--- a/airflow/tests/test_sync_isis_to_kernel.py
+++ b/airflow/tests/test_sync_isis_to_kernel.py
@@ -288,7 +288,8 @@ class TestJournalAsKernel(unittest.TestCase):
         self.mocked_journal.publisher_city = "Uberaba"
         self.mocked_journal.mission = {}
         self.mocked_journal.status_history = [
-            ('date', 'status', 'reason'),
+            ("2020-01-01", "current", ""),
+            ("2020-02-01", "deceased", "reason")
         ]
         self.mocked_journal.sponsors = []
 
@@ -319,3 +320,19 @@ class TestJournalAsKernel(unittest.TestCase):
         self.assertEqual(
             "Brasil",
             result["institution_responsible_for"][0]["country"])
+
+    def test_journal_as_kernel_returns_the_complete_status_history(self):
+        mocked_journal = self.mocked_journal
+        result = journal_as_kernel(mocked_journal)
+        self.assertEqual(
+            {"status": "current", "date": "2020-01-01T00:00:00.000000Z"},
+            result["status_history"][0],
+        )
+        self.assertEqual(
+            {
+                "date": "2020-02-01T00:00:00.000000Z",
+                "status": "deceased",
+                "reason": "reason",
+            },
+            result["status_history"][1],
+        )


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request corrige o issue #174, fazendo com que durante a sincronização dos periódicos, o campo `status_history` seja persistido/atualizado no Kernel.

#### Onde a revisão poderia começar?
- `airflow/dags/sync_isis_to_kernel.py` L`109`

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Inicie uma instância do airflow;
- Configure as conexões/variáveis do airflow;
- Inicie o processo de espelhamento executando a DAG `sync_isis_to_kernel`;
- Observe que o campo `status` deu lugar ao campo `status_history` que agora contém uma lista de status.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#174 

### Referências
N/A