### PR TITLE
Atualiza método da classe SP_Package de acordo com o ds migração

### DIFF
--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -209,14 +209,17 @@ class SPS_Package:
 
     @property
     def number(self):
-        issue = dict(self.parse_article_meta).get("issue")
-        if issue:
-            if "s" in issue and "spe" not in issue:
-                if "-s" in issue:
-                    return issue[: issue.find("-s")]
-                if issue.startswith("s"):
-                    return None
-        return issue
+        if self.article_meta is not None:
+            issue_tag = self.article_meta.find("./issue")
+            if issue_tag is not None:
+                issue_tag_text = issue_tag.text.strip()
+                lower_value = issue_tag_text.lower()
+                if "sup" in lower_value:
+                    index = lower_value.find("sup")
+                    if index == 0:  # starts with "s"
+                        return None
+                    issue_tag_text = issue_tag_text[:index].strip()
+                return "".join(issue_tag_text.split())
 
     @property
     def supplement(self):

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -224,7 +224,7 @@ class TestGetXMLData(TestCase):
         self.assertEqual(result["issn"], "1806-907X")
         self.assertEqual(result["year"], "2018")
         self.assertEqual(result["volume"], "53")
-        self.assertEqual(result["number"], "01")
+        self.assertEqual(result["number"], "1")
         self.assertEqual(
             result["assets"],
             [


### PR DESCRIPTION
#### O que esse PR faz?

Atualiza o método `number` da classe `SP_Package` de acordo com o código do repositório [ds migração](https://github.com/scieloorg/document-store-migracao/blob/496722f72d2a7ffe1169a9db18b306f0ff5e9258/documentstore_migracao/export/sps_package.py#L349-L360). É possível ver a motivação da modificação [aqui](https://github.com/scieloorg/document-store-migracao/commit/b8c80c8bdfe7c0119b2c7c3f2b2dd15cb53c7d84).

#### Onde a revisão poderia começar?
N/A

#### Como este poderia ser testado manualmente?
N/A

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A