### PR TITLE
Possibilita a reinicialização do scheduler && Passa a inicializar o scheduler e o webserver em containers distintos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,11 @@ RUN apk add --no-cache --virtual .build-deps \
     && apk --purge del .build-deps
 
 COPY ./entrypoint.sh /entrypoint.sh
-COPY ./start_airflow.sh /start_airflow.sh
+COPY ./scripts /scripts
 
 RUN chmod +x /entrypoint.sh
-RUN chmod +x /start_airflow.sh
+RUN chmod +x /scripts/start_webserver.sh
+RUN chmod +x /scripts/start_scheduler_autorestart.sh
 
 USER airflow
 

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ dev_compose_ps:  ## See all containers using $(COMPOSE_FILE_DEV)
 dev_compose_rm:  ## Remove all containers using $(COMPOSE_FILE_DEV)
 	@docker-compose -f $(COMPOSE_FILE_DEV) rm -f
 
-dev_compose_bash:  ## Open python terminal from opac-airflow $(COMPOSE_FILE_DEV)
-	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow bash
+dev_compose_bash:  ## Open python terminal from webserver $(COMPOSE_FILE_DEV)
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm webserver bash
 
 dev_compose_add_opac_conn:  ## Add default opac_conn
-	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow airflow connections \
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm webserver airflow connections \
 	-a --conn_type=Mongo \
 	--conn_id=opac_conn \
 	--conn_host=localhost \
@@ -43,22 +43,22 @@ dev_compose_add_opac_conn:  ## Add default opac_conn
 	--conn_extra='{"authentication_source": "admin"}'
 
 dev_compose_add_kernel_conn:  ## Add default kernel_conn
-	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow airflow connections \
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm webserver airflow connections \
 	    -a --conn_type=HTTP \
 	    --conn_id=kernel_conn \
 	    --conn_host=http://0.0.0.0 \
 	    --conn_port=6543
 
 dev_compose_add_postgres_report_conn:
-	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow airflow connections \
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm webserver airflow connections \
 	-a --conn_type=Postgres \
 	--conn_id=postgres_report_connection
 
 dev_compose_rm_db:  ## Remove database
-	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow rm airflow.db
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm webserver rm airflow.db
 
 dev_compose_initdb:  ## Initialize airflow database
-	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm opac-airflow airflow initdb
+	@docker-compose -f $(COMPOSE_FILE_DEV) run --rm webserver airflow initdb
 
 ############################################
 ## atalhos docker-compose produção        ##
@@ -83,10 +83,10 @@ compose_rm:  ## Remove all containers using $(COMPOSE_FILE_PROD)
 	@docker-compose -f $(COMPOSE_FILE_PROD) rm -f
 
 compose_bash:  ## Open python terminal from portal $(COMPOSE_FILE_PROD)
-	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow bash
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm webserver bash
 
 compose_add_opac_conn:  ## Add default opac_conn
-	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow airflow connections \
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm webserver airflow connections \
 	-a --conn_type=Mongo \
 	--conn_id=opac_conn \
 	--conn_host=localhost \
@@ -95,22 +95,22 @@ compose_add_opac_conn:  ## Add default opac_conn
 	--conn_extra='{"authentication_source": "admin"}'
 
 compose_add_postgres_report_conn:
-	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow airflow connections \
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm webserver airflow connections \
 	-a --conn_type=Postgres \
 	--conn_id=postgres_report_connection
 
 compose_add_kernel_conn:  ## Add default kernel_conn
-	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow airflow connections \
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm webserver airflow connections \
 	    -a --conn_type=HTTP \
 	    --conn_id=kernel_conn \
 	    --conn_host=http://0.0.0.0 \
 	    --conn_port=6543
 
 compose_rm_db:  ## Remove database
-	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow rm airflow.db
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm webserver rm airflow.db
 
 compose_initdb:  ## Initialize airflow database
-	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm opac-airflow airflow initdb
+	@docker-compose -f $(COMPOSE_FILE_PROD) run --rm webserver airflow initdb
 
 #####################################################
 ## atalhos docker-compose build e testes no travis ##
@@ -121,7 +121,7 @@ travis_compose_build:
 	@docker-compose -f $(COMPOSE_FILE_PROD) build
 
 travis_compose_up:
-	@docker-compose -f $(COMPOSE_FILE_PROD) up -d
+	@docker-compose -f $(COMPOSE_FILE_PROD) up -d webserver
 
 travis_compose_make_test:
-	@docker-compose -f $(COMPOSE_FILE_PROD) exec opac-airflow python -m unittest -v
+	@docker-compose -f $(COMPOSE_FILE_PROD) exec webserver python -m unittest -v

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $ airflow webserver
 * `POSTGRES_HOST`: Endereço do Postgres
 * `POSTGRES_PORT`: Porta de rede para conexão com o Postgres
 * `POSTGRES_DB`: Nome do banco de dados do Opac-airflow para conexão com Postgres
-
+* `AIRFLOW_SCHEDULER_MAX_RUNS` - `(default: 5)`: Define a quantidade de vezes que o _scheduler_ executará antes de ser reiniciado.
 
 ## Testes Automatizados
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -8,11 +8,11 @@ services:
         ports:
             - "8025:8025"
 
-    opac-airflow:
+    webserver:
         build: ./
         ports:
           - "8080:8080"
