### PR TITLE
Caso configurado um email, será enviado o relatório PreSyncToKernel.log

### DIFF
--- a/proc/CallPrepSyncToKernel.bat
+++ b/proc/CallPrepSyncToKernel.bat
@@ -1,8 +1,9 @@
 # Disponibiliza pacotes SPS resultantes do XML Converter + scilista + log
 # para o SciELO Publishing Framework 
 
-PREP_LOG=log/PrepSyncToKernel-$1.log
-./PrepSyncToKernel.bat $1 > $PREP_LOG
+ID_PROC=${1}
+PREP_LOG=log/PrepSyncToKernel-${ID_PROC}.log
+./PrepSyncToKernel.bat ${ID_PROC} > $PREP_LOG
 
 if [ -f SyncToKernel.ini ];
 then
@@ -12,4 +13,9 @@ fi
 if [ "" != "${XC_KERNEL_GATE}" ] && [ -e ${XC_KERNEL_GATE} ];
 then
     cp $PREP_LOG ${XC_KERNEL_GATE}
+fi
+
+if [ "" != "${EMAIL_TO}" ];
+then
+    mail -s "`cat /tmp/subject-${ID_PROC}.txt`" ${EMAIL_TO} < ${PREP_LOG}
 fi

--- a/proc/PrepSyncToKernel.bat
+++ b/proc/PrepSyncToKernel.bat
@@ -147,6 +147,10 @@ then
         fi
     done < ${AIRFLOW_SCILISTA_PATH}
 
+    TOTAL_ERRORS=`grep ERROR ${ERRORFILE} | wc -l | xargs`
+    TOTAL_ITEMS=`cat ${AIRFLOW_SCILISTA_PATH} | wc -l | xargs`
+    echo "PrepSyncToKernel ${ID_PROC} Not found ${TOTAL_ERRORS}/${TOTAL_ITEMS}" > /tmp/subject-${ID_PROC}.txt
+
     echo "--------------------------------------------------------"
     echo "Number of items: "
     echo "`cat ${SCILISTA_PATH_TMP} | wc -l` in ${SCILISTA_PATH_TMP} (original)"
@@ -158,6 +162,8 @@ then
     grep ERROR $ERRORFILE
     echo "--------------------------------------------------------"
  
+
+
     echo
     echo "PrepSyncToKernel finalizado"
     echo

--- a/proc/SyncToKernel.ini.template
+++ b/proc/SyncToKernel.ini.template
@@ -3,3 +3,4 @@ XC_SPS_PACKAGES=origem
 XC_KERNEL_GATE=destino
 OPAC_AIRFLOW=http://localhost:8080
 CISIS_DIR=cisis
+EMAIL_TO=DEVS@scielo.org


### PR DESCRIPTION
#### O que esse PR faz?
Envia email contendo o PreSyncToKernel.log ao executar GeraPadrao.bat, desde que o email esteja configurado

#### Onde a revisão poderia começar?
proc/SyncToKernel.ini.template
proc/CallPrepSyncToKernel.bat
proc/PrepSyncToKernel.bat

#### Como este poderia ser testado manualmente?
1. Tenha o ambiente preparado. 
- Crie diretório de origem com arquivos ZIP (não precisam ser reais), simulando o diretório de saída do XC.
  Ex:
```
$ ls dir_origem
2020-07-13-16-03-47-785030_ag_v42.zip
2020-07-13-16-03-47-785030_axy_2020nahead.zip
2020-07-13-16-03-47-785030_csp_v4nspe3.zip
```
- Crie diretório de destino, simulando o diretório do SPF. Ex: `dir_destino`
- Crie `scilista.lst` com conteúdo de fascículos.
```
acron v1n2
abc v1n1
ag v42
csp v4nspe3
```
- Acesse o diretório `proc/`, crie uma cópia do arquivo `SyncToKernel.ini.template` e configure as variáveis `SCILISTA_PATH`, `XC_SPS_PACKAGES`, `XC_KERNEL_GATE` e o email

```
SCILISTA_PATH=scilista.lst
XC_SPS_PACKAGES=dir_origem
XC_KERNEL_GATE=dir_destino
EMAIL_TO=
```
2. Em algum servidor, execute `./CallPreSyncToKernel <ID>`, sendo `<ID>` uma string que sirva de ID.
3. Verifique que você deve ter recebido um email 

#### Algum cenário de contexto que queira dar?
No assunto, apresenta quantos erros do total de itens da scilista
Nota: Pode haver mais "erros" que o total de itens da scilista, pois 1 erro para cada arquivo zip não encontrado e um item na scilista tem pelo menos 1 arquivo zip

### Screenshots
n/a

#### Quais são tickets relevantes?
#223 

### Referências
n/a
