### PR TITLE
[FASE 3][GeraPadrao] Ajusta PreSyncToKernel para evitar manipular a scilista original em concorrência com GeraScielo.bat

### DIFF
--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -7,6 +7,7 @@
 # XC_KERNEL_GATE: path do diretório para copia dos pacotes como estao no momento que o processamento do GeraPadrao e iniciado
 
 ID_PROC=$1
+SCILISTA_PATH_TMP=/tmp/scilista-${ID_PROC}.lst
 
 echo ""
 echo "${ID_PROC} - Executing $0 from `pwd`"
@@ -34,6 +35,8 @@ else
         ERROR=1
     fi
 fi
+
+cp ${SCILISTA_PATH} ${SCILISTA_PATH_TMP}
 
 if [ "" == "${XC_SPS_PACKAGES}" ];
 then
@@ -84,8 +87,6 @@ echo XC_KERNEL_GATE=$XC_KERNEL_GATE
 echo
 echo ===============
 
-SCILISTA_PATH_TMP=/tmp/scilista.lst
-cp $SCILISTA_PATH $SCILISTA_PATH_TMP
 if [ -e $SCILISTA_PATH_TMP ];
 then
     cat $SCILISTA_PATH_TMP | sort -u > $SCILISTA_PATH

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -87,12 +87,19 @@ echo XC_KERNEL_GATE=$XC_KERNEL_GATE
 echo
 echo ===============
 
-if [ -e $SCILISTA_PATH_TMP ];
+AIRFLOW_SCILISTA_PATH=${XC_KERNEL_GATE}/scilista-${ID_PROC}.lst
+
+if [ -f ${SCILISTA_PATH_TMP} ];
 then
-    cat $SCILISTA_PATH_TMP | sort -u > $SCILISTA_PATH
+    echo
+    echo "Removendo duplicidade de scilista ${SCILISTA_PATH_TMP}"
+    echo "e copiando para a área do Escalonador em ${AIRFLOW_SCILISTA_PATH}"
+    echo
+
+    cat ${SCILISTA_PATH_TMP} | sort -u > ${AIRFLOW_SCILISTA_PATH}
 fi
 
-if [ -f ${SCILISTA_PATH} ] && [ -e ${XC_SPS_PACKAGES} ] && [ -e ${XC_KERNEL_GATE} ];
+if [ -f ${AIRFLOW_SCILISTA_PATH} ] && [ -e ${XC_SPS_PACKAGES} ] && [ -e ${XC_KERNEL_GATE} ];
 then
     while read LINE; do
         echo "LINE: ${LINE}"
@@ -138,12 +145,12 @@ then
                 fi
             done
         fi
-    done < $SCILISTA_PATH
+    done < ${AIRFLOW_SCILISTA_PATH}
 
     echo "--------------------------------------------------------"
     echo "Number of items: "
     echo "`cat ${SCILISTA_PATH_TMP} | wc -l` in ${SCILISTA_PATH_TMP} (original)"
-    echo "`cat ${SCILISTA_PATH} | wc -l` in ${SCILISTA_PATH} (no repetition)"
+    echo "`cat ${AIRFLOW_SCILISTA_PATH} | wc -l` in ${AIRFLOW_SCILISTA_PATH} (no repetition)"
     echo "`ls ${XC_SPS_PACKAGES} | wc -l` in ${XC_SPS_PACKAGES}"
     echo "`ls ${XC_KERNEL_GATE} | wc -l` in ${XC_KERNEL_GATE}"
     echo "--------------------------------------------------------"
@@ -151,12 +158,6 @@ then
     grep ERROR $ERRORFILE
     echo "--------------------------------------------------------"
  
-    echo
-    echo "Copiando scilista de $SCILISTA_PATH para a área do Escalonador em ${XC_KERNEL_GATE}/scilista-${ID_PROC}.lst"
-    echo
-
-    cp ${SCILISTA_PATH} "${XC_KERNEL_GATE}/scilista-${ID_PROC}.lst"
-
     echo
     echo "SPS Packages and Scilista copied successfully!"
     echo

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -159,7 +159,7 @@ then
     echo "--------------------------------------------------------"
  
     echo
-    echo "SPS Packages and Scilista copied successfully!"
+    echo "PrepSyncToKernel finalizado"
     echo
 else
     echo


### PR DESCRIPTION
#### O que esse PR faz?
Ajusta `PreSyncToKernel.bat` para evitar manipular a scilista original em concorrência com `GeraScielo.bat`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
1. Tenha o ambiente preparado. 

- Crie diretório de origem com arquivos ZIP, simulando o diretório de saída do XC.
  Ex:
```
$ ls dir_origem
2020-07-13-16-03-47-785030_acron_v1n2.zip
2020-07-13-16-03-47-785030_abc_v1n1.zip
2020-07-13-16-03-47-785030_ag_v42.zip
2020-07-13-16-03-47-785030_axy_2020nahead.zip
2020-07-13-16-03-47-785030_csp_v4nspe3.zip
```
- Crie diretório de destino, simulando o diretório do SPF. Ex: `dir_destino`
- Crie `scilista.lst` com conteúdo de fascículos.
```
acron v1n2
abc v1n1
ag v42
csp v4nspe3
```
- Acesse o diretório `proc/`, crie uma cópia do arquivo `SyncToKernel.ini.template` e configure as variáveis `SCILISTA_PATH`, `XC_SPS_PACKAGES` e `XC_KERNEL_GATE`

```
SCILISTA_PATH=scilista.lst
XC_SPS_PACKAGES=dir_origem
XC_KERNEL_GATE=dir_destino
```

2. Execute `./CallPreSyncToKernel <ID>`, sendo `<ID>` uma string que sirva de ID.

3. Verifique que os arquivos foram criados em `dir_destino`:
- scilista-GERAPADRAO-ID.lst
- PrepSyncToKernel-GERAPADRAO-ID.log
- 2020-07-13-16-03-47-785030_acron_v1n2.zip
- 2020-07-13-16-03-47-785030_abc_v1n1.zip
- 2020-07-13-16-03-47-785030_ag_v42.zip
- 2020-07-13-16-03-47-785030_csp_v4nspe3.zip

4. Observe em `dir_destino/PrepSyncToKernel-GERAPADRAO-ID.log`, a mensagem:

```
Removendo duplicidade de scilista /tmp/scilista-GERAPADRAO-ID.lst
e copiando para a área do Escalonador em dir_destino/scilista-GERAPADRAO-ID.lst
```
sendo que `GERAPADRAO-ID` é a string passada como parâmetro


#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#209

### Referências
n/a