### PR TITLE
Corrige leitura da scilista gerada pelo script de processamento PrepSyncToKernel

### DIFF
--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -40,21 +40,23 @@ dag = DAG(
 
 
 def get_scilista_file_path(
-    xc_sps_packages_dir: Path, proc_sps_packages_dir: Path, execution_date: str
+    xc_sps_packages_dir: Path, proc_sps_packages_dir: Path, gerapadrao_id: str
 ) -> str:
     """Garante que a scilista usada será a do diretório de PROC. Quando for a primeira
     execução da DAG, a lista será copiada para o diretório de PROC. Caso contrário, a 
     mesma será mantida.
     """
-    _scilista_filename = f"scilista-{execution_date}.lst"
-    _proc_scilista_file_path = proc_sps_packages_dir / _scilista_filename
-    if _proc_scilista_file_path.is_file():
+    proc_dir_scilista_list = list(proc_sps_packages_dir.glob(f"scilista-*.lst"))
+    if proc_dir_scilista_list:
+        _proc_scilista_file_path = proc_dir_scilista_list[0]
         Logger.info('Proc scilista "%s" already exists', _proc_scilista_file_path)
     else:
+        _scilista_filename = f"scilista-{gerapadrao_id}.lst"
         _origin_scilista_file_path = xc_sps_packages_dir / _scilista_filename
         if not _origin_scilista_file_path.is_file():
             raise FileNotFoundError(_origin_scilista_file_path)
 
+        _proc_scilista_file_path = proc_sps_packages_dir / _scilista_filename
         Logger.info(
             'Copying original scilista "%s" to proc "%s"',
             _origin_scilista_file_path,
@@ -80,7 +82,7 @@ def get_sps_packages(conf, **kwargs):
     _scilista_file_path = get_scilista_file_path(
         _xc_sps_packages_dir,
         _proc_sps_packages_dir,
-        kwargs["execution_date"].to_date_string(), # Data da primeira execução da DAG
+        Variable.get("GERAPADRAO_ID_FOR_SCILISTA"),
     )
     _sps_packages = pre_sync_documents_to_kernel_operations.get_sps_packages(
         _scilista_file_path,

--- a/airflow/tests/test_pre_sync_documents_to_kernel.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel.py
@@ -28,38 +28,38 @@ class TestGetScilistaFilePath(TestCase):
             get_scilista_file_path(
                 pathlib.Path("no/dir/path"),
                 pathlib.Path(self.proc_dir),
-                "2020-12-31",
+                "2020-12-31-08172297086458",
             )
-        self.assertIn(str(exc_info.exception), "no/dir/path/scilista-2020-12-31.lst")
+        self.assertIn(str(exc_info.exception), "no/dir/path/scilista-2020-12-31-08172297086458.lst")
 
     def test_scilista_already_exists_in_proc(self):
-        scilista_path_origin = pathlib.Path(self.gate_dir) / "scilista-2020-01-01.lst"
+        scilista_path_origin = pathlib.Path(self.gate_dir) / "scilista-2020-01-01-12204897086458.lst"
         scilista_path_origin.write_text("acron v1n22")
-        scilista_path_proc = pathlib.Path(self.proc_dir) / "scilista-2020-01-01.lst"
+        scilista_path_proc = pathlib.Path(self.proc_dir) / "scilista-2020-01-01-10204897086458.lst"
         scilista_path_proc.write_text("acron v1n20")
         _scilista_file_path = get_scilista_file_path(
             pathlib.Path(self.gate_dir),
             pathlib.Path(self.proc_dir),
-            "2020-01-01",
+            "2020-01-01-10204897086458",
         )
 
         self.assertEqual(
             _scilista_file_path,
-            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01.lst")
+            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01-10204897086458.lst")
         )
         self.assertEqual(scilista_path_proc.read_text(), "acron v1n20")
 
     def test_scilista_must_be_copied(self):
-        scilista_path = pathlib.Path(self.gate_dir) / "scilista-2020-01-01.lst"
+        scilista_path = pathlib.Path(self.gate_dir) / "scilista-2020-01-01-19032697086458.lst"
         scilista_path.write_text("acron v1n20")
         _scilista_file_path = get_scilista_file_path(
             pathlib.Path(self.gate_dir),
             pathlib.Path(self.proc_dir),
-            "2020-01-01",
+            "2020-01-01-19032697086458",
         )
         self.assertEqual(
             _scilista_file_path,
-            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01.lst")
+            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01-19032697086458.lst")
         )
 
 
@@ -67,17 +67,14 @@ class TestGetSPSPackages(TestCase):
     def setUp(self):
         self.dir_source = tempfile.mkdtemp()
         self.dir_dest = tempfile.mkdtemp()
-        self._execution_date = pendulum.now(pendulum.timezone("America/Sao_Paulo"))
-        self._scilista_basename = "scilista-{}.lst".format(
-            self._execution_date.to_date_string()
-        )
+        self.id_proc_gerapadrao = "2020-01-01-16412600000000"
+        self._scilista_basename = f"scilista-{self.id_proc_gerapadrao}.lst"
         self._scilista_path = pathlib.Path(self.dir_source) / self._scilista_basename
         self._scilista_path.write_text("package 01")
         self.kwargs = {
             "ti": MagicMock(),
             "conf": None,
             "run_id": "test_run_id",
-            "execution_date": self._execution_date,
         }
 
     def tearDown(self):
@@ -99,6 +96,7 @@ class TestGetSPSPackages(TestCase):
         mk_variable_get.side_effect = [
             self.dir_source,
             self.dir_dest,
+            self.id_proc_gerapadrao,
         ]
         _sps_packages = ["package_01", "package_02", "package_03"]
         mk_get_sps_packages.return_value = _sps_packages
@@ -116,6 +114,7 @@ class TestGetSPSPackages(TestCase):
         mk_variable_get.side_effect = [
             self.dir_source,
             self.dir_dest,
+            self.id_proc_gerapadrao,
         ]
         mk_get_sps_packages.return_value = []
         _exec_start_sync_packages = get_sps_packages(**self.kwargs)

--- a/proc/CallPrepSyncToKernel.bat
+++ b/proc/CallPrepSyncToKernel.bat
@@ -1,8 +1,8 @@
 # Disponibiliza pacotes SPS resultantes do XML Converter + scilista + log
 # para o SciELO Publishing Framework 
 
-PREP_LOG=log/PrepSyncToKernel-$(date "+%Y-%m-%d").log
-./PrepSyncToKernel.bat > $PREP_LOG
+PREP_LOG=log/PrepSyncToKernel-$1.log
+./PrepSyncToKernel.bat $1 > $PREP_LOG
 
 if [ -f SyncToKernel.ini ];
 then

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -6,10 +6,10 @@
 # XC_SPS_PACKAGES: path do diretório com todos os pacotes gerados pelo XC
 # XC_KERNEL_GATE: path do diretório para copia dos pacotes como estao no momento que o processamento do GeraPadrao e iniciado
 
-TODAY_DATE=$(date "+%Y-%m-%d")
+ID_PROC=$1
 
 echo ""
-echo "$TODAY_DATE - Executing $0 from `pwd`"
+echo "${ID_PROC} - Executing $0 from `pwd`"
 echo ""
 
 if [ -f SyncToKernel.ini ];
@@ -144,10 +144,10 @@ then
     echo "--------------------------------------------------------"
  
     echo
-    echo "Copiando scilista de $SCILISTA_PATH para a área do Escalonador em ${XC_KERNEL_GATE}/scilista-$TODAY_DATE.lst"
+    echo "Copiando scilista de $SCILISTA_PATH para a área do Escalonador em ${XC_KERNEL_GATE}/scilista-${ID_PROC}.lst"
     echo
 
-    cp ${SCILISTA_PATH} "${XC_KERNEL_GATE}/scilista-$TODAY_DATE.lst"
+    cp ${SCILISTA_PATH} "${XC_KERNEL_GATE}/scilista-${ID_PROC}.lst"
 
     echo
     echo "SPS Packages and Scilista copied successfully!"


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige a leitura da `scilista` pela DAG `pre_sync_documents_to_kernel`, que se baseava na data de execução da DAG e que pode acontecer em dia diferente do processamento.

Foi feita alteração no script `PrepSyncToKernel` para receber ID do GeraPadrao, que é utilizado na identificação da `scilista` e dos logs gerados pelo script. Também foi alterada a DAG `pre_sync_documents_to_kernel` para utilizar este ID, armazenado em `Variables`, na leitura da `scilista`. Assim, ao invés da data de execução do DagRun, passa a obter o valor do GeraPadrao ID, usado para identificar a scilista de novos processamentos. Este ID será usado somente caso não exista uma scilista 
associada a esse DagRun, para manter a idempotência da execução.

#### Onde a revisão poderia começar?
Commit a5e366d.

#### Como este poderia ser testado manualmente?
Com pacotes em um diretório alimentado pelo XC, as configurações necessárias para a execução dos scripts do `/proc` e uma scilista:
1. Acesse o diretório `/proc` e execute o script `CallPrepSyncToKernel.bat <ID GeraPadrao Fake>`
2. Os pacotes relacionados à scilista devem ser movidos para o diretório de destino (Kernel-Gate) com uma cópia da scilista, identificada com o `<ID GeraPadrao Fake>`
3. Execute a DAG `pre_sync_documents_to_kernel`
4. Os pacotes relacionados à scilista devem ser copiados para o diretório de destino (PROC Airflow), identificado com o DagRun ID, junto com uma cópia da scilista, identificada com o <ID GeraPadrao Fake>.
5. Faça o _clear_ em `get_sps_packages_task` da DAG `pre_sync_documentos_to_kernel` já executada e o passo 5 deve ocorrer normalmente, sem erros
7. Faça o _clear_ em `start_sync_packages_task_id` da DAG `pre_sync_documentos_to_kernel` já executada

#### Algum cenário de contexto que queira dar?
Este PR depende do #202

### Screenshots
n/a

#### Quais são tickets relevantes?
#200 

### Referências
.