### PR TITLE
Altera sincronização de documentos para sincronizar pacotes por bundle, não mais por pacote

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ $ airflow webserver
 * `BASE_TITLE_FOLDER_PATH`: Diretório de origem da base ISIS title
 * `BASE_ISSUE_FOLDER_PATH`: Diretório de origem da base ISIS issue
 * `WORK_FOLDER_PATH`: Diretório para a cópia das bases ISIS
-* `SCILISTA_FILE_PATH`: Caminho onde o arquivo `scilista` deverá ser lido
 * `XC_SPS_PACKAGES_DIR`: Diretório de origem dos pacotes SPS a serem sincronizados
 * `PROC_SPS_PACKAGES_DIR`: Diretório de destino dos pacotes SPS a serem sincronizados
 * `NEW_SPS_ZIP_DIR`: Diretório de destino dos pacotes SPS otimizados

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -70,6 +70,26 @@ def list_documents(sps_package):
         return xmls_filenames
 
 
+def delete_documents_from_packages(bundle_xmls: dict) -> Dict[str, List[str]]:
+    """
+    Deleta documentos informados do Kernel
+
+    dict bundle_xmls: dict com os paths dos pacotes SPS e os respectivos nomes dos
+        arquivos XML.
+    """
+    bundle_xmls_to_preserve = {}
+    delete_executions = []
+    for sps_package, xmls_filenames in bundle_xmls.items():
+        Logger.info("Reading sps_package: %s" % sps_package)
+        xmls_to_preserve, executions = delete_documents(sps_package, xmls_filenames)
+        if xmls_to_preserve:
+            bundle_xmls_to_preserve[sps_package] = xmls_to_preserve
+        if executions:
+            delete_executions += executions
+
+    return bundle_xmls_to_preserve, delete_executions
+
+
 def delete_documents(
     sps_package: str, xmls_filenames: list
 ) -> Tuple[List[str], List[dict]]:

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -39,6 +39,8 @@ def get_documents_from_packages(sps_packages: List[str]) -> Dict[str, list]:
     chaves são os paths dos pacotes e a lista de documentos XML são os valores.
 
     list sps_packages: lista com os paths dos pacotes SPS
+
+    Retorna dicionário com a lista dos XMLs por pacote
     """
     packages_xmls = {}
     for sps_package in sps_packages:
@@ -74,10 +76,14 @@ def delete_documents_from_packages(
     bundle_xmls: dict
 ) -> (Dict[str, List[str]], List[Dict]):
     """
-    Deleta documentos informados do Kernel
+    Executa a deleção para cada pacote de bundle_xmls, informando todos os arquivos XML
+    contidos nele.
 
     dict bundle_xmls: dict com os paths dos pacotes SPS e os respectivos nomes dos
-        arquivos XML.
+        arquivos XML presentes.
+
+    Retorna dicionário com a lista dos XMLs a preservar por pacote e lista das execuções
+     de deleção
     """
     bundle_xmls_to_preserve = {}
     delete_executions = []
@@ -184,6 +190,16 @@ def optimize_sps_pkg_zip_file(sps_pkg_zip_file, new_sps_zip_dir):
 
 
 def put_documents_in_kernel(bundle_xmls: dict) -> (Dict[str, List[str]], List[Dict]):
+    """
+    Executa registro/atualização para cada pacote de bundle_xmls, informando todos os 
+    arquivos XML a preservar contidos nele.
+
+    dict bundle_xmls: dict com os paths dos pacotes SPS e os respectivos nomes dos
+        arquivos XML presentes a preservar.
+
+    Retorna dicionário com a lista de metadados dos documentos registrados/atualizados 
+    por pacote e lista das execuções realizadas.
+    """
     bundle_docs_metadata = {}
     put_executions = []
 
@@ -269,6 +285,18 @@ def register_update_documents(sps_package, xmls_to_preserve):
 def link_docs_from_packages_to_bundle(
     bundle_xmls: dict, issn_index_json_path: str
 ) -> (Dict[str, List[str]], List[Dict]):
+    """
+    Executa link de documentos com o bundle para cada pacote em bundle_xmls, informando 
+    todos os metadados de documentos registrados contidos nele.
+
+    dict bundle_xmls: dict com os paths dos pacotes SPS e os respectivos nomes dos
+        arquivos XML presentes a preservar.
+    str issn_index_json_path: path para arquivo JSON gerado no espelhamento de 
+        periódicos, contendo índice de ISSNs de periódicos
+
+    Retorna dicionário com o resultado das atualizações nos bundles do Kernel por pacote
+    e lista das execuções dos links dos documentos com o bundle.
+    """
     linked_bundle_result = {}
     link_executions = []
     for sps_package, documents in bundle_xmls.items():

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -70,7 +70,9 @@ def list_documents(sps_package):
         return xmls_filenames
 
 
-def delete_documents_from_packages(bundle_xmls: dict) -> Dict[str, List[str]]:
+def delete_documents_from_packages(
+    bundle_xmls: dict
+) -> (Dict[str, List[str]], List[Dict]):
     """
     Deleta documentos informados do Kernel
 