-        command: /start_airflow.sh
+        command: /scripts/start_webserver.sh
         volumes:
             - ./airflow:/usr/local/airflow
             - ./data_dev:/usr/local/airflow/data_dev
@@ -34,6 +34,27 @@ services:
             - postgres:postgres
         depends_on:
             - postgres
+
+    scheduler:
+        build: ./
+        command: /scripts/start_scheduler_autorestart.sh
+        environment:
+          - AIRFLOW_HOME=/usr/local/airflow
+          - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org
+          - AIRFLOW__SMTP__SMTP_HOST=${AIRFLOW__SMTP__SMTP_HOST}
+          - AIRFLOW__SMTP__SMTP_USER=${AIRFLOW__SMTP__SMTP_USER}
+          - AIRFLOW__SMTP__SMTP_PASSWORD=${AIRFLOW__SMTP__SMTP_PASSWORD}
+          - AIRFLOW__SMTP__SMTP_MAIL_FROM=${AIRFLOW__SMTP__SMTP_MAIL_FROM}
+          - AIRFLOW__SMTP__SMTP_SSL=${AIRFLOW__SMTP__SMTP_SSL}
+          - AIRFLOW__SMTP__SMTP_PORT=${AIRFLOW__SMTP__SMTP_PORT}
+          - POSTGRES_USER=postgres_user
+          - POSTGRES_PASSWORD=postgres_pass
+          - POSTGRES_HOST=postgres
+          - POSTGRES_PORT=5432
+          - POSTGRES_DB=opac_airflow
+          - AIRFLOW_SCHEDULER_MAX_RUNS=5
+        depends_on:
+            - webserver
 
     postgres:
         image: postgres:9.6-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: '2'
 
 services:
-    opac-airflow:
+    webserver:
         build: ./
         ports:
           - "8080:8080"
-        command: /start_airflow.sh
+        command: /scripts/start_webserver.sh
         environment:
           - AIRFLOW_HOME=/usr/local/airflow
           - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org
@@ -24,6 +24,27 @@ services:
             - postgres:postgres
         depends_on:
             - postgres
+
+    scheduler:
+        build: ./
+        command: /scripts/start_scheduler_autorestart.sh
+        environment:
+          - AIRFLOW_HOME=/usr/local/airflow
+          - EMIAL_ON_FAILURE_RECIPIENTS=infra@scielo.org
+          - AIRFLOW__SMTP__SMTP_HOST=${AIRFLOW__SMTP__SMTP_HOST}
+          - AIRFLOW__SMTP__SMTP_USER=${AIRFLOW__SMTP__SMTP_USER}
+          - AIRFLOW__SMTP__SMTP_PASSWORD=${AIRFLOW__SMTP__SMTP_PASSWORD}
+          - AIRFLOW__SMTP__SMTP_MAIL_FROM=${AIRFLOW__SMTP__SMTP_MAIL_FROM}
+          - AIRFLOW__SMTP__SMTP_SSL=${AIRFLOW__SMTP__SMTP_SSL}
+          - AIRFLOW__SMTP__SMTP_PORT=${AIRFLOW__SMTP__SMTP_PORT}
+          - POSTGRES_USER=postgres_user
+          - POSTGRES_PASSWORD=postgres_pass
+          - POSTGRES_HOST=postgres
+          - POSTGRES_PORT=5432
+          - POSTGRES_DB=opac_airflow
+          - AIRFLOW_SCHEDULER_MAX_RUNS=5
+        depends_on:
+            - webserver
 
     postgres:
         image: postgres:9.6-alpine

--- a/scripts/start_scheduler_autorestart.sh
+++ b/scripts/start_scheduler_autorestart.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+if [[ -z "$AIRFLOW_SCHEDULER_MAX_RUNS" ]]
+then
+    AIRFLOW_SCHEDULER_MAX_RUNS=5
+fi
+
+while echo "Running"; do
+    airflow scheduler -n "$AIRFLOW_SCHEDULER_MAX_RUNS"
+    echo "Scheduler crashed with exit code $?.  Respawning.." >&2
+    date >> /tmp/airflow_scheduler_errors.txt
+    sleep 1
+done

--- a/scripts/start_webserver.sh
+++ b/scripts/start_webserver.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+airflow initdb
+airflow webserver

--- a/scripts/start_webserver.sh
+++ b/scripts/start_webserver.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-airflow initdb
+airflow upgradedb
 airflow webserver

--- a/start_airflow.sh
+++ b/start_airflow.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-airflow initdb
-airflow scheduler &
-airflow webserver


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request modifica o processo de inicialização do _scheduler_ por parte do container docker. A partir de agora o _scheduler_ passa a ser executado em um container separado do _webserver_. Também adiciona um script responsável por reiniciar o _scheduler_ assim que um número `X` (`default: 5`) de execuções é atingido.

#### Onde a revisão poderia começar?

- A partir do commit c56d0cf 

#### Como este poderia ser testado manualmente?

Para testar este pull request manualmente, deve-se:
- Suba os processos utilizando o docker-compose;
- Execute qualquer `DAG` já existente neste projeto;
- Verifique que a execução ocorre como o esperado.

#### Algum cenário de contexto que queira dar?

Esta mudança adiciona uma quebra de compatibilidade por parte dos nossos _deployments_ no kubernetes.

### Screenshots
N/A

#### Quais são tickets relevantes?
#217

### Referências
N/A