### PR TITLE
[FASE 3] Alterar comando `rsync` para resolver o erro que estava ocorrendo

### DIFF
--- a/proc/CallPrepSyncToKernel.bat
+++ b/proc/CallPrepSyncToKernel.bat
@@ -6,7 +6,7 @@ PREP_LOG=log/PrepSyncToKernel-$1.log
 
 if [ -f SyncToKernel.ini ];
 then
-    . SyncToKernel.ini
+    . ./SyncToKernel.ini
 fi
 
 if [ "" != "${XC_KERNEL_GATE}" ] && [ -e ${XC_KERNEL_GATE} ];

--- a/proc/CallTriggerSyncIsisToKernel.bat
+++ b/proc/CallTriggerSyncIsisToKernel.bat
@@ -8,7 +8,7 @@ TRIGGER_LOG=log/TriggerSyncIsisToKernel-${GERAPADRAO_ID}.log
 
 if [ -f SyncToKernel.ini ];
 then
-    . SyncToKernel.ini
+    . ./SyncToKernel.ini
 fi
 
 if [ "" != "${XC_KERNEL_GATE}" ] && [ -e ${XC_KERNEL_GATE} ];

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -116,7 +116,8 @@ then
                 then
                     echo "  Moving pack ${PACK_FILE} to ${XC_KERNEL_GATE} ..."
                     echo
-                    rsync -qa --inplace --remove-source-files "${PACK_FILE}" ${XC_KERNEL_GATE}
+                    rsync -qa --inplace "${PACK_FILE}" ${XC_KERNEL_GATE}
+                    rm "${PACK_FILE}"
                 else
                     if [[ "$ISSUE" == *"ahead"* ]];
                     then

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -15,7 +15,7 @@ echo ""
 if [ -f SyncToKernel.ini ];
 then
     echo "VARIABLES read from file SyncToKernel.ini"
-    . SyncToKernel.ini
+    . ./SyncToKernel.ini
     echo
     echo SCILISTA_PATH=$SCILISTA_PATH
     echo XC_SPS_PACKAGES=$XC_SPS_PACKAGES

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -102,6 +102,12 @@ then
         echo "ACRON: $ACRON | ISSUE: $ISSUE"
         echo
 
+        if [ "${ACRON}" = "" ] && [ "${ISSUE}" = "" ];
+        then
+            echo "Blank line, continue"
+            continue
+        fi
+
         if [[ $(tr '[:upper:]' '[:lower:]' <<< "$DEL_COMMAND") = del ]];
         then
             echo "  Package to delete: ${ACRON}_${ISSUE}"
@@ -136,7 +142,7 @@ then
 
     echo "--------------------------------------------------------"
     echo "Number of items: "
-    echo "`cat ${SCILISTA_PATH_TMP} | wc -l` in ${SCILISTA_PATH} (original)"
+    echo "`cat ${SCILISTA_PATH_TMP} | wc -l` in ${SCILISTA_PATH_TMP} (original)"
     echo "`cat ${SCILISTA_PATH} | wc -l` in ${SCILISTA_PATH} (no repetition)"
     echo "`ls ${XC_SPS_PACKAGES} | wc -l` in ${XC_SPS_PACKAGES}"
     echo "`ls ${XC_KERNEL_GATE} | wc -l` in ${XC_KERNEL_GATE}"

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -122,8 +122,7 @@ then
                 then
                     echo "  Moving pack ${PACK_FILE} to ${XC_KERNEL_GATE} ..."
                     echo
-                    rsync -qa --inplace "${PACK_FILE}" ${XC_KERNEL_GATE}
-                    rm "${PACK_FILE}"
+                    mv "${PACK_FILE}" ${XC_KERNEL_GATE}
                 else
                     if [[ "$ISSUE" == *"ahead"* ]];
                     then

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -94,6 +94,7 @@ fi
 if [ -f ${SCILISTA_PATH} ] && [ -e ${XC_SPS_PACKAGES} ] && [ -e ${XC_KERNEL_GATE} ];
 then
     while read LINE; do
+        echo "LINE: ${LINE}"
         ACRON="$(echo $LINE | cut -f1 -d ' ')"
         ISSUE="$(echo $LINE | cut -f2 -d ' ')"
         DEL_COMMAND="$(echo $LINE | cut -f3 -d ' ')"

--- a/proc/TriggerSyncIsisToKernel.bat
+++ b/proc/TriggerSyncIsisToKernel.bat
@@ -3,7 +3,7 @@ GERAPADRAO_ID=$1
 if [ -f SyncToKernel.ini ];
 then
     echo "VARIABLES read from file SyncToKernel.ini"
-    . SyncToKernel.ini
+    . ./SyncToKernel.ini
 fi
 
 if [ "" == "${OPAC_AIRFLOW}" ];


### PR DESCRIPTION
#### O que esse PR faz?
Alterar comando `rsync` para resolver o erro que estava ocorrendo:

```
rsync: close failed on "/var/www/scielo_br/spf/": Invalid argument (22)
rsync error: error in file IO (code 11) at receiver.c(859) [receiver=3.1.2]
```

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
1. Entre no ambiente de homologação (`/var/www/scielo_br/proc_spf`)
2. Copie pelo menos um pacote de `/var/www/scielo_br/xc_gerapadrao` para  `/var/www/scielo_br/proc_spf/xc_gerapadrao` 
3. Crie uma scilista em `/var/www/scielo_br/proc_spf/`, colocando linhas em branco e pelo menos um acron volumenumero correspondente ao inserido na pasta `/var/www/scielo_br/proc_spf/xc_gerapadrao`
4. Execute o ./PreSyncToKernel.bat, no ambiente de homologação (`/var/www/scielo_br/proc_spf/`)
5. Observe os arquivos gerados em: `/var/www/scielo_br/spf_hml`.
- PreSyncToKernel*.log
- o arquivo *.zip
- Veja o conteúdo de PrepSyncToKernel*.log:
a) note que está escrito "LINE: <conteudo da linha>" para todas as linhas 
b) note que quando ACRON e ISSUE são str em branco, a mensagem é "Blank line, continue"
c) rsync executou sem apresentar erro

#### Algum cenário de contexto que queira dar?
Neste meio tempo (de abertura do PR, testes etc), adotamos a **proposta 3**, com orientações de Rondineli
https://github.com/scieloorg/opac-airflow/issues/206.
Então, no lugar de `rsync`, faremos `mv` para uma pasta local e do ponto de vista do airflow esta pasta será um ponto de montagem.

### Screenshots
n/a

#### Quais são tickets relevantes?
#204, #205

### Referências
n/a