@@ -80,7 +82,6 @@ def delete_documents_from_packages(bundle_xmls: dict) -> Dict[str, List[str]]:
     bundle_xmls_to_preserve = {}
     delete_executions = []
     for sps_package, xmls_filenames in bundle_xmls.items():
-        Logger.info("Reading sps_package: %s" % sps_package)
         xmls_to_preserve, executions = delete_documents(sps_package, xmls_filenames)
         if xmls_to_preserve:
             bundle_xmls_to_preserve[sps_package] = xmls_to_preserve
@@ -178,6 +179,20 @@ def optimize_sps_pkg_zip_file(sps_pkg_zip_file, new_sps_zip_dir):
         return new_sps_pkg_zip_file
 
     Logger.debug("optimize_sps_pkg_zip_file OUT")
+
+
+def put_documents_in_kernel(bundle_xmls: dict) -> (Dict[str, List[str]], List[Dict]):
+    bundle_docs_metadata = {}
+    put_executions = []
+
+    for sps_package, xmls_to_preserve in bundle_xmls.items():
+        docs_metadata, executions = register_update_documents(sps_package, xmls_to_preserve)
+        if docs_metadata:
+            bundle_docs_metadata[sps_package] = docs_metadata
+        if executions:
+            put_executions += executions
+
+    return bundle_docs_metadata, put_executions
 
 
 def register_update_documents(sps_package, xmls_to_preserve):

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -114,7 +114,9 @@ def delete_documents(
                 i,
                 len(xmls_filenames),
             )
-            execution = {"file_name": sps_xml_file, "deletion": True}
+            execution = {
+                "package_name": sps_package, "file_name": sps_xml_file, "deletion": True
+            }
             try:
                 is_doc_to_delete, doc_id = is_document_to_delete(zipfile, sps_xml_file)
             except DocumentToDeleteException as exc:
@@ -218,7 +220,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
                 len(xmls_to_preserve),
             )
 
-            execution = {"file_name": xml_filename}
+            execution = {"package_name": sps_package, "file_name": xml_filename}
 
             try:
                 xml_data = put_xml_into_object_store(zipfile, xml_filename)

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -265,6 +265,24 @@ def register_update_documents(sps_package, xmls_to_preserve):
 
     return (synchronized_docs_metadata, executions)
 
+
+def link_docs_from_packages_to_bundle(
+    bundle_xmls: dict, issn_index_json_path: str
+) -> (Dict[str, List[str]], List[Dict]):
+    linked_bundle_result = {}
+    link_executions = []
+    for sps_package, documents in bundle_xmls.items():
+        linked_bundle_info, executions = link_documents_to_documentsbundle(
+            sps_package, documents, issn_index_json_path
+        )
+        if linked_bundle_info:
+            linked_bundle_result[sps_package] = linked_bundle_info
+        if executions:
+            link_executions += executions
+
+    return linked_bundle_result, link_executions
+
+
 def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_path):
     """
         Relaciona documentos com seu fascículos(DocumentsBundle).
@@ -339,6 +357,7 @@ def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_pa
                 )
                 executions.append(
                     {
+                        "package_name": sps_package,
                         "pid": doc.get("scielo_id"),
                         "bundle_id": None,
                         "error": 'Could not get journal ISSN ID: ISSN id "%s" not found'
@@ -386,6 +405,7 @@ def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_pa
                 for new_item_relationship in new_items:
                     executions.append(
                         {
+                            "package_name": sps_package,
                             "pid": new_item_relationship.get("id"),
                             "bundle_id": bundle_id,
                             "failed": True,
@@ -407,6 +427,7 @@ def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_pa
                     for new_item_relationship in new_items:
                         executions.append(
                             {
+                                "package_name": sps_package,
                                 "pid": new_item_relationship.get("id"),
                                 "bundle_id": bundle_id,
                             }

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -33,6 +33,23 @@ from operations.docs_utils import (
 Logger = logging.getLogger(__name__)
 
 
+def get_documents_from_packages(sps_packages: List[str]) -> Dict[str, list]:
+    """
+    Obtém todos os XMLs dos SPS Packages da lista dada. Retorna um dicionário onde a
+    chaves são os paths dos pacotes e a lista de documentos XML são os valores.
+
+    list sps_packages: lista com os paths dos pacotes SPS
+    """
+    packages_xmls = {}
+    for sps_package in sps_packages:
+        xmls_filenames = list_documents(sps_package)
+        if xmls_filenames:
+            packages_xmls[sps_package] = xmls_filenames
+        else:
+            Logger.error("No documents in package: %s", sps_package)
+    return packages_xmls
+
+
 def list_documents(sps_package):
     """
     Lista todos os XMLs dos SPS Packages da lista obtida do diretório do XC.

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -121,7 +121,9 @@ def delete_documents(
                 len(xmls_filenames),
             )
             execution = {
-                "package_name": sps_package, "file_name": sps_xml_file, "deletion": True
+                "package_name": os.path.basename(sps_package),
+                "file_name": sps_xml_file,
+                "deletion": True,
             }
             try:
                 is_doc_to_delete, doc_id = is_document_to_delete(zipfile, sps_xml_file)
