### PR TITLE
Garante que ao executar a DAG `check_website`, use todas as `uri_list_<sufixo>.lst` pendentes de verificação

### DIFF
--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -66,23 +66,28 @@ def check_website_uri_list(conf, **kwargs):
     """Executa ``check_website.check_website_uri_list`` com a 
     uri_list referente à DagRun. 
     """
+    gerapadrao_id_items = Variable.get(
+        "GERAPADRAO_ID_FOR_URI_LIST", default_var=[], deserialize_json=True)
+
     _website_url_list = Variable.get("WEBSITE_URL_LIST", "")
     _website_url_list = _website_url_list.split(",")
-
     _xc_sps_packages_dir = Path(Variable.get("XC_SPS_PACKAGES_DIR"))
     _proc_sps_packages_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / kwargs["run_id"]
     if not _proc_sps_packages_dir.is_dir():
         _proc_sps_packages_dir.mkdir()
 
-    _uri_list_file_path = get_uri_list_file_path(
-        _xc_sps_packages_dir,
-        _proc_sps_packages_dir,
-        kwargs["execution_date"].to_date_string(), # Data da primeira execução da DAG
-    )
-    check_website_operations.check_website_uri_list(
-        _uri_list_file_path,
-        _website_url_list,
-    )
+    for gerapadrao_id in gerapadrao_id_items:
+        _uri_list_file_path = get_uri_list_file_path(
+            _xc_sps_packages_dir,
+            _proc_sps_packages_dir,
+            gerapadrao_id,
+        )
+        check_website_operations.check_website_uri_list(
+            _uri_list_file_path,
+            _website_url_list,
+        )
+    # atribui um str vazia para sinalizar que o valor foi usado
+    Variable.set("GERAPADRAO_ID_FOR_URI_LIST", [], serialize_json=True)
 
 
 check_website_uri_list_task = PythonOperator(

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -69,8 +69,7 @@ def check_website_uri_list(conf, **kwargs):
     gerapadrao_id_items = Variable.get(
         "GERAPADRAO_ID_FOR_URI_LIST", default_var=[], deserialize_json=True)
 
-    _website_url_list = Variable.get("WEBSITE_URL_LIST", "")
-    _website_url_list = _website_url_list.split(",")
+    _website_url_list = Variable.get("WEBSITE_URL_LIST", default_var=[], deserialize_json=True)
     _xc_sps_packages_dir = Path(Variable.get("XC_SPS_PACKAGES_DIR"))
     _proc_sps_packages_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / kwargs["run_id"]
     if not _proc_sps_packages_dir.is_dir():

--- a/proc/CallGeraUriList.bat
+++ b/proc/CallGeraUriList.bat
@@ -42,11 +42,18 @@ then
     exit 1
 fi
 
-$CISIS_DIR/mx "seq=scilista.lst " lw=9000 "pft=if p(v1) and p(v2) and a(v3) then './GeraUriList.bat ',v1,' ',v2/ fi" now >/tmp/GeraURI.bat
+# Garante que o valor de `TMP_SCRIPT` seja sempre novo
+# evitando de executar um script antigo
 
-chmod 755 /tmp/GeraURI.bat
+TMP_SCRIPT=/tmp/GeraUriList_$(date "+%Y-%m-%d-%H%M%s").bat
+
+$CISIS_DIR/mx "seq=scilista.lst " lw=9000 "pft=if p(v1) and p(v2) and a(v3) then './GeraUriList.bat ',v1,' ',v2/ fi" now >${TMP_SCRIPT}
+
+chmod 755 ${TMP_SCRIPT}
 
 URI_LIST=${XC_KERNEL_GATE}/uri_list_$(date "+%Y-%m-%d").lst
 
-/tmp/GeraURI.bat > ${URI_LIST}
+${TMP_SCRIPT} > ${URI_LIST}
+
+rm ${TMP_SCRIPT}
 

--- a/proc/CallGeraUriList.bat
+++ b/proc/CallGeraUriList.bat
@@ -6,11 +6,12 @@
 if [ -f SyncToKernel.ini ];
 then
     echo "VARIABLES read from file SyncToKernel.ini"
-    . SyncToKernel.ini
+    . ./SyncToKernel.ini
     echo
     echo SCILISTA_PATH=$SCILISTA_PATH
     echo XC_SPS_PACKAGES=$XC_SPS_PACKAGES
     echo XC_KERNEL_GATE=$XC_KERNEL_GATE
+    echo CISIS_DIR=$CISIS_DIR
     echo
 fi
 
@@ -25,11 +26,19 @@ else
         ERROR=1
     fi
 fi
+if [ "" == "${CISIS_DIR}" ];
+then
+    echo "Missing required variable: CISIS_DIR"
+    ERROR=1
+else
+    if [ ! -f ${CISIS_DIR} ];
+    then
+        echo "Missing file: ${CISIS_DIR} "
+        ERROR=1
+    fi
+fi
 if [ "$ERROR" == "1" ];
 then
-    echo
-    echo "XC_KERNEL_GATE eh obrigatorio para gerar a lista de URI"
-    echo
     exit 1
 fi
 

--- a/proc/CallGeraUriList.bat
+++ b/proc/CallGeraUriList.bat
@@ -33,9 +33,9 @@ then
     echo "Missing required variable: CISIS_DIR"
     ERROR=1
 else
-    if [ ! -f ${CISIS_DIR} ];
+    if [ ! -f ${CISIS_DIR}/mx ];
     then
-        echo "Missing file: ${CISIS_DIR} "
+        echo "Missing file: ${CISIS_DIR}/mx "
         ERROR=1
     fi
 fi

--- a/proc/CallGeraUriList.bat
+++ b/proc/CallGeraUriList.bat
@@ -3,6 +3,8 @@
 # ou após as bases-work/acron/acron estarem atualizadas
 # A lista fica disponibilizada em XC_KERNEL_GATE
 
+RUN_ID=$1
+
 if [ -f SyncToKernel.ini ];
 then
     echo "VARIABLES read from file SyncToKernel.ini"
@@ -51,7 +53,7 @@ $CISIS_DIR/mx "seq=scilista.lst " lw=9000 "pft=if p(v1) and p(v2) and a(v3) then
 
 chmod 755 ${TMP_SCRIPT}
 
-URI_LIST=${XC_KERNEL_GATE}/uri_list_$(date "+%Y-%m-%d").lst
+URI_LIST=${XC_KERNEL_GATE}/uri_list_${RUN_ID}.lst
 
 ${TMP_SCRIPT} > ${URI_LIST}
 

--- a/proc/CallGeraUriList.bat
+++ b/proc/CallGeraUriList.bat
@@ -47,7 +47,7 @@ fi
 
 TMP_SCRIPT=/tmp/GeraUriList_$(date "+%Y-%m-%d-%H%M%s").bat
 
-$CISIS_DIR/mx "seq=scilista.lst " lw=9000 "pft=if p(v1) and p(v2) and a(v3) then './GeraUriList.bat ',v1,' ',v2/ fi" now >${TMP_SCRIPT}
+$CISIS_DIR/mx "seq=scilista.lst " lw=9000 "pft=if p(v1) and p(v2) and a(v3) then './GeraUriList.bat ',v1,' ',v2,' $CISIS_DIR/mx'/ fi" now >${TMP_SCRIPT}
 
 chmod 755 ${TMP_SCRIPT}
 

--- a/proc/CallGeraUriList.bat
+++ b/proc/CallGeraUriList.bat
@@ -3,7 +3,7 @@
 # ou após as bases-work/acron/acron estarem atualizadas
 # A lista fica disponibilizada em XC_KERNEL_GATE
 
-RUN_ID=$1
+GERAPADRAO_ID=$1
 
 if [ -f SyncToKernel.ini ];
 then
@@ -53,7 +53,7 @@ $CISIS_DIR/mx "seq=scilista.lst " lw=9000 "pft=if p(v1) and p(v2) and a(v3) then
 
 chmod 755 ${TMP_SCRIPT}
 
-URI_LIST=${XC_KERNEL_GATE}/uri_list_${RUN_ID}.lst
+URI_LIST=${XC_KERNEL_GATE}/uri_list_${GERAPADRAO_ID}.lst
 
 ${TMP_SCRIPT} > ${URI_LIST}
 

--- a/proc/CallTriggerSyncIsisToKernel.bat
+++ b/proc/CallTriggerSyncIsisToKernel.bat
@@ -2,8 +2,9 @@
 # Disponibiliza pacotes SPS resultantes do XML Converter + scilista + log
 # para o SciELO Publishing Framework 
 
-TRIGGER_LOG=log/TriggerSyncIsisToKernel-$(date "+%Y-%m-%d").log
-./TriggerSyncIsisToKernel.bat > $TRIGGER_LOG
+GERAPADRAO_ID=$1
+TRIGGER_LOG=log/TriggerSyncIsisToKernel-${GERAPADRAO_ID}.log
+./TriggerSyncIsisToKernel.bat ${GERAPADRAO_ID} > $TRIGGER_LOG
 
 if [ -f SyncToKernel.ini ];
 then

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -14,10 +14,10 @@ echo GeraScielo.bat .. /scielo/web log/GeraPadrao.log adiciona
 echo "nohup ./CallTriggerSyncIsisToKernel.bat > /tmp/CallTriggerSyncIsisToKernel.out&"
 echo 
 
-
-nohup ./CallPrepSyncToKernel.bat > /tmp/CallPrepSyncToKernel.out 2>&1 &
+GERAPADRAO_ID=$(date "+%Y-%m-%d-%H%M%s")
+nohup ./CallPrepSyncToKernel.bat ${GERAPADRAO_ID} > /tmp/CallPrepSyncToKernel.out 2>&1 &
 
 GeraScielo.bat .. .. log/GeraPadrao.log adiciona
 
-nohup ./CallTriggerSyncIsisToKernel.bat > /tmp/CallTriggerSyncIsisToKernel.out 2>&1 &
-nohup ./CallGeraUriList.bat > /tmp/CallGeraUriList.out 2>&1 &
+nohup ./CallTriggerSyncIsisToKernel.bat  ${GERAPADRAO_ID} > /tmp/CallTriggerSyncIsisToKernel.out 2>&1 &
+nohup ./CallGeraUriList.bat  ${GERAPADRAO_ID} > /tmp/CallGeraUriList.out 2>&1 &

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -15,9 +15,9 @@ echo "nohup ./CallTriggerSyncIsisToKernel.bat > /tmp/CallTriggerSyncIsisToKernel
 echo 
 
 
-nohup ./CallPrepSyncToKernel.bat > /tmp/CallPrepSyncToKernel.out&
+nohup ./CallPrepSyncToKernel.bat > /tmp/CallPrepSyncToKernel.out 2>&1 &
 
 GeraScielo.bat .. .. log/GeraPadrao.log adiciona
 
-nohup ./CallTriggerSyncIsisToKernel.bat > /tmp/CallTriggerSyncIsisToKernel.out&
-nohup ./CallGeraUriList.bat > /tmp/CallGeraUriList.out&
+nohup ./CallTriggerSyncIsisToKernel.bat > /tmp/CallTriggerSyncIsisToKernel.out 2>&1 &
+nohup ./CallGeraUriList.bat > /tmp/CallGeraUriList.out 2>&1 &

--- a/proc/GeraUriList.bat
+++ b/proc/GeraUriList.bat
@@ -8,7 +8,7 @@ ISSUE=$2
 
 $CISIS_DIR/mx ../bases-work/${ACRON}/${ACRON} \
     btell=0 \
-    bool=${ISSUE} \
+    "bool=I=${ISSUE} or H=${ISSUE}" \
     lw=9000 \
     "proc='a9999{${ACRON}{a9990{${ISSUE}{'" \
     pft=@pft/gera_uri_list.pft \

--- a/proc/GeraUriList.bat
+++ b/proc/GeraUriList.bat
@@ -5,8 +5,9 @@
 
 ACRON=$1
 ISSUE=$2
+MX=$3
 
-$CISIS_DIR/mx ../bases-work/${ACRON}/${ACRON} \
+$MX ../bases-work/${ACRON}/${ACRON} \
     btell=0 \
     "bool=I=${ISSUE} or H=${ISSUE}" \
     lw=9000 \

--- a/proc/SyncToKernel.ini.template
+++ b/proc/SyncToKernel.ini.template
@@ -2,3 +2,4 @@ SCILISTA_PATH=xlista
 XC_SPS_PACKAGES=origem
 XC_KERNEL_GATE=destino
 OPAC_AIRFLOW=http://localhost:8080
+CISIS_DIR=cisis

--- a/proc/TriggerSyncIsisToKernel.bat
+++ b/proc/TriggerSyncIsisToKernel.bat
@@ -1,3 +1,5 @@
+GERAPADRAO_ID=$1
+
 if [ -f SyncToKernel.ini ];
 then
     echo "VARIABLES read from file SyncToKernel.ini"
@@ -9,11 +11,13 @@ then
     echo "MISSING OPAC_AIRFLOW"
 else
     URL="${OPAC_AIRFLOW}/api/experimental/dags/sync_isis_to_kernel/dag_runs"
-    echo "curl -X POST ${URL} -H 'Cache-Control: no-cache' -H 'Content-Type: application/json' -d '{}' -v"
+    CONF='{"conf":"{\"GERAPADRAO_ID\":\"${GERAPADRAO_ID}\"}}'
+
+    echo "curl -X POST ${URL} -H 'Cache-Control: no-cache' -H 'Content-Type: application/json' -d '${CONF}' -v"
     curl -X POST \
         ${URL} \
         -H 'Cache-Control: no-cache' \
         -H 'Content-Type: application/json' \
-        -d '{}' \
+        -d '${CONF}' \
         -v
 fi

--- a/proc/TriggerSyncIsisToKernel.bat
+++ b/proc/TriggerSyncIsisToKernel.bat
@@ -11,13 +11,13 @@ then
     echo "MISSING OPAC_AIRFLOW"
 else
     URL="${OPAC_AIRFLOW}/api/experimental/dags/sync_isis_to_kernel/dag_runs"
-    CONF='{"conf":"{\"GERAPADRAO_ID\":\"${GERAPADRAO_ID}\"}}'
+    CONF="{\"conf\": {\"GERAPADRAO_ID\": \"${GERAPADRAO_ID}\"} }"
 
     echo "curl -X POST ${URL} -H 'Cache-Control: no-cache' -H 'Content-Type: application/json' -d '${CONF}' -v"
     curl -X POST \
         ${URL} \
         -H 'Cache-Control: no-cache' \
         -H 'Content-Type: application/json' \
-        -d '${CONF}' \
+        -d "${CONF}" \
         -v
 fi


### PR DESCRIPTION
#### O que esse PR faz?

Garante que ao executar a DAG `check_website`, use as `uri_list_<sufixo>.lst` pendentes de verificação.
Garante isso, gerando um `GERAPADRAO_ID` e o passando para todos os scripts vinculados com o `GeraPadrao.bat` de modo que fiquem vinculados: scilista.lst, uri_list.lst e o disparo da DAG `sync_isis_to_kernel`. 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?

**Teste da Execução do GeraPadrao**

Teste em um ambiente onde possa executar o `mx`.
1. Crie o diretório `log` em `proc`
2. Crie um arquivo `GeraScielo.bat` vazio
3. Configure o arquivo `proc/SyncToKernel.ini`, use `proc/SyncToKernel.ini.template` como modelo
4. Extraia 
[bases-work.zip](https://github.com/scieloorg/opac-airflow/files/5058707/bases-work.zip) num diretório irmão de `proc`. Nesta base contém dois fascículos (`anaimsp v27` e `anaimsp v28`)
5. Entre no diretório proc
6. Crie um arquivo `scilista.lst`, cujo conteúdo é pelo menos um dos fascículo
7. Execute `./GeraPadrao.bat`
8. Note que no diretório que você definiu em `proc/SyncToKernel.ini`, valor de `XC_KERNEL_GATE`, será gerado um arquivo no padrão `uri_list_<GERAPADRAO_ID>.lst`, sendo `<GERAPADRAO_ID>`, formato `YYYY-MM-DD-hh-mm-ss`.
9. Verifique os arquivos abaixo foram gerados:
- `/tmp/CallPrepSyncToKernel.out`
- `/tmp/CallTriggerSyncIsisToKernel.out`
- `/tmp/CallGeraUriList.out`
neles ficam registrados eventuais erros
10. Verifique o conteúdo do arquivo recém criado log/TriggerSyncIsisToKernel-`<GERAPADRAO_ID>`.log

**Teste da DAG**

1. No docker-compose-dev.yml, garanta que tenha os volumes declarados:

```
            - ./test_source:/usr/local/xc_packages
            - ./test_dest:/usr/local/proc_airflow
            - ./isis:/usr/local/bases
```
Sendo que `./test_source` é onde estaria o `uri_list_<GERAPADRAO_ID>.lst`
Sendo que `./test_dest` é para onde o airflow copiará `uri_list_<GERAPADRAO_ID>.lst` de `./test_source`.
Sendo que `./isis` contém as pastas `title` e `issue` em anexo [isis.zip](https://github.com/scieloorg/opac-airflow/files/5059362/isis.zip)


2. Execute o comando
```
docker-compose -f docker-compose-dev.yml up -d
```
3. Crie a variável `WEBSITE_URL_LIST` com valor `["http://www.scielo.br", "https://www.scielosp.org"]`
4. Verifique que a variável `GERAPADRAO_ID_FOR_URI_LIST` está com o valor `["<GERAPADRAO_ID>"]`
5. Acrescente um valor à `GERAPADRAO_ID_FOR_URI_LIST`, exemplo: `["<GERAPADRAO_ID>", "2020-xxxx"]`
6. Execute a DAG `check_website`
7. Observe seu log. Atualmente a DAG apenas registra o resultado no log. A mensagem final indica se todos os recursos estão disponíveis ou se o quanto está indisponível.
8. Observe seu log. Observe que não conseguiu localizar o arquivo `uri_list_2020-xxxx.lst`.

#### Algum cenário de contexto que queira dar?
Como a DAG não está diretamente sincronizada com a DAG sync_isis_to_kernel, seria plausível acumular mais de um processamento, por isso, foi optado por acumular em `GERAPADRAO_ID_FOR_URI_LIST` mais de um valor.

### Screenshots
n/a

#### Quais são tickets relevantes?
#201

### Referências
n/a
