### PR TITLE
Melhorias na DAG `check_website`

### DIFF
--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -144,12 +144,21 @@ def get_uri_list_file_paths(conf, **kwargs):
         if _uri_list_file_path not in file_paths:
             file_paths.append(_uri_list_file_path)
 
-    kwargs["ti"].xcom_push("old_uri_list_file_paths", sorted(old_file_paths))
-    kwargs["ti"].xcom_push("new_uri_list_file_paths", sorted(file_paths))
-    kwargs["ti"].xcom_push("uri_list_file_paths", sorted(old_file_paths + file_paths))
     Logger.info("Found: %s", file_paths)
+
     # atribui um str vazia para sinalizar que o valor foi usado
     Variable.set("GERAPADRAO_ID_FOR_URI_LIST", [], serialize_json=True)
+
+    if old_file_paths or file_paths:
+        kwargs["ti"].xcom_push(
+            "old_uri_list_file_paths", sorted(old_file_paths))
+        kwargs["ti"].xcom_push(
+            "new_uri_list_file_paths", sorted(file_paths))
+        kwargs["ti"].xcom_push(
+            "uri_list_file_paths", sorted(old_file_paths + file_paths))
+        return True
+    else:
+        return False
 
 
 def get_uri_items_from_uri_list_files(**context):
@@ -575,7 +584,7 @@ def check_input_vs_processed_pids(**context):
         present_in_pid_items_but_not_in_processed)
 
 