@@ -236,7 +238,9 @@ def register_update_documents(sps_package, xmls_to_preserve):
                 len(xmls_to_preserve),
             )
 
-            execution = {"package_name": sps_package, "file_name": xml_filename}
+            execution = {
+                "package_name": os.path.basename(sps_package), "file_name": xml_filename
+            }
 
             try:
                 xml_data = put_xml_into_object_store(zipfile, xml_filename)
@@ -385,7 +389,7 @@ def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_pa
                 )
                 executions.append(
                     {
-                        "package_name": sps_package,
+                        "package_name": os.path.basename(sps_package),
                         "pid": doc.get("scielo_id"),
                         "bundle_id": None,
                         "error": 'Could not get journal ISSN ID: ISSN id "%s" not found'

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -102,16 +102,17 @@ def start_sync_packages(conf, **kwargs):
     um pacote SPS da lista armazenada pela tarefa anterior.
     """
     _sps_packages = kwargs["ti"].xcom_pull(key="sps_packages") or []
-    for sps_package in _sps_packages:
-        Logger.info("Triggering an external dag with package %s" % sps_package)
+    for bundle_label, bundle_packages in _sps_packages.items():
+        Logger.info("Triggering an external dag with package %s" % bundle_label)
         now = timezone.utcnow()
         trigger_dag(
             dag_id="sync_documents_to_kernel",
-            run_id="manual__%s_%s" % (os.path.basename(sps_package), now.isoformat()),
+            run_id="manual__%s_%s" % (os.path.basename(bundle_label), now.isoformat()),
             execution_date=now,
             replace_microseconds=False,
             conf={
-                "sps_package": sps_package,
+                "bundle_label": bundle_label,
+                "sps_package": bundle_packages,
                 "pre_syn_dag_run_id": kwargs.get("run_id"),
             },
         )

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -54,21 +54,20 @@ def list_documents(dag_run, **kwargs):
 
 
 def delete_documents(dag_run, **kwargs):
-    _sps_package = dag_run.conf.get("sps_package")
     _xmls_filenames = kwargs["ti"].xcom_pull(
         key="xmls_filenames", task_ids="list_docs_task_id"
     )
     if not _xmls_filenames:
         return False
 
-    _xmls_to_preserve, executions = sync_documents_to_kernel_operations.delete_documents(
-        _sps_package, _xmls_filenames
-    )
+    _xmls_to_preserve, executions = \
+        sync_documents_to_kernel_operations.delete_documents_from_packages(
+            _xmls_filenames
+        )
 
     for execution in executions:
         execution["dag_run"] = kwargs.get("run_id")
         execution["pre_sync_dag_run"] = dag_run.conf.get("pre_syn_dag_run_id")
-        execution["package_name"] = os.path.basename(_sps_package)
         add_execution_in_database(table="xml_documents", data=execution)
 
     if _xmls_to_preserve:

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -78,20 +78,23 @@ def delete_documents(dag_run, **kwargs):
 
 
 def optimize_package(dag_run, **kwargs):
-    _sps_package = dag_run.conf.get("sps_package")
     _xmls_to_preserve = kwargs["ti"].xcom_pull(
         key="xmls_to_preserve", task_ids="delete_docs_task_id"
     )
     if not _xmls_to_preserve:
         return False
 
+    _optimized_packages = {}
     new_sps_zip_dir = Variable.get("NEW_SPS_ZIP_DIR", mkdtemp())
-    _optimized_package = sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file(
-        _sps_package, new_sps_zip_dir
-    )
-    if _optimized_package:
+    for _sps_package, _package_xmls in _xmls_to_preserve.items():
+        _optimized_package = sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file(
+            _sps_package, new_sps_zip_dir
+        )
+        if _optimized_package:
+            _optimized_packages[_optimized_package] = _package_xmls
+    if _optimized_packages:
         kwargs["ti"].xcom_push(
-            key="optimized_package", value=_optimized_package)
+            key="optimized_packages", value=_optimized_packages)
     return True
 
 

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -101,26 +101,18 @@ def optimize_package(dag_run, **kwargs):
 
 
 def register_update_documents(dag_run, **kwargs):
-
-    _xmls_to_preserve = kwargs["ti"].xcom_pull(
-        key="xmls_to_preserve", task_ids="delete_docs_task_id"
+    _optimized_packaged = kwargs["ti"].xcom_pull(
+        key="optimized_packages", task_ids="optimize_package_task_id"
     )
-    if not _xmls_to_preserve:
+    if not _optimized_packaged:
         return False
 
-    _optimized_package = kwargs["ti"].xcom_pull(
-        key="optimized_package", task_ids="optimize_package_task_id"
-    )
-
-    package = _optimized_package or dag_run.conf.get("sps_package")
-    _documents, executions = sync_documents_to_kernel_operations.register_update_documents(
-        package, _xmls_to_preserve
-    )
+    _documents, executions = \
+        sync_documents_to_kernel_operations.put_documents_in_kernel(_optimized_packaged)
 
     for execution in executions:
         execution["dag_run"] = kwargs.get("run_id")
         execution["pre_sync_dag_run"] = dag_run.conf.get("pre_syn_dag_run_id")
-        execution["package_name"] = os.path.basename(_optimized_package)
         add_execution_in_database(table="xml_documents", data=execution)
 
     if _documents:

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -92,6 +92,8 @@ def optimize_package(dag_run, **kwargs):
         )
         if _optimized_package:
             _optimized_packages[_optimized_package] = _package_xmls
+        else:
+            _optimized_packages[_sps_package] = _package_xmls
     if _optimized_packages:
         kwargs["ti"].xcom_push(
             key="optimized_packages", value=_optimized_packages)

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -44,8 +44,11 @@ dag = DAG(dag_id="sync_documents_to_kernel", default_args=default_args, schedule
 
 
 def list_documents(dag_run, **kwargs):
-    _sps_package = dag_run.conf.get("sps_package")
-    _xmls_filenames = sync_documents_to_kernel_operations.list_documents(_sps_package)
+    _bundle_label = dag_run.conf.get("bundle_label")
+    _sps_packages = dag_run.conf.get("sps_package")
+    if not _bundle_label and type(_sps_packages) == str:
+        _sps_packages = [_sps_packages]
+    _xmls_filenames = sync_documents_to_kernel_operations.get_documents_from_packages(_sps_packages)
     if _xmls_filenames:
         kwargs["ti"].xcom_push(key="xmls_filenames", value=_xmls_filenames)
         return True

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -2,6 +2,7 @@ import tempfile
 import shutil
 import pathlib
 import zipfile
+import json
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock
 
@@ -32,99 +33,84 @@ class TestGetSPSPackages(TestCase):
         mk_open.side_effect = FileNotFoundError
         self.assertRaises(FileNotFoundError, get_sps_packages, *self.kwargs)
 
-    def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(self):
-        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
-        source_filenames = []
+    def _create_fake_sps_packages(self, scilista_lines):
+        """
+        Cria 3 pacotes fake para entrada para cada linha da scilista fake.
+        Também cria a lista esperada ao final do teste, que conterá o caminho completo
+        """
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        fake_sps_packages = {}
+        proc_dir_path = pathlib.Path(self.proc_dir_name)
         with scilista_file_path.open("w") as scilista_file:
             for line in scilista_lines:
                 scilista_file.write(line + "\n")
-                source_filenames += [
-                    "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
-                    for i in range(1, 4)
-                ]
-        for filename in source_filenames:
-            zip_filename = pathlib.Path(self.xc_dir_name) / filename
-            with zipfile.ZipFile(zip_filename, "w") as zip_file:
-                zip_file.write(self.test_filepath)
+                bundle_label = "_".join(line.split())
+                source_filenames = []
+                if not line.endswith("del"):
+                    for i in range(1, 4):
+                        filename = "_".join(
+                            [f"2020-01-01-00-0{i}-09-090901"] + line.split()
+                        ) + ".zip"
+                        source_filenames.append(filename)
+                        zip_filename = pathlib.Path(self.xc_dir_name) / filename
+                        with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                            zip_file.write(self.test_filepath)
+                    fake_sps_packages[bundle_label] = [
+                        str(proc_dir_path.joinpath(filename))
+                        for filename in source_filenames
+                    ]
+        return fake_sps_packages
+
+    def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(self):
+        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
 
         sps_packages = get_sps_packages(**self.kwargs)
-        for filename in source_filenames:
-            with self.subTest(filename=filename):
-                self.assertTrue(
-                    pathlib.Path(self.kwargs["proc_dir_name"])
-                    .joinpath(filename)
-                    .exists()
-                )
-        self.assertEqual(
-            sps_packages,
-            [
-                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
-                for filename in source_filenames
-            ],
-        )
+
+        self.assertEqual(sps_packages, fake_sps_packages)
+        for fake_filenames in fake_sps_packages.values():
+            for filename in fake_filenames:
+                with self.subTest(filename=filename):
+                    self.assertTrue(
+                        pathlib.Path(self.kwargs["proc_dir_name"])
+                        .joinpath(filename)
+                        .exists()
+                    )
 
     def test_get_sps_packages_creates_sps_packages_list_file(self):
         scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
-        source_filenames = []
-        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
-        with scilista_file_path.open("w") as scilista_file:
-            for line in scilista_lines:
-                scilista_file.write(line + "\n")
-                source_filenames += [
-                    "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
-                    for i in range(1, 4)
-                ]
-        for filename in source_filenames:
-            zip_filename = pathlib.Path(self.xc_dir_name) / filename
-            with zipfile.ZipFile(zip_filename, "w") as zip_file:
-                zip_file.write(self.test_filepath)
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
 
         sps_packages = get_sps_packages(**self.kwargs)
+
         package_paths_list = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
         self.assertTrue(package_paths_list.is_file())
-        sps_packages_list = package_paths_list.read_text().split("\n")
-        self.assertEqual(
-            sps_packages_list,
-            [
-                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
-                for filename in source_filenames
-            ],
-        )
+        with package_paths_list.open() as sps_list_file:
+            sps_packages_list = json.load(sps_list_file)
+        self.assertEqual(sps_packages_list, fake_sps_packages)
 
 
     def test_get_sps_packages_ignores_del_command_in_scilista(self):
-        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1 del", "rsp v10n4s1", "csp v35nspe del"]
-        source_filenames = []
-        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
-        with scilista_file_path.open("w") as scilista_file:
-            for line in scilista_lines:
-                scilista_file.write(line + "\n")
-                if not line.endswith("del"):
-                    source_filenames += [
-                        "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
-                        for i in range(1, 4)
-                    ]
-        for filename in source_filenames:
-            zip_filename = pathlib.Path(self.xc_dir_name) / filename
-            with zipfile.ZipFile(zip_filename, "w") as zip_file:
-                zip_file.write(self.test_filepath)
+        scilista_lines = [
+            "rba v53n1",
+            "rba 2019nahead",
+            "rsp v10n4s1 del",
+            "rsp v10n4s1",
+            "csp v35nspe del",
+        ]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
 
         sps_packages = get_sps_packages(**self.kwargs)
-        self.assertEqual(
-            sps_packages,
-            [
-                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
-                for filename in source_filenames
-            ],
-        )
+        self.assertEqual(sps_packages, fake_sps_packages)
 
     def test_get_sps_packages_moves_nothing_if_no_source_file(self):
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
         package = "rba v53n2"
         scilista_file_path.write_text(package)
         source_filenames = [
-            "2020-05-22-10-00-34-480190_rba_v53n1", "2020-05-22-10-00-34-480190_rba_2019nahead", "2020-05-22-10-00-34-480190_rsp_v10n4s1"
+            "2020-05-22-10-00-34-480190_rba_v53n1",
+            "2020-05-22-10-00-34-480190_rba_2019nahead",
+            "2020-05-22-10-00-34-480190_rsp_v10n4s1",
         ]
         for filename in source_filenames:
             zip_filename = pathlib.Path(self.xc_dir_name) / filename
@@ -142,19 +128,24 @@ class TestGetSPSPackages(TestCase):
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
         package = "ag 2019nahead"
         scilista_file_path.write_text(package)
+        ag_package_filename = "2020-05-22-10-00-34-480190_ag_2019nahead.zip"
         source_filenames = ("2020-05-22-10-00-34-480190_brag_2019nahead.zip\n"
-                            "2020-05-22-10-00-34-480190_ag_2019nahead.zip").splitlines()
+                            + ag_package_filename).splitlines()
         for filename in source_filenames:
             zip_filename = pathlib.Path(self.xc_dir_name) / filename
             with zipfile.ZipFile(zip_filename, "w") as zip_file:
                 zip_file.write(self.test_filepath)
 
         result = get_sps_packages(**self.kwargs)
-        self.assertEqual(
-            [str(pathlib.Path(
-                self.kwargs["proc_dir_name"]) / "2020-05-22-10-00-34-480190_ag_2019nahead.zip")],
-            result
-        )
+
+        expected = {
+            "_".join(package.split()): [
+                str(
+                    pathlib.Path(self.kwargs["proc_dir_name"]) / ag_package_filename
+                )
+            ]
+        }
+        self.assertEqual(result, expected)
 
     def test_get_sps_packages_must_return_packages_list_if_sps_packages_lst_exists(self):
         package_paths_list = [
@@ -162,7 +153,8 @@ class TestGetSPSPackages(TestCase):
             for seq in range(1, 4)
         ]
         package_paths_list_file = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
-        package_paths_list_file.write_text("\n".join(package_paths_list))
+        with package_paths_list_file.open("w") as sps_list_file:
+            json.dump(package_paths_list, sps_list_file)
         result = get_sps_packages(**self.kwargs)
         self.assertEqual(result, package_paths_list)
 

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -193,12 +193,75 @@ class TestDeleteDocuments(TestCase):
         expected_executions = deepcopy(executions)
 
         task_result = delete_documents(**kwargs)
-        for execution in expected_executions:
-            execution["dag_run"] = "dag_run_id"
-            execution["pre_sync_dag_run"] = "pre_sync_dag_run_id"
-            mk_add_execution_in_database.assert_any_call(
-                table="xml_documents", data=execution
-            )
+        expected_calls = [
+            call(
+                table="xml_documents",
+                data={
+                    "package_name": "path_to_sps_package/package-1.zip",
+                    "file_name": "1806-907X-rba-53-01-1-8.xml",
+                    "deletion": True,
+                    "pid": ANY,
+                    "dag_run": "dag_run_id",
+                    "pre_sync_dag_run": "pre_sync_dag_run_id",
+                },
+            ),
+            call(
+                table="xml_documents",
+                data={
+                    "package_name": "path_to_sps_package/package-2.zip",
+                    "file_name": "1806-907X-rba-53-01-1-8.xml",
+                    "deletion": True,
+                    "pid": ANY,
+                    "dag_run": "dag_run_id",
+                    "pre_sync_dag_run": "pre_sync_dag_run_id",
+                },
+            ),
+            call(
+                table="xml_documents",
+                data={
+                    "package_name": "path_to_sps_package/package-2.zip",
+                    "file_name": "1806-907X-rba-53-01-9-18.xml",
+                    "deletion": True,
+                    "pid": ANY,
+                    "dag_run": "dag_run_id",
+                    "pre_sync_dag_run": "pre_sync_dag_run_id",
+                },
+            ),
+            call(
+                table="xml_documents",
+                data={
+                    "package_name": "path_to_sps_package/package-3.zip",
+                    "file_name": "1806-907X-rba-53-01-1-8.xml",
+                    "deletion": True,
+                    "pid": ANY,
+                    "dag_run": "dag_run_id",
+                    "pre_sync_dag_run": "pre_sync_dag_run_id",
+                },
+            ),
+            call(
+                table="xml_documents",
+                data={
+                    "package_name": "path_to_sps_package/package-3.zip",
+                    "file_name": "1806-907X-rba-53-01-9-18.xml",
+                    "deletion": True,
+                    "pid": ANY,
+                    "dag_run": "dag_run_id",
+                    "pre_sync_dag_run": "pre_sync_dag_run_id",
+                },
+            ),
+            call(
+                table="xml_documents",
+                data={
+                    "package_name": "path_to_sps_package/package-3.zip",
+                    "file_name": "1806-907X-rba-53-01-19-25.xml",
+                    "deletion": True,
+                    "pid": ANY,
+                    "dag_run": "dag_run_id",
+                    "pre_sync_dag_run": "pre_sync_dag_run_id",
+                },
+            ),
+        ]
+        mk_add_execution_in_database.assert_has_calls(expected_calls)
 
     @patch(
         "sync_documents_to_kernel.sync_documents_to_kernel_operations.delete_documents_from_packages"

--- a/airflow/tests/test_sync_documents_to_kernel.py
+++ b/airflow/tests/test_sync_documents_to_kernel.py
@@ -1,3 +1,4 @@
+import os
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock, ANY
 from tempfile import mkdtemp
@@ -424,24 +425,24 @@ class TestLinkDocumentsToDocumentsbundle(TestCase):
 
 class TestOptimizeDocuments(TestCase):
 
-    @patch("sync_documents_to_kernel.Variable")
-    @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
-    def test_optimize_package_gets_sps_package_from_dag_run_conf(
-        self, mk_optimize_package, mk_variable
-    ):
-        mk_dag_run = MagicMock()
-        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
-        mk_optimize_package.return_value = [], []
-        new_sps_zip_dir = mkdtemp()
-        mk_variable.get.return_value = new_sps_zip_dir
-        optimize_package(**kwargs)
-        mk_dag_run.conf.get.assert_called_once_with("sps_package")
+    def setUp(self):
+        self.xmls_to_preserve = {
+            "path_to_sps_package/package-1.zip": [
+                "1806-907X-rba-53-01-1-8.xml",
+            ],
+            "path_to_sps_package/package-2.zip": [
+                "1806-907X-rba-53-01-9-18.xml",
+            ],
+            "path_to_sps_package/package-3.zip": [
+                "1806-907X-rba-53-01-1-8.xml",
+                "1806-907X-rba-53-01-19-25.xml",
+            ],
+        }
 
     @patch("sync_documents_to_kernel.Variable")
     @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
     def test_optimize_package_gets_ti_xcom_info(self, mk_optimize_package, mk_variable):
-        mk_dag_run = MagicMock()
-        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
         mk_optimize_package.return_value = [], []
         new_sps_zip_dir = mkdtemp()
         mk_variable.get.return_value = new_sps_zip_dir
@@ -452,8 +453,7 @@ class TestOptimizeDocuments(TestCase):
 
     @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
     def test_optimize_package_does_not_call_optimize_package_operation(self, mk_optimize_package):
-        mk_dag_run = MagicMock()
-        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
+        kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
         kwargs["ti"].xcom_pull.return_value = None
         optimize_package(**kwargs)
         mk_optimize_package.assert_not_called()
@@ -464,35 +464,23 @@ class TestOptimizeDocuments(TestCase):
     def test_optimize_package_calls_optimize_package_operation(
         self, mk_optimize_package, mk_variable
     ):
-        xmls_filenames = [
-            "1806-907X-rba-53-01-1-8.xml",
-            "1806-907X-rba-53-01-9-18.xml",
-            "1806-907X-rba-53-01-19-25.xml",
-        ]
-        mk_dag_run = MagicMock()
-        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
-        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
-        kwargs["ti"].xcom_pull.return_value = xmls_filenames
-        mk_optimize_package.return_value = "path_to_otimized_package/package.zip"
+        kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = self.xmls_to_preserve
+        mk_optimize_package.return_value = None
         new_sps_zip_dir = mkdtemp()
         mk_variable.get.return_value = new_sps_zip_dir
         optimize_package(**kwargs)
-        mk_optimize_package.assert_called_once_with(
-            "path_to_sps_package/package.zip", new_sps_zip_dir
-        )
+        for package_to_optimize in self.xmls_to_preserve.keys():
+            with self.subTest(package_to_optimize=package_to_optimize):
+                mk_optimize_package.assert_any_call(
+                    package_to_optimize, new_sps_zip_dir
+                )
 
     @patch("sync_documents_to_kernel.Variable")
     @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
     def test_optimize_package_does_not_push_if_none_was_optimized(self, mk_optimize_package, mk_variable):
-        xmls_filenames = [
-            "1806-907X-rba-53-01-1-8.xml",
-            "1806-907X-rba-53-01-9-18.xml",
-            "1806-907X-rba-53-01-19-25.xml",
-        ]
-        mk_dag_run = MagicMock()
-        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
-        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
-        kwargs["ti"].xcom_pull.return_value = xmls_filenames
+        kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = self.xmls_to_preserve
         mk_optimize_package.return_value = None
         new_sps_zip_dir = mkdtemp()
         mk_variable.get.return_value = new_sps_zip_dir
@@ -502,22 +490,25 @@ class TestOptimizeDocuments(TestCase):
     @patch("sync_documents_to_kernel.Variable")
     @patch("sync_documents_to_kernel.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file")
     def test_optimize_package_pushes_optimized_package(self, mk_optimize_package, mk_variable):
-        xmls_filenames = [
-            "1806-907X-rba-53-01-1-8.xml",
-            "1806-907X-rba-53-01-9-18.xml",
-            "1806-907X-rba-53-01-19-25.xml",
+        kwargs = {"ti": MagicMock(), "dag_run": MagicMock()}
+        kwargs["ti"].xcom_pull.return_value = self.xmls_to_preserve
+        mk_optimize_package.side_effect = [
+            os.path.join(
+                "path_to_otimized_package", os.path.basename(optimized_package)
+            )
+            for optimized_package in self.xmls_to_preserve.keys()
         ]
-        
-        mk_dag_run = MagicMock()
-        mk_dag_run.conf.get.return_value = "path_to_sps_package/package.zip"
-        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run}
-        kwargs["ti"].xcom_pull.return_value = xmls_filenames
-        mk_optimize_package.return_value = "path_to_otimized_package/package.zip"
         new_sps_zip_dir = mkdtemp()
         mk_variable.get.return_value = new_sps_zip_dir
         optimize_package(**kwargs)
+        optimized_packages = {
+            os.path.join(
+                "path_to_otimized_package", os.path.basename(package_to_optimize)
+            ): package_xmls
+            for package_to_optimize, package_xmls in self.xmls_to_preserve.items()
+        }
         kwargs["ti"].xcom_push.assert_called_once_with(
-            key="optimized_package", value="path_to_otimized_package/package.zip"
+            key="optimized_packages", value=optimized_packages
         )
 
 

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -91,12 +91,16 @@ class TestGetDocumentsFromPackages(TestCase):
         xmls = get_documents_from_packages(list(sps_packages_files.keys()))
 
         expected = {
-            package_path: [
-                package_file
-                for package_file in package_files
-                if package_file.endswith(".xml")
-            ]
-            for package_path, package_files in sps_packages_files.items()
+            f"{self.proc_dir_path}/2020-01-01-00-01-09-090901_abc_v1n1.zip": [
+                "0123-4567-abc-50-1-8.xml",
+            ],
+            f"{self.proc_dir_path}/2020-01-01-00-01-09-090902_abc_v1n1.zip": [
+                "0123-4567-abc-50-1-8.xml",
+            ],
+            f"{self.proc_dir_path}/2020-01-01-00-01-09-090903_abc_v1n1.zip": [
+                "0123-4567-abc-50-1-8.xml",
+                "0123-4567-abc-50-9-18.xml",
+            ],
         }
         self.assertEqual(xmls, expected)
 

--- a/airflow/tests/test_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_sync_documents_to_kernel_operations.py
@@ -246,13 +246,13 @@ class TestDeleteDocumentsFromPackages(TestCase):
         }
         expected_executions = [
             {
-                "package_name": f"{self.proc_dir_path}/2020-01-01-00-01-09-090902_abc_v1n1.zip",
+                "package_name": "2020-01-01-00-01-09-090902_abc_v1n1.zip",
                 "file_name": "0123-4567-abc-50-1-8.xml",
                 "deletion": True,
                 "pid": "FX6F3cbyYmmwvtGmMB7WCgr",
             },
             {
-                "package_name": f"{self.proc_dir_path}/2020-01-01-00-01-09-090903_abc_v1n1.zip",
+                "package_name": "2020-01-01-00-01-09-090903_abc_v1n1.zip",
                 "file_name": "0123-4567-abc-50-1-18.xml",
                 "deletion": True,
                 "failed": True, "error": "SciELO PID V3 is None",


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera a DAG `pre_sync_documents_to_kernel` e `sync_documents_to_kernel` para sincronizar pacotes por bundle ao invés por pacote. Assim, é possível garantir a ordem dos pacotes para um mesmo bundle em um processamento, evitando regressão de documentos caso um dos pacotes falhe. Agora, se um pacote falha, os demais posteriores não serão sincronizados.
Com a mudança, será possível também executar a sincronização de forma concorrente e, até mesmo, de forma paralela.

#### Onde a revisão poderia começar?
É recomendado que a revisão seja feita por commits, iniciando de c0ff426.

#### Como este poderia ser testado manualmente?
Com o Airflow devidamente configurado, com as variáveis e as conexões com o Kernel, MinIO e Postgres configuradas:
- Prepare o diretório configurado na variável `XC_SPS_PACKAGES_DIR` com:
  - Pacotes SPS convertidos pelo XC, com alguns para o mesmo bundle
  - Scilista com nome de arquivo `scilista-<ID do GeraPadrao>.lst`, onde `<ID do GeraPadrao>` é qualquer texto alfanumérico
- Atualize/garanta que as bases ISIS em `BASE_TITLE_FOLDER_PATH` e `BASE_ISSUE_FOLDER_PATH` estão atualizadas com os issues dos pacotes que serão sincronizados.
- Execute o trigger da DAG `sync_isis_to_kernel` com o comando:
```
airflow trigger_dag sync_isis_to_kernel --exec_date <data de execução> --conf '{"GERAPADRAO_ID": "<ID do GeraPadrao>"}'
```
, informando o mesmo `<ID do GeraPadrao>` usado para o nome do arquivo scilista
- Ao final da execução das DAGs `sync_isis_to_kernel`, `pre_sync_documents_to_kernel` e `sync_documents_to_kernel`, verifique:
  - Se a tarefa `start_sync_packages_task_id` executou o trigger por bundle, enviando uma lista de pacotes SPS para uma mesma DAG Run de `sync_documents_to_kernel`
  - Se há DAG Runs de `sync_documents_to_kernel` por bundle, onde os pacotes para o mesmo bundle tenham sido processados pelo mesmo DAG Run.
  - Se mesmo pacotes únicos para um bundle foram processados sem problema

#### Algum cenário de contexto que queira dar?
Optei por implementar a segunda proposta de solução pois a criação de tarefas e subdags dinamicamente, sem ao menos um ponto imutável, se mostrou complexo e exigiria um esforço maior para a implementação do que a utilizada para o exemplo da primeira proposta.

### Screenshots

Exemplo de mensagem de log da DAG `pre_sync_documents_to_kernel`, tarefa `start_sync_packages_task_id`, após a alteração:

<img width="1396" alt="Screen Shot 2020-10-13 at 08 35 58" src="https://user-images.githubusercontent.com/18053487/95855888-84f1df80-0d2f-11eb-8c9b-cc0d39138de2.png">

Exemplo de mensagem de log da DAG `sync_documents_to_kernel`, tarefa `list_docs_task_id`, após a alteração:

<img width="1557" alt="Screen Shot 2020-10-13 at 08 42 39" src="https://user-images.githubusercontent.com/18053487/95856378-4f012b00-0d30-11eb-8396-0267f137dabe.png">


#### Quais são tickets relevantes?
Closes #188

### Referências
.