### PR TITLE
Idempotência na reexecução de DagRun `pre_sync_documentos_to_kernel`

### DIFF
--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -31,6 +31,10 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
 
     package_paths_list = proc_dir_path / "sps_packages.lst"
     if package_paths_list.is_file():
+        Logger.info(
+            'Pre-sync already done. Returning packages from "%s" file',
+            package_paths_list,
+        )
         return package_paths_list.read_text().split("\n")
 
     with open(scilista_file_path) as scilista:
@@ -65,6 +69,7 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
                     filename_pattern, str(xc_dir_path), str(proc_dir_path))
 
     if sps_packages_list:
+        Logger.info('Saving SPS packages list in "%s" file', package_paths_list)
         package_paths_list.write_text("\n".join(sps_packages_list))
 
     Logger.debug("get_sps_packages OUT")

--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -16,7 +16,7 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
     processamento do Airflow e gera lista dos paths dos pacotes SPS no diretório de 
     processamento.
 
-    list scilista: lista com as linhas do arquivo scilista.lst
+    list scilista: lista com as linhas do arquivo scilista
         rsp v10n4
         rsp 2018nahead
         csp v4n2-3
@@ -59,6 +59,9 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
                 Logger.exception(
                     "Missing files which pattern is '%s' in %s and in %s",
                     filename_pattern, str(xc_dir_path), str(proc_dir_path))
+
+    if sps_packages_list:
+        package_paths_list.write_text("\n".join(sps_packages_list))
 
     Logger.debug("get_sps_packages OUT")
     return sps_packages_list

--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -29,6 +29,10 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
     proc_dir_path = Path(proc_dir_name)
     sps_packages_list = []
 
+    package_paths_list = proc_dir_path / "sps_packages.lst"
+    if package_paths_list.is_file():
+        return package_paths_list.read_text().split("\n")
+
     with open(scilista_file_path) as scilista:
         for scilista_item in scilista.readlines():
             acron_issue = scilista_item.strip().split()

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from airflow import DAG
 from airflow.models import Variable
-from airflow.operators.python_operator import PythonOperator
+from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
 from airflow.utils import timezone
 from airflow.api.common.experimental.trigger_dag import trigger_dag
 
@@ -116,11 +116,18 @@ def start_sync_packages(conf, **kwargs):
     Logger.debug("create_all_subdags OUT")
 
 
