### PR TITLE
Define variável HTTP_HOOK_RUN_RETRIES sem templates jinja

### DIFF
--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -16,6 +16,7 @@ from airflow.models import Variable
 from psycopg2 import ProgrammingError
 
 from mongoengine import connect
+from sqlalchemy.exc import OperationalError
 
 
 Logger = logging.getLogger(__name__)
@@ -25,14 +26,11 @@ DEFAULT_HEADER = {
 }
 
 KERNEL_HOOK_BASE = HttpHook(http_conn_id="kernel_conn", method="GET")
-# HTTP_HOOK_RUN_RETRIES = Variable.get("HTTP_HOOK_RUN_RETRIES", 5)
-HTTP_HOOK_RUN_RETRIES = """
-    {% if var.value.HTTP_HOOK_RUN_RETRIES is defined %}
-        {{ var.value.HTTP_HOOK_RUN_RETRIES }}
-    {% else %}
-        5
-    {% endif %}
-"""
+
+try:
+    HTTP_HOOK_RUN_RETRIES = int(Variable.get("HTTP_HOOK_RUN_RETRIES", 5))
+except (OperationalError, ValueError):
+    HTTP_HOOK_RUN_RETRIES = 5
 
 @retry(
     wait=wait_exponential(),


### PR DESCRIPTION
### O que esse PR faz?

Este pull request corrige o erro de execução da task `sync_documents_to_kernel` quando a conexão com o `Kernel` está parcialmente indisponível, permite que tentativas de conexões sejam feitas.

#### Onde a revisão poderia começar?

- `airflow/dags/common/hooks.py`

#### Como este poderia ser testado manualmente?

- Inicie uma instância do airflow;
- Desligue a instância do `Kernel`;
- Execute a DAG de sincronização dos documentos;
- Observe que algumas tentativas de execução serão realizadas;
- A task irá quebrar porque a conexão com o Kernel é requisito básico MAS as tentativas serão realizadas.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
#182 

### Referências
- https://airflow.apache.org/docs/stable/concepts.html#jinja-templating
- https://airflow.apache.org/docs/stable/macros-ref.html