### PR TITLE
Trata o `order` caso seu valor não seja válido (conversível a int)

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -242,8 +242,10 @@ def ArticleFactory(
     article.issue = issue
     article.journal = issue.journal
 
-    if document_order:
+    try:
         article.order = int(document_order)
+    except (ValueError, TypeError):
+        article.order = 0
 
     article.xml = document_xml_url
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -322,6 +322,35 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertTrue(hasattr(self.document, "updated"))
         self.assertIsNotNone(self.document.updated)
 
+    def test_order_attribute_is_fixed_if_alnum(self):
+        article = ArticleFactory(
+            document_id=MagicMock(),
+            data=MagicMock(),
+            issue_id=MagicMock(),
+            document_order="1bla",
+            document_xml_url=MagicMock()
+        )
+        self.assertEqual(0, article.order)
+
+    def test_order_attribute_is_fixed_if_None(self):
+        article = ArticleFactory(
+            document_id=MagicMock(),
+            data=MagicMock(),
+            issue_id=MagicMock(),
+            document_order=None,
+            document_xml_url=MagicMock()
+        )
+        self.assertEqual(0, article.order)
+
+    def test_order_attribute_is_kept_if_number(self):
+        article = ArticleFactory(
+            document_id=MagicMock(),
+            data=MagicMock(),
+            issue_id=MagicMock(),
+            document_order="1234",
+            document_xml_url=MagicMock()
+        )
+        self.assertEqual(1234, article.order)
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")


### PR DESCRIPTION
#### O que esse PR faz?
Caso o valor de `order` não seja válido (conversível a int), retorna 0.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver #230 

#### Algum cenário de contexto que queira dar?
Erro foi causado porque o XML não continha o `<article-id pub-id-type="other"/>` que é obrigatório quando fpage é alfanumérico.
relacionado com https://github.com/scieloorg/document-store-migracao/issues/365

### Screenshots
n/a

#### Quais são tickets relevantes?
#230 

### Referências
n/a