### PR TITLE
[FASE 3] Substitui comando mv por rsync

### DIFF
--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -115,7 +115,7 @@ then
                 then
                     echo "  Moving pack ${PACK_FILE} to ${XC_KERNEL_GATE} ..."
                     echo
-                    mv "${PACK_FILE}" ${XC_KERNEL_GATE}
+                    rsync -qa --inplace --remove-source-files "${PACK_FILE}" ${XC_KERNEL_GATE}
                 else
                     if [[ "$ISSUE" == *"ahead"* ]];
                     then


### PR DESCRIPTION
#### O que esse PR faz?
Este PR tem o objetivo de alterar o script de cópia dos pacotes SPS para o SPF mais robusta e mitigar problemas de instabilidade de rede na movimentação dos pacotes para o SPF. Os parâmetros `-qa` são para ter o comando em modo silencioso e tentar preservar as características do arquivo (mode, owner, group, outros), `--inplace` para atualizar o arquivo no destino, caso já exista, e `--remove-source-files` para remover o arquivo da origem, caso consiga executar o comando com sucesso.

#### Onde a revisão poderia começar?
Commit 1d0c7c2

#### Como este poderia ser testado manualmente?
- Crie diretório de origem com arquivos ZIP, simulando o diretório de saída do XC.
  Ex:
```
$ ls dir_origem
2020-07-13-16-03-47-785030_acron_v1n2.zip
data_abc_v1n1.zip
data_ag_v42.zip
data_axy_2020nahead.zip
data_csp_v4nspe3.zip
```
- Crie diretório de destino, simulando o diretório do SPF. Ex: `dir_destino`
- Crie `scilista.lst` com conteúdo de fascículos.
```
acron v1n2
abc v1n1
ag v42
csp v4nspe3
```
- Acesse o diretório `proc/`, crie uma cópia do arquivo `SyncToKernel.ini.template` e configure as variáveis `SCILISTA_PATH`, `XC_SPS_PACKAGES` e `XC_KERNEL_GATE`
- Crie um arquivo `GeraScielo.bat`
- Execute o script `GeraPadrao.bat`
- Ao final da execução do script, o diretório destino deve ter os arquivos a serem movidos de acordo com a scilista, a cópia da scilista e os logs, e os arquivos movidos não devem estar no diretório de origem.

#### Algum cenário de contexto que queira dar?
Esta necessidade foi identificada durante os testes do `GeraPadrao` no ambiente `homolog-metodologia`, movendo os arquivos para o novo ambiente do SPF.

### Screenshots
n/a

#### Quais são tickets relevantes?
#195 

### Referências
.