### PR TITLE
Adiciona o Sentry como uma dependência do projeto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM scieloorg/airflow:1.10.4
+FROM scieloorg/airflow:1.10.12
 
 ARG AIRFLOW_HOME=/usr/local/airflow
 ARG PROC_DIR=/usr/local/proc

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ $ airflow webserver
 * `AIRFLOW__SMTP__SMTP_MAIL_FROM`: Endereço de e-mail do remetente
 * `AIRFLOW__SMTP__SMTP_SSL`: ```True``` ou ```False``` para indicar o uso de criptografia no servidor de e-mail
 * `AIRFLOW__SMTP__SMTP_PORT`: Porta do servidor de e-mail
+* `AIRFLOW__SENTRY__SENTRY_DSN`: DSN do projeto cadastrado no Sentry para logar tracebacks registrados nas execuções
 * `POSTGRES_USER`: Usuário para conexão com o Postgres
 * `POSTGRES_PASSWORD`: Senha para conexão com o Postgres
 * `POSTGRES_HOST`: Endereço do Postgres

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-apache-airflow[s3,postgres]==01.10.4
+apache-airflow[s3,postgres,sentry]==01.10.12
 lxml==4.5
 pymongo==3.9.0
 deepdiff[murmur]==4.0.7


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona o Sentry como uma dependência do projeto em `requirements.txt`. Essa integração foi inserida em versões mais recentes do Airflow e, por isso, também faz-se necessário atualizar a versão dele.

#### Onde a revisão poderia começar?
Pelo commit 27a16b8.

#### Como este poderia ser testado manualmente?
- Execute o build para construir a nova imagem Docker do projeto (com `docker-compose build` ou `docker build .`)
- Adicione a variável de ambiente `AIRFLOW__SENTRY__SENTRY_DSN` no `docker-compose.yml` ou declare a variável executando `docker run`. O valor deve ser um DSN válido do Sentry
- Provoque uma exceção no Airflow. Ex: apague uma das variáveis essenciais para a execução de uma DAG e tente rodá-la
- A exceção deve ser enviada para o Sentry

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
https://github.com/orgs/scieloorg/projects/4#card-44828419.

### Referências
https://docs.sentry.io/platforms/python/guides/airflow/