### PR TITLE
Corrige o tipo do `TIMEOUT_FOR_MULT_REQ` e `TIMEOUT_FOR_SINGLE_REQ`, …

### DIFF
--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -389,7 +389,7 @@ def check_any_uri_items(uri_list_items, label, dag_info):
     website_uri_list = check_website_operations.concat_website_url_and_uri_list_items(
         _website_url_list, uri_list_items)
 
-    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ")
+    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ", deserialize_json=True)
 
     # verifica a lista de URI
     success, failures = check_website_operations.check_website_uri_list(
@@ -545,7 +545,7 @@ def check_documents_deeply(**context):
     extra_data = context.copy()
     extra_data.update(flags)
 
-    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ")
+    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ", deserialize_json=True)
     pid_v2_processed = check_website_operations.check_website_uri_list_deeply(
         pid_v3_list, website_url, object_store_url, extra_data, timeout)
     total_processed_pid_v2 = len(pid_v2_processed or [])
@@ -582,7 +582,7 @@ def get_pid_v3_list(**context):
     if uri_items is None or len(uri_items) == 0:
         raise ValueError("Missing URI items to get PID v3")
 
-    timeout = Variable.get("TIMEOUT_FOR_SINGLE_REQ")
+    timeout = Variable.get("TIMEOUT_FOR_SINGLE_REQ", deserialize_json=True)
     pid_v3_list = check_website_operations.get_pid_v3_list(
         uri_items, website_url, timeout)
 

--- a/airflow/dags/check_website.py
+++ b/airflow/dags/check_website.py
@@ -389,7 +389,7 @@ def check_any_uri_items(uri_list_items, label, dag_info):
     website_uri_list = check_website_operations.concat_website_url_and_uri_list_items(
         _website_url_list, uri_list_items)
 
-    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ", deserialize_json=True)
+    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ", default_var=None, deserialize_json=True)
 
     # verifica a lista de URI
     success, failures = check_website_operations.check_website_uri_list(
@@ -545,7 +545,7 @@ def check_documents_deeply(**context):
     extra_data = context.copy()
     extra_data.update(flags)
 
-    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ", deserialize_json=True)
+    timeout = Variable.get("TIMEOUT_FOR_MULT_REQ", default_var=None, deserialize_json=True)
     pid_v2_processed = check_website_operations.check_website_uri_list_deeply(
         pid_v3_list, website_url, object_store_url, extra_data, timeout)
     total_processed_pid_v2 = len(pid_v2_processed or [])
@@ -582,7 +582,7 @@ def get_pid_v3_list(**context):
     if uri_items is None or len(uri_items) == 0:
         raise ValueError("Missing URI items to get PID v3")
 
-    timeout = Variable.get("TIMEOUT_FOR_SINGLE_REQ", deserialize_json=True)
+    timeout = Variable.get("TIMEOUT_FOR_SINGLE_REQ", default_var=None, deserialize_json=True)
     pid_v3_list = check_website_operations.get_pid_v3_list(
         uri_items, website_url, timeout)
 


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o tipo do `TIMEOUT_FOR_MULT_REQ` e `TIMEOUT_FOR_SINGLE_REQ` inserindo `deserialize_json=True`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
No Airflow: 

<img width="576" alt="Captura de Tela 2020-10-13 às 08 49 06" src="https://user-images.githubusercontent.com/505143/95856795-00a05c00-0d31-11eb-9f6b-1bd36bf2e075.png">

Garanta que **NÃO HÁ** as variáveis `TIMEOUT_FOR_MULT_REQ` e `TIMEOUT_FOR_SINGLE_REQ` dando um valor numérico inteiro e execute a DAG check_website e não deve ocorrer o erro
<img width="914" alt="Captura de Tela 2020-10-13 às 08 56 58" src="https://user-images.githubusercontent.com/505143/95857628-44479580-0d32-11eb-858a-3faca39810ce.png">

Crie as variáveis `TIMEOUT_FOR_MULT_REQ` e `TIMEOUT_FOR_SINGLE_REQ` dando um valor numérico inteiro e execute a DAG check_website e não deve ocorrer o erro
<img width="743" alt="Captura de Tela 2020-10-13 às 08 53 20" src="https://user-images.githubusercontent.com/505143/95857532-25490380-0d32-11eb-8ab3-46f977c656c3.png">

#### Algum cenário de contexto que queira dar?
Bug do PR #222

### Screenshots
n/a

#### Quais são tickets relevantes?
#222

### Referências
n/a