-get_sps_packages_task = PythonOperator(
+get_sps_packages_task = ShortCircuitOperator(
     task_id="get_sps_packages_task_id",
     provide_context=True,
     python_callable=get_sps_packages,
     dag=dag,
 )
 
-get_sps_packages_task
+start_sync_packages_task = PythonOperator(
+    task_id="start_sync_packages_task_id",
+    provide_context=True,
+    python_callable=start_sync_packages,
+    dag=dag,
+)
+
+get_sps_packages_task >> start_sync_packages_task

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -70,6 +70,7 @@ def get_sps_packages(conf, **kwargs):
     diretório identificado pelo DAG_RUN_ID junto com a scilista. Caso esta DAG seja 
     reexecutada, os mesmos pacotes serão sincronizados anteriormente serão novamente 
     sincronizados.
+    Armazena os pacotes em XCom para a próxima tarefa.
     """
     _xc_sps_packages_dir = Path(Variable.get("XC_SPS_PACKAGES_DIR"))
     _proc_sps_packages_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / kwargs["run_id"]
@@ -86,6 +87,12 @@ def get_sps_packages(conf, **kwargs):
         _xc_sps_packages_dir,
         _proc_sps_packages_dir,
     )
+
+    if _sps_packages:
+        kwargs["ti"].xcom_push(key="sps_packages", value=_sps_packages)
+        return True
+    else:
+        return False
 
 
 def start_sync_packages(conf, **kwargs):

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -12,6 +12,7 @@
 """
 import os
 import logging
+import shutil
 from datetime import datetime
 
 from airflow import DAG
@@ -35,6 +36,25 @@ default_args = {
 dag = DAG(
     dag_id="pre_sync_documents_to_kernel", default_args=default_args, schedule_interval=None
 )
+
+
+def get_scilista_file_path(xc_sps_packages_dir, proc_sps_packages_dir, execution_date):
+    _scilista_filename = f"scilista-{execution_date}.lst"
+    _proc_scilista_file_path = proc_sps_packages_dir / _scilista_filename
+    if _proc_scilista_file_path.is_file():
+        Logger.info('Proc scilista "%s" already exists', _proc_scilista_file_path)
+    else:
+        _origin_scilista_file_path = xc_sps_packages_dir / _scilista_filename
+        if not _origin_scilista_file_path.is_file():
+            raise FileNotFoundError(_origin_scilista_file_path)
+
+        Logger.info(
+            'Copying original scilista "%s" to proc "%s"',
+            _origin_scilista_file_path,
+            _proc_scilista_file_path,
+        )
+        shutil.copy(_origin_scilista_file_path, _proc_scilista_file_path)
+    return str(_proc_scilista_file_path)
 
 
 def get_sps_packages(conf, **kwargs):

--- a/airflow/tests/test_pre_sync_documents_to_kernel.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel.py
@@ -1,9 +1,64 @@
+import tempfile
+import shutil
+import pathlib
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock, ANY
 
 from airflow import DAG
 
-from pre_sync_documents_to_kernel import get_sps_packages
+from pre_sync_documents_to_kernel import (
+    get_scilista_file_path,
+    get_sps_packages,
+)
+
+
+class TestGetScilistaFilePath(TestCase):
+    def setUp(self):
+        self.gate_dir = tempfile.mkdtemp()
+        self.proc_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.gate_dir)
+        shutil.rmtree(self.proc_dir)
+
+    def test_scilista_does_not_exist_in_origin(self):
+        with self.assertRaises(FileNotFoundError) as exc_info:
+            get_scilista_file_path(
+                pathlib.Path("no/dir/path"),
+                pathlib.Path(self.proc_dir),
+                "2020-12-31",
+            )
+        self.assertIn(str(exc_info.exception), "no/dir/path/scilista-2020-12-31.lst")
+
+    def test_scilista_already_exists_in_proc(self):
+        scilista_path_origin = pathlib.Path(self.gate_dir) / "scilista-2020-01-01.lst"
+        scilista_path_origin.write_text("acron v1n22")
+        scilista_path_proc = pathlib.Path(self.proc_dir) / "scilista-2020-01-01.lst"
+        scilista_path_proc.write_text("acron v1n20")
+        _scilista_file_path = get_scilista_file_path(
+            pathlib.Path(self.gate_dir),
+            pathlib.Path(self.proc_dir),
+            "2020-01-01",
+        )
+
+        self.assertEqual(
+            _scilista_file_path,
+            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01.lst")
+        )
+        self.assertEqual(scilista_path_proc.read_text(), "acron v1n20")
+
+    def test_scilista_must_be_copied(self):
+        scilista_path = pathlib.Path(self.gate_dir) / "scilista-2020-01-01.lst"
+        scilista_path.write_text("acron v1n20")
+        _scilista_file_path = get_scilista_file_path(
+            pathlib.Path(self.gate_dir),
+            pathlib.Path(self.proc_dir),
+            "2020-01-01",
+        )
+        self.assertEqual(
+            _scilista_file_path,
+            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01.lst")
+        )
 
 
 class TestGetSPSPackages(TestCase):

--- a/airflow/tests/test_pre_sync_documents_to_kernel.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel.py
@@ -103,6 +103,8 @@ class TestGetSPSPackages(TestCase):
         _sps_packages = ["package_01", "package_02", "package_03"]
         mk_get_sps_packages.return_value = _sps_packages
         _exec_start_sync_packages = get_sps_packages(**self.kwargs)
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key='sps_packages', value=_sps_packages
         )
         self.assertTrue(_exec_start_sync_packages)
 
@@ -117,6 +119,7 @@ class TestGetSPSPackages(TestCase):
         ]
         mk_get_sps_packages.return_value = []
         _exec_start_sync_packages = get_sps_packages(**self.kwargs)
+        self.kwargs["ti"].xcom_push.assert_not_called()
         self.assertFalse(_exec_start_sync_packages)
 
 

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -64,6 +64,35 @@ class TestGetSPSPackages(TestCase):
             ],
         )
 
+    def test_get_sps_packages_creates_sps_packages_list_file(self):
+        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
+        source_filenames = []
+        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        with scilista_file_path.open("w") as scilista_file:
+            for line in scilista_lines:
+                scilista_file.write(line + "\n")
+                source_filenames += [
+                    "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
+                    for i in range(1, 4)
+                ]
+        for filename in source_filenames:
+            zip_filename = pathlib.Path(self.xc_dir_name) / filename
+            with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                zip_file.write(self.test_filepath)
+
+        sps_packages = get_sps_packages(**self.kwargs)
+        package_paths_list = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
+        self.assertTrue(package_paths_list.is_file())
+        sps_packages_list = package_paths_list.read_text().split("\n")
+        self.assertEqual(
+            sps_packages_list,
+            [
+                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
+                for filename in source_filenames
+            ],
+        )
+
+
     def test_get_sps_packages_ignores_del_command_in_scilista(self):
         scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1 del", "rsp v10n4s1", "csp v35nspe del"]
         source_filenames = []

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -156,6 +156,16 @@ class TestGetSPSPackages(TestCase):
             result
         )
 