-get_uri_list_file_paths_task = PythonOperator(
+get_uri_list_file_paths_task = ShortCircuitOperator(
     task_id="get_uri_list_file_paths_id",
     provide_context=True,
     python_callable=get_uri_list_file_paths,

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -324,6 +324,7 @@ def get_uri_items_grouped_by_script_name(**context):
         Logger.info(
             "Total %i URIs for `%s`", len(_items), script_name)
         context["ti"].xcom_push(script_name, sorted(_items))
+    return bool(items)
 
 
 def get_website_url_list():
@@ -646,7 +647,7 @@ merge_uri_items_from_different_sources_task = PythonOperator(
     dag=dag,
 )
 
-get_uri_items_grouped_by_script_name_task = PythonOperator(
+get_uri_items_grouped_by_script_name_task = ShortCircuitOperator(
     task_id="get_uri_items_grouped_by_script_name_id",
     provide_context=True,
     python_callable=get_uri_items_grouped_by_script_name,

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -281,12 +281,17 @@ def group_uri_items_from_uri_lists_by_script_name(**context):
                 task_ids="get_uri_items_from_uri_list_files_id",
                 key="uri_items"
             )
-    Logger.info("Total %i URIs", len(uri_items))
+    total = len(uri_items or [])
+    Logger.info("Total %i URIs", total)
+    if total == 0:
+        return True
+
     items = check_website_operations.group_items_by_script_name(uri_items)
     for script_name, _items in items.items():
         Logger.info(
             "Total %i URIs for `%s`", len(_items), script_name)
         context["ti"].xcom_push(script_name, sorted(_items))
+    return len(items) > 0
 
 
 def merge_uri_items_from_different_sources(**context):

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -363,11 +363,15 @@ def check_any_uri_items(uri_list_items, label, dag_info):
     flag_name = "CHECK_{}_PAGES".format(label.upper())
     flag = get_task_execution_flag(
         flag_name, "checking '%s' pages".format(label))
-
     if flag is False:
         return 0
 
     _website_url_list = get_website_url_list()
+
+    total = len(uri_list_items or [])
+    Logger.info("Total URI items: %i", total)
+    if total == 0:
+        return 0
 
     # concatena cada item de `_website_url_list` com
     # cada item de `uri_list_items`

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -295,18 +295,19 @@ def merge_uri_items_from_different_sources(**context):
     removendo repetições
     """
     Logger.info("Merge URI items from `uri_list_*.lst` and `*.csv`")
-    uri_items = set(
-            context["ti"].xcom_pull(
-                task_ids="get_uri_items_from_uri_list_files_id",
-                key="uri_items"
-            ) +
-            context["ti"].xcom_pull(
-                task_ids="get_uri_items_from_pid_list_csv_files_id",
-                key="uri_items"
-            )
-    )
+    uri_items_from_lst = context["ti"].xcom_pull(
+        task_ids="get_uri_items_from_uri_list_files_id",
+        key="uri_items"
+    ) or []
+    uri_items_from_csv = context["ti"].xcom_pull(
+        task_ids="get_uri_items_from_pid_list_csv_files_id",
+        key="uri_items"
+    ) or []
+
+    uri_items = set(uri_items_from_lst + uri_items_from_csv)
     Logger.info("Total %i URIs", len(uri_items))
     context["ti"].xcom_push("uri_items", sorted(uri_items))
+    return True
 
 
 def get_uri_items_grouped_by_script_name(**context):

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -229,11 +229,11 @@ def get_pid_list_csv_file_paths(**kwargs):
     Logger.info("Found: %s", file_paths)
     if old_file_paths or file_paths:
         kwargs["ti"].xcom_push(
-            "old_uri_list_file_paths", sorted(old_file_paths))
+            "old_file_paths", sorted(old_file_paths))
         kwargs["ti"].xcom_push(
-            "new_uri_list_file_paths", sorted(file_paths))
+            "new_file_paths", sorted(file_paths))
         kwargs["ti"].xcom_push(
-            "uri_list_file_paths", sorted(old_file_paths + file_paths))
+            "file_paths", sorted(old_file_paths + file_paths))
         return True
     else:
         return False

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -220,10 +220,17 @@ def get_pid_list_csv_file_paths(**kwargs):
         if _pid_list_csv_file_path not in file_paths:
             file_paths.append(_pid_list_csv_file_path)
 
-    kwargs["ti"].xcom_push("old_file_paths", sorted(old_file_paths))
-    kwargs["ti"].xcom_push("new_file_paths", sorted(file_paths))
-    kwargs["ti"].xcom_push("file_paths", sorted(old_file_paths + file_paths))
     Logger.info("Found: %s", file_paths)
+    if old_file_paths or file_paths:
+        kwargs["ti"].xcom_push(
+            "old_uri_list_file_paths", sorted(old_file_paths))
+        kwargs["ti"].xcom_push(
+            "new_uri_list_file_paths", sorted(file_paths))
+        kwargs["ti"].xcom_push(
+            "uri_list_file_paths", sorted(old_file_paths + file_paths))
+        return True
+    else:
+        return False
 
 
 def get_uri_items_from_pid_list_csv_files(**context):
@@ -598,7 +605,7 @@ get_uri_items_from_uri_list_files_task = PythonOperator(
     dag=dag,
 )
 
-get_pid_list_csv_file_paths_task = PythonOperator(
+get_pid_list_csv_file_paths_task = ShortCircuitOperator(
     task_id="get_pid_list_csv_file_paths_id",
     provide_context=True,
     python_callable=get_pid_list_csv_file_paths,

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -1604,6 +1604,23 @@ class TestMergeUriItemsFromDifferentSources(TestCase):
             ]
         )
 
+    def test_merge_uri_items_from_different_sources_returns_false(self):
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            None,
+            None,
+        ]
+        result = merge_uri_items_from_different_sources(**self.kwargs)
+        self.assertFalse(result)
+        self.assertListEqual([
+            call(key="uri_items",
+                 task_ids="get_uri_items_from_uri_list_files_id",),
+            call(key="uri_items",
+                 task_ids="get_uri_items_from_pid_list_csv_files_id",)
+            ],
+            self.kwargs["ti"].xcom_pull.call_args_list
+        )
+        self.kwargs["ti"].xcom_push.assert_not_called()
+
 
 class TestCheckInputVsProcessedPids(TestCase):
 

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -489,7 +489,7 @@ class TestGetUriItemsGroupedByScriptName(TestCase):
         }
 
     @patch("check_website.Logger.info")
-    def test_get_uri_items_grouped_by_script_name(self, mock_info):
+    def test_get_uri_items_grouped_by_script_name_returns_true(self, mock_info):
         uri_list = [
             "/scielo.php?script=sci_arttext&pid=S0001-30352020000501101",
             "/scielo.php?script=sci_arttext&pid=S0001-37652020000501101",
@@ -519,7 +519,8 @@ class TestGetUriItemsGroupedByScriptName(TestCase):
             "/scielo.php?script=sci_serial&pid=1213-1998",
         ]
         self.kwargs["ti"].xcom_pull.return_value = uri_list
-        get_uri_items_grouped_by_script_name(**self.kwargs)
+        result = get_uri_items_grouped_by_script_name(**self.kwargs)
+        self.assertTrue(result)
         self.kwargs["ti"].xcom_pull.assert_called_once_with(
             task_ids="merge_uri_items_from_different_sources_id",
             key="uri_items"
@@ -594,6 +595,16 @@ class TestGetUriItemsGroupedByScriptName(TestCase):
             ),
             self.kwargs["ti"].xcom_push.call_args_list
         )
+
+    @patch("check_website.Logger.info")
+    def test_get_uri_items_grouped_by_script_name_returns_false(self, mock_info):
+        bad_uri_list = [
+            "/scielo.php?param1=sci_arttext&pid=S0001-30352020000501101",
+        ]
+        self.kwargs["ti"].xcom_pull.return_value = bad_uri_list
+        result = get_uri_items_grouped_by_script_name(**self.kwargs)
+        self.assertFalse(result)
+        self.kwargs["ti"].xcom_push.assert_not_called()
 
 
 class TestGetWebsiteURLlist(TestCase):

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -805,6 +805,33 @@ class TestCheckAnyUriItems(TestCase):
             "run_id": "test_run_id",
         }
 
+    @patch("check_website.Variable.get")
+    def test_check_any_uri_items_returns_0_because_flag_is_off(self, mock_get):
+        uri_items = [
+            "/scielo.php?script=sci_issues&pid=0001-3035",
+            "/scielo.php?script=sci_issues&pid=0001-3765",
+        ]
+        mock_get.return_value = False
+        result = check_any_uri_items(uri_items, "label", {"daginfo": ""})
+        self.assertEqual(0, result)
+
+    @patch("check_website.Variable.get")
+    def test_check_any_uri_items_raises_value_error(self, mock_get):
+        uri_items = [
+            "/scielo.php?script=sci_issues&pid=0001-3035",
+            "/scielo.php?script=sci_issues&pid=0001-3765",
+        ]
+        mock_get.return_value = None
+        with self.assertRaises(ValueError):
+            check_any_uri_items(uri_items, "label", {"daginfo": ""})
+
+    @patch("check_website.Variable.get")
+    def test_check_any_uri_items_returns_0_because_uri_items_is_None(self, mock_get):
+        uri_items = None
+        mock_get.return_value = ["https://www.scielo.br"]
+        result = check_any_uri_items(uri_items, "label", {"daginfo": ""})
+        self.assertEqual(0, result)
+
     @patch("check_website.check_website_operations.concat_website_url_and_uri_list_items")
     @patch("check_website.Variable.get")
     def test_check_any_uri_items_assert_called_once_concat_website_url_and_uri_list_items(
@@ -814,7 +841,12 @@ class TestCheckAnyUriItems(TestCase):
             "/scielo.php?script=sci_issues&pid=0001-3765",
         ]
         mock_get.return_value = ["https://www.scielo.br"]
-        check_any_uri_items(uri_items, "label", {"daginfo": ""})
+        mock_concat_website_url_and_uri_list_items.return_value = [
+            "https://www.scielo.br/scielo.php?script=sci_issues&pid=0001-3035",
+            "https://www.scielo.br/scielo.php?script=sci_issues&pid=0001-3765",
+        ]
+        result = check_any_uri_items(uri_items, "label", {"daginfo": ""})
+        self.assertEqual(2, result)
         mock_concat_website_url_and_uri_list_items.assert_called_once_with(
             ["https://www.scielo.br"],
             [
@@ -833,7 +865,8 @@ class TestCheckAnyUriItems(TestCase):
         ]
         mock_get.return_value = ["https://www.scielo.br"]
         mock_check_website_uri_list.return_value = MagicMock(), MagicMock()
-        check_any_uri_items(uri_items, "label", self.kwargs)
+        result = check_any_uri_items(uri_items, "label", self.kwargs)
+        self.assertEqual(2, result)
         mock_check_website_uri_list.assert_called_once_with(
             [
                 "https://www.scielo.br/scielo.php?script=sci_issues&pid=0001-3035",
@@ -896,7 +929,8 @@ class TestCheckAnyUriItems(TestCase):
             failures,
         )
         dag_info = {"dag": "daginfo"}
-        check_any_uri_items(uri_items, "label", dag_info, )
+        result = check_any_uri_items(uri_items, "label", dag_info)
+        self.assertEqual(4, result)
 
         calls = [
             call(failures, dag_info),
@@ -1014,7 +1048,8 @@ class TestCheckAnyUriItems(TestCase):
                 "pid_v2_doc": None,
             },
         ]
-        check_any_uri_items(uri_items, "label", dag_info)
+        result = check_any_uri_items(uri_items, "label", dag_info)
+        self.assertEqual(4, result)
         calls = [
             call("sci_pages_availability", expected[0]),
             call("sci_pages_availability", expected[1]),
@@ -1133,7 +1168,8 @@ class TestCheckAnyUriItems(TestCase):
                 "pid_v2_doc": None,
             },
         ]
-        check_any_uri_items(uri_items, "label", dag_info)
+        result = check_any_uri_items(uri_items, "label", dag_info)
+        self.assertEqual(4, result)
         calls = [
             call("sci_pages_availability", expected[0]),
             call("sci_pages_availability", expected[1]),
@@ -1242,7 +1278,8 @@ class TestCheckAnyUriItems(TestCase):
                 "pid_v2_doc": None,
             },
         ]
-        check_any_uri_items(uri_items, "label", dag_info)
+        result = check_any_uri_items(uri_items, "label", dag_info)
+        self.assertEqual(4, result)
         calls = [
             call("sci_pages_availability", expected[0]),
             call("sci_pages_availability", expected[1]),

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -832,10 +832,12 @@ class TestCheckAnyUriItems(TestCase):
         result = check_any_uri_items(uri_items, "label", {"daginfo": ""})
         self.assertEqual(0, result)
 
+    @patch("check_website.check_website_operations.check_website_uri_list")
     @patch("check_website.check_website_operations.concat_website_url_and_uri_list_items")
     @patch("check_website.Variable.get")
     def test_check_any_uri_items_assert_called_once_concat_website_url_and_uri_list_items(
-            self, mock_get, mock_concat_website_url_and_uri_list_items):
+            self, mock_get, mock_concat_website_url_and_uri_list_items,
+            mock_check_website_uri_list):
         uri_items = [
             "/scielo.php?script=sci_issues&pid=0001-3035",
             "/scielo.php?script=sci_issues&pid=0001-3765",
@@ -845,6 +847,7 @@ class TestCheckAnyUriItems(TestCase):
             "https://www.scielo.br/scielo.php?script=sci_issues&pid=0001-3035",
             "https://www.scielo.br/scielo.php?script=sci_issues&pid=0001-3765",
         ]
+        mock_check_website_uri_list.return_value = MagicMock(), MagicMock()
         result = check_any_uri_items(uri_items, "label", {"daginfo": ""})
         self.assertEqual(2, result)
         mock_concat_website_url_and_uri_list_items.assert_called_once_with(

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -1614,6 +1614,7 @@ class TestMergeUriItemsFromDifferentSources(TestCase):
             ]
         )
 
+
 class TestCheckInputVsProcessedPids(TestCase):
 
     def setUp(self):
@@ -1637,7 +1638,8 @@ class TestCheckInputVsProcessedPids(TestCase):
                 "0001-376520200005",
             ],
         ]
-        check_input_vs_processed_pids(**self.kwargs)
+        result = check_input_vs_processed_pids(**self.kwargs)
+        self.assertTrue(result)
 
         self.assertListEqual([
             call(key="sci_arttext",
@@ -1664,10 +1666,16 @@ class TestCheckInputVsProcessedPids(TestCase):
                 "0001-303520200005", "0001-376520200005",
             ]
         ]
-        check_input_vs_processed_pids(**self.kwargs)
+        result = check_input_vs_processed_pids(**self.kwargs)
+        self.assertTrue(result)
 
         self.assertListEqual([
-                call("Merge PID items from `uri_list_*.lst` and `*.csv`"),
+                call(
+                    "Check if all the PID items from `uri_list_*.lst` "
+                    "and `*.csv` were processed at the end"
+                ),
+                call("Total %i PIDs v2 from uri_list", 1),
+                call("Total %i PIDs v2 from csv", 1),
                 call("Total %i input PIDs", 2),
                 call("Total %i processed PIDs", 2),
                 call("All the PIDs were processed"),
@@ -1687,10 +1695,16 @@ class TestCheckInputVsProcessedPids(TestCase):
             ],
             []
         ]
-        check_input_vs_processed_pids(**self.kwargs)
+        result = check_input_vs_processed_pids(**self.kwargs)
+        self.assertFalse(result)
 
         self.assertListEqual([
-                call("Merge PID items from `uri_list_*.lst` and `*.csv`"),
+                call(
+                    "Check if all the PID items from `uri_list_*.lst` "
+                    "and `*.csv` were processed at the end"
+                ),
+                call("Total %i PIDs v2 from uri_list", 1),
+                call("Total %i PIDs v2 from csv", 1),
                 call("Total %i input PIDs", 2),
                 call("Total %i processed PIDs", 0),
             ],
@@ -1722,10 +1736,16 @@ class TestCheckInputVsProcessedPids(TestCase):
                 "0001-30352020XXX5",
             ]
         ]
-        check_input_vs_processed_pids(**self.kwargs)
+        result = check_input_vs_processed_pids(**self.kwargs)
+        self.assertTrue(result)
 
         self.assertListEqual([
-                call("Merge PID items from `uri_list_*.lst` and `*.csv`"),
+                call(
+                    "Check if all the PID items from `uri_list_*.lst` "
+                    "and `*.csv` were processed at the end"
+                ),
+                call("Total %i PIDs v2 from uri_list", 1),
+                call("Total %i PIDs v2 from csv", 1),
                 call("Total %i input PIDs", 2),
                 call("Total %i processed PIDs", 3),
                 call("All the PIDs were processed"),

--- a/airflow/tests/test_check_website_operations.py
+++ b/airflow/tests/test_check_website_operations.py
@@ -2783,7 +2783,7 @@ class TestGetPIDv3List(TestCase):
             "/scielo.php?script=sci_arttext&pid=S1234-56781987000102315",
             "/scielo.php?script=sci_arttext&pid=S1234-56781987000112345",
         ]
-        website_url = ["https://www.scielo.br", ]
+        website_url = "https://www.scielo.br"
         pid_list = get_pid_v3_list(uri_items, website_url)
         expected = [
             "S1Y3X-5678198700010Y3X5",


### PR DESCRIPTION
#### O que esse PR faz?
Revisa os tipos de operadores (PythonOperator ou ShortCircuitOperator) e, em consequência os retornos e os pré-requisitos de execução de cada tarefa da DAG `check_website`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver seção "Como este poderia ser testado manualmente", do #216

#### Algum cenário de contexto que queira dar?
- Inicialmente, neste PR, foi pensado que todas as tarefas poderiam ser `ShortCircuitOperator`, mas se uma tarefa é dependente de mais de 1 fluxo, como a `merge_uri_items_from_different_sources_task`, as tarefas das quais ela depende não podem parar, senão ela não é finalizada. 

### Screenshots
n/a

#### Quais são tickets relevantes?
closes #211

### Referências
ler descrição do PR #216