+    def test_get_sps_packages_must_return_packages_list_if_sps_packages_lst_exists(self):
+        package_paths_list = [
+            str(pathlib.Path(self.proc_dir_name) / f"package_0{seq}.zip")
+            for seq in range(1, 4)
+        ]
+        package_paths_list_file = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
+        package_paths_list_file.write_text("\n".join(package_paths_list))
+        result = get_sps_packages(**self.kwargs)
+        self.assertEqual(result, package_paths_list)
+
 
 if __name__ == "__main__":
     main()

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -11,7 +11,7 @@ echo PrepSyncToKernel.bat
 echo GeraScielo.bat .. /scielo/web log/GeraPadrao.log adiciona
 echo 
 
-PREP_LOG=log/PrepSyncToKernel.log
+PREP_LOG=log/PrepSyncToKernel-$(date "+%Y-%m-%d").log
 PrepSyncToKernel.bat > $PREP_LOG
 
 if [ -f PrepSyncToKernel.ini ];

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -6,8 +6,10 @@
 # XC_SPS_PACKAGES: path do diretório com todos os pacotes gerados pelo XC
 # XC_KERNEL_GATE: path do diretório para copia dos pacotes como estao no momento que o processamento do GeraPadrao e iniciado
 
+TODAY_DATE=$(date "+%Y-%m-%d")
+
 echo ""
-echo "Executing $0 from `pwd`"
+echo "$TODAY_DATE - Executing $0 from `pwd`"
 echo ""
 
 if [ -f PrepSyncToKernel.ini ];
@@ -142,10 +144,10 @@ then
     echo "--------------------------------------------------------"
  
     echo
-    echo "Copiando scilista de $SCILISTA_PATH para a área do Escalonador em ${XC_KERNEL_GATE}"
+    echo "Copiando scilista de $SCILISTA_PATH para a área do Escalonador em ${XC_KERNEL_GATE}/scilista-$TODAY_DATE.lst"
     echo
 
-    cp ${SCILISTA_PATH} ${XC_KERNEL_GATE}
+    cp ${SCILISTA_PATH} "${XC_KERNEL_GATE}/scilista-$TODAY_DATE.lst"
 
     echo
     echo "SPS Packages and Scilista copied successfully!"


### PR DESCRIPTION
#### O que esse PR faz?
Este PR garante idempotência na reexecução de DagRun `pre_sync_documentos_to_kernel`, iniciando processo de sincronização dos pacotes sincronizados na primeira execução.
Para garantir que os pacotes serão exatamente os mesmos da execução da DAG, um diretório identificado com o DagRun ID é criado e, dentro dele, são armazenados a scilista inicial do diretório alimentado pelo GeraPadrao, todos os pacotes relacionados aos números da scilista e um arquivo com a relação de todos os paths de pacotes do diretório. Este último é salvo somente caso a movimentação dos arquivos foi feita conforme esperado, ordenada pelo nome dos pacotes.
Em uma reexecução desse DagRun, o ID é o mesmo e é possível identificar o diretório e todo o conteúdo, não sendo necessário refazer as movimentações de arquivos, que já deverão estar no diretório de processamento.

#### Onde a revisão poderia começar?
Pelo commit f8150cb

#### Como este poderia ser testado manualmente?
Com pacotes em um diretório alimentado pelo XC e uma scilista:
1. Acesse o diretório `/proc` e execute o script `GeraPadrao.bat`
2. Os pacotes relacionados à scilista devem ser movidos para o diretório de destino (Kernel-Gate) com uma cópia da scilista, identificada com a data da execução
3. Execute a DAG `pre_sync_documentos_to_kernel` (seja através da DAG `sync_isis_to_kernel` ou diretamente)
4. Os pacotes relacionados à scilista devem ser copiados para o diretório de destino (PROC Airflow), identificado com o DagRun ID, junto com uma cópia da scilista, identificada com a data da execução. Também deve ser criado um arquivo `sps_packages.lst`, contendo o path de todos os pacotes SPS do diretório.
5. Ao final da execução da DAG `pre_sync_documentos_to_kernel`, o trigger de DAGs `sync_documents_to_kernel` para cada um dos pacotes devem ser iniciadas
6. Faça o _clear_ em `get_sps_packages_task` da DAG `pre_sync_documentos_to_kernel` já executada e o passo 5 deve ocorrer normalmente, sem erros
7. Faça o _clear_ em `start_sync_packages_task_id` da DAG `pre_sync_documentos_to_kernel` já executada

#### Algum cenário de contexto que queira dar?
Este PR não garante a reexecução dos mesmos DagRuns de `sync_documents_to_kernel` iniciadas pelo gatilho anterior pois não há uma maneira simples de fazer o _clear_ de TaskInstances via código Python.

### Screenshots
n/a

#### Quais são tickets relevantes?
#184 

### Referências
.