### PR TITLE
Usa como valor do "order" os 5 últimos dígitos do PID v2 em caso de o `document_order` fornecido ao `ArticleFactory` for inválido

### DIFF
--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -30,6 +30,10 @@ class RegisterUpdateDocIntoKernelException(Exception):
     ...
 
 
+class InvalidOrderValueError(Exception):
+    ...
+
+
 class LinkDocumentToDocumentsBundleException(Exception):
     def __init__(self, message, response=None, *args, **kwargs):
         self.message = message

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -243,7 +243,8 @@ def ArticleFactory(
     article.journal = issue.journal
 
     try:
-        article.order = int(document_order)
+        _order = article.scielo_pids.get("v2") or document_order
+        article.order = int(_order[-5:])
     except (ValueError, TypeError):
         article.order = 0
 

--- a/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json
+++ b/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json
@@ -1,0 +1,952 @@
+{
+    "article": [
+      {
+        "type": [
+          "research-article"
+        ],
+        "lang": [
+          "en"
+        ]
+      }
+    ],
+    "article_meta": [
+      {
+        "article_doi": [
+          "10.11606/S1518-8787.2019053000621"
+        ],
+        "article_publisher_id": [
+            "S1518-87872019053000621",
+            "67TH7T7CyPPmgtVrGXhWXVs"
+        ],
+        "scielo_pid_v1": [
+            "S1518-8787(19)03000621"
+        ],
+        "scielo_pid_v3": [
+            "67TH7T7CyPPmgtVrGXhWXVs"
+        ],
+        "article_title": [
+          "Validation of an anxiety scale for prenatal diagnostic procedures"
+        ],
+        "article_title_lang": [],
+        "abstract": [
+          "ABSTRACT OBJECTIVE: To perform a cross-cultural adaptation of the Prenatal Diagnostic Procedures Anxiety Scale questionnaire for application in the Brazilian cultural context. METHODS: The translation and back translation processes followed internationally accepted criteria. A committee of experts evaluated the semantic, idiomatic, experimental and conceptual equivalence, proposing a pre-final version that was applied in 10.0% of the final sample. Afterwards, the final version was approved for the psychometric analysis. At that stage, 55 pregnant women participated which responded to the proposed Brazilian version before taking an ultrasound examination at a public hospital in Santa Catarina, in the year of 2017. The Edinburgh Postnatal Depression Scale was used as an external reliability parameter. The internal consistency of the instrument was obtained by Cronbach's alpha. Validation was performed by exploratory factorial analysis with extraction of principal components by the Kaiser-Guttman method and Varimax rotation. RESULTS: The Cronbach's alpha value of the total instrument was 0.886, and only the percentage of variance from item 2 (0.183) was not significant. The Kaiser-Guttman criterion defined three factors responsible for explaining 78.5% of the variance, as well as the Scree plot. Extraction of the main components by the Varimax method presented values from 0.713 to 0.926, with only item 2 being allocated in the third component. CONCLUSIONS: The Brazilian version is reliable and valid for use in the diagnosis of anxiety related to the performance of ultrasound procedures in prenatal care. Due to the lack of correlation with the rest of the construct, it is suggested that item 2 be removed from the final version."
+        ],
+        "abstract_title": [
+          "ABSTRACT",
+          "OBJECTIVE:",
+          "METHODS:",
+          "RESULTS:",
+          "CONCLUSIONS:"
+        ],
+        "abstract_p": [
+          "To perform a cross-cultural adaptation of the Prenatal Diagnostic Procedures Anxiety Scale questionnaire for application in the Brazilian cultural context.",
+          "The translation and back translation processes followed internationally accepted criteria. A committee of experts evaluated the semantic, idiomatic, experimental and conceptual equivalence, proposing a pre-final version that was applied in 10.0% of the final sample. Afterwards, the final version was approved for the psychometric analysis. At that stage, 55 pregnant women participated which responded to the proposed Brazilian version before taking an ultrasound examination at a public hospital in Santa Catarina, in the year of 2017. The Edinburgh Postnatal Depression Scale was used as an external reliability parameter. The internal consistency of the instrument was obtained by Cronbach's alpha. Validation was performed by exploratory factorial analysis with extraction of principal components by the Kaiser-Guttman method and Varimax rotation.",
+          "The Cronbach's alpha value of the total instrument was 0.886, and only the percentage of variance from item 2 (0.183) was not significant. The Kaiser-Guttman criterion defined three factors responsible for explaining 78.5% of the variance, as well as the Scree plot. Extraction of the main components by the Varimax method presented values from 0.713 to 0.926, with only item 2 being allocated in the third component.",
+          "The Brazilian version is reliable and valid for use in the diagnosis of anxiety related to the performance of ultrasound procedures in prenatal care. Due to the lack of correlation with the rest of the construct, it is suggested that item 2 be removed from the final version."
+        ],
+        "abstract_seq": [
+          "OBJECTIVE: To perform a cross-cultural adaptation of the Prenatal Diagnostic Procedures Anxiety Scale questionnaire for application in the Brazilian cultural context.",
+          "METHODS: The translation and back translation processes followed internationally accepted criteria. A committee of experts evaluated the semantic, idiomatic, experimental and conceptual equivalence, proposing a pre-final version that was applied in 10.0% of the final sample. Afterwards, the final version was approved for the psychometric analysis. At that stage, 55 pregnant women participated which responded to the proposed Brazilian version before taking an ultrasound examination at a public hospital in Santa Catarina, in the year of 2017. The Edinburgh Postnatal Depression Scale was used as an external reliability parameter. The internal consistency of the instrument was obtained by Cronbach's alpha. Validation was performed by exploratory factorial analysis with extraction of principal components by the Kaiser-Guttman method and Varimax rotation.",
+          "RESULTS: The Cronbach's alpha value of the total instrument was 0.886, and only the percentage of variance from item 2 (0.183) was not significant. The Kaiser-Guttman criterion defined three factors responsible for explaining 78.5% of the variance, as well as the Scree plot. Extraction of the main components by the Varimax method presented values from 0.713 to 0.926, with only item 2 being allocated in the third component.",
+          "CONCLUSIONS: The Brazilian version is reliable and valid for use in the diagnosis of anxiety related to the performance of ultrasound procedures in prenatal care. Due to the lack of correlation with the rest of the construct, it is suggested that item 2 be removed from the final version."
+        ],
+        "pub_elocation": [],
+        "pub_fpage": [],
+        "pub_fpage_seq": [],
+        "pub_lpage": [],
+        "pub_subject": [
+          "Original Article"
+        ],
+        "pub_volume": [
+          "53"
+        ],
+        "pub_issue": []
+      }
+    ],
+    "journal_meta": [
+      {
+        "issn_epub": [
+          "1518-8787"
+        ],
+        "issn_ppub": [
+          "0034-8910"
+        ],
+        "journal_nlm_ta": [
+          "Rev Saude Publica"
+        ],
+        "journal_publisher_id": [
+          "rsp"
+        ],
+        "journal_title": [
+          "Revista de Saúde Pública"
+        ],
+        "publisher_name": [
+          "Faculdade de Saúde Pública da Universidade de São Paulo"
+        ]
+      }
+    ],
+    "contrib": [
+      {
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Kindermann Lucas"
+        ],
+        "contrib_given_names": [
+          "Lucas"
+        ],
+        "contrib_orcid": [
+          "0000-0002-9789-501X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Kindermann"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [
+          "c1"
+        ],
+        "xref_corresp_text": [
+          ""
+        ],
+        "xref_aff": [
+          "aff1"
+        ],
+        "xref_aff_text": [
+          "I"
+        ]
+      },
+      {
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Traebert Jefferson"
+        ],
+        "contrib_given_names": [
+          "Jefferson"
+        ],
+        "contrib_orcid": [
+          "0000-0002-7389-985X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Traebert"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Nunes Rodrigo Dias"
+        ],
+        "contrib_given_names": [
+          "Rodrigo Dias"
+        ],
+        "contrib_orcid": [
+          "0000-0002-2261-8253"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Nunes"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      }
+    ],
+    "aff": [
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": []
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff2"
+        ],
+        "aff_text": [
+          "II Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Programa de Pós-Graduação em Ciências da Saúde Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Programa de Pós-Graduação em Ciências da Saúde"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "II"
+        ],
+        "phone": []
+      }
+    ],
+    "pub_date": [
+      {
+        "text": [
+          "31 01 2019"
+        ],
+        "pub_type": [
+          "epub"
+        ],
+        "pub_format": [],
+        "date_type": [],
+        "day": [
+          "31"
+        ],
+        "month": [
+          "01"
+        ],
+        "year": [
+          "2019"
+        ],
+        "season": []
+      }
+    ],
+    "history_date": [
+      {
+        "date_type": [
+          "received"
+        ],
+        "day": [
+          "14"
+        ],
+        "month": [
+          "12"
+        ],
+        "year": [
+          "2017"
+        ]
+      },
+      {
+        "date_type": [
+          "accepted"
+        ],
+        "day": [
+          "10"
+        ],
+        "month": [
+          "04"
+        ],
+        "year": [
+          "2018"
+        ]
+      }
+    ],
+    "kwd_group": [
+      {
+        "lang": [
+          "en"
+        ],
+        "title": [
+          "DESCRIPTORS:"
+        ],
+        "kwd": [
+          "Ultrasonography Prenatal, psychology",
+          "Test Anxiety Scale",
+          "Surveys and Questionnaires, utilization",
+          "Translations",
+          "Validation Studies"
+        ]
+      }
+    ],
+    "trans_abstract": [],
+    "sub_article": [
+      {
+        "article": [
+          {
+            "type": [
+              "translation"
+            ],
+            "lang": [
+              "pt"
+            ]
+          }
+        ],
+        "article_meta": [
+          {
+            "article_doi": [],
+            "article_publisher_id": [],
+            "article_title": [
+              "Validação de uma escala de ansiedade para procedimentos diagnósticos prénatais"
+            ],
+            "article_title_lang": [],
+            "abstract": [
+              "RESUMO OBJETIVO: Proceder à adaptação transcultural do questionário Prenatal Diagnostic Procedures Anxiety Scale para aplicação no contexto cultural brasileiro. MÉTODOS: Os processos de tradução e retrotradução seguiram critérios aceitos internacionalmente. Um comitê de especialistas avaliou as equivalências semântica, idiomática, experimental e conceitual, propondo uma versão pré-final que foi aplicada em 10,0% da amostra final. Em seguida, foi aprovada a versão final para a análise psicométrica. Nessa etapa participaram 55 gestantes que responderam à versão brasileira proposta antes de realizarem um exame ultrassonográfico em um hospital público de Santa Catarina, no ano de 2017. A Edinburgh Postnatal Depression Scale foi utilizada como parâmetro de confiabilidade externa. A consistência interna do instrumento foi obtida pelo alfa de Cronbach. A validação foi realizada por análise fatorial exploratória com extração de componentes principais pelo método de Kaiser-Guttman e rotação Varimax. RESULTADOS: O alfa de Cronbach do instrumento total foi 0,886, e apenas o percentual de variância do item 2 (0,183) não foi significativo. O critério de Kaiser-Guttman definiu três fatores responsáveis por explicar 78,5% da variância, assim como o gráfico de Escarpa. A extração dos componentes principais pelo método Varimax apresentou valores de 0,713 a 0,926, sendo apenas o item 2 alocado no terceiro componente. CONCLUSÕES: A versão brasileira é confiável e válida para uso no diagnóstico de ansiedade relacionada à realização de procedimentos ultrassonográficos no pré-natal. Devido à falta de correlação com o restante do construto, sugere-se a retirada do item 2 da versão final."
+            ],
+            "abstract_title": [
+              "RESUMO",
+              "OBJETIVO:",
+              "MÉTODOS:",
+              "RESULTADOS:",
+              "CONCLUSÕES:"
+            ],
+            "abstract_p": [
+              "Proceder à adaptação transcultural do questionário Prenatal Diagnostic Procedures Anxiety Scale para aplicação no contexto cultural brasileiro.",
+              "Os processos de tradução e retrotradução seguiram critérios aceitos internacionalmente. Um comitê de especialistas avaliou as equivalências semântica, idiomática, experimental e conceitual, propondo uma versão pré-final que foi aplicada em 10,0% da amostra final. Em seguida, foi aprovada a versão final para a análise psicométrica. Nessa etapa participaram 55 gestantes que responderam à versão brasileira proposta antes de realizarem um exame ultrassonográfico em um hospital público de Santa Catarina, no ano de 2017. A Edinburgh Postnatal Depression Scale foi utilizada como parâmetro de confiabilidade externa. A consistência interna do instrumento foi obtida pelo alfa de Cronbach. A validação foi realizada por análise fatorial exploratória com extração de componentes principais pelo método de Kaiser-Guttman e rotação Varimax.",
+              "O alfa de Cronbach do instrumento total foi 0,886, e apenas o percentual de variância do item 2 (0,183) não foi significativo. O critério de Kaiser-Guttman definiu três fatores responsáveis por explicar 78,5% da variância, assim como o gráfico de Escarpa. A extração dos componentes principais pelo método Varimax apresentou valores de 0,713 a 0,926, sendo apenas o item 2 alocado no terceiro componente.",
+              "A versão brasileira é confiável e válida para uso no diagnóstico de ansiedade relacionada à realização de procedimentos ultrassonográficos no pré-natal. Devido à falta de correlação com o restante do construto, sugere-se a retirada do item 2 da versão final."
+            ],
+            "abstract_seq": [
+              "OBJETIVO: Proceder à adaptação transcultural do questionário Prenatal Diagnostic Procedures Anxiety Scale para aplicação no contexto cultural brasileiro.",
+              "MÉTODOS: Os processos de tradução e retrotradução seguiram critérios aceitos internacionalmente. Um comitê de especialistas avaliou as equivalências semântica, idiomática, experimental e conceitual, propondo uma versão pré-final que foi aplicada em 10,0% da amostra final. Em seguida, foi aprovada a versão final para a análise psicométrica. Nessa etapa participaram 55 gestantes que responderam à versão brasileira proposta antes de realizarem um exame ultrassonográfico em um hospital público de Santa Catarina, no ano de 2017. A Edinburgh Postnatal Depression Scale foi utilizada como parâmetro de confiabilidade externa. A consistência interna do instrumento foi obtida pelo alfa de Cronbach. A validação foi realizada por análise fatorial exploratória com extração de componentes principais pelo método de Kaiser-Guttman e rotação Varimax.",
+              "RESULTADOS: O alfa de Cronbach do instrumento total foi 0,886, e apenas o percentual de variância do item 2 (0,183) não foi significativo. O critério de Kaiser-Guttman definiu três fatores responsáveis por explicar 78,5% da variância, assim como o gráfico de Escarpa. A extração dos componentes principais pelo método Varimax apresentou valores de 0,713 a 0,926, sendo apenas o item 2 alocado no terceiro componente.",
+              "CONCLUSÕES: A versão brasileira é confiável e válida para uso no diagnóstico de ansiedade relacionada à realização de procedimentos ultrassonográficos no pré-natal. Devido à falta de correlação com o restante do construto, sugere-se a retirada do item 2 da versão final."
+            ],
+            "pub_elocation": [],
+            "pub_fpage": [],
+            "pub_fpage_seq": [],
+            "pub_lpage": [],
+            "pub_subject": [
+              "Artigo Original"
+            ],
+            "pub_volume": [],
+            "pub_issue": []
+          }
+        ],
+        "journal_meta": [
+          {
+            "issn_epub": [],
+            "issn_ppub": [],
+            "journal_nlm_ta": [],
+            "journal_publisher_id": [],
+            "journal_title": [],
+            "publisher_name": []
+          }
+        ],
+        "contrib": [
+          {
+            "contrib_bio": [],
+            "contrib_degrees": [],
+            "contrib_email": [],
+            "contrib_name": [
+              "Kindermann Lucas"
+            ],
+            "contrib_given_names": [
+              "Lucas"
+            ],
+            "contrib_orcid": [
+              "0000-0002-9789-501X"
+            ],
+            "contrib_prefix": [],
+            "contrib_role": [],
+            "contrib_suffix": [],
+            "contrib_surname": [
+              "Kindermann"
+            ],
+            "contrib_type": [
+              "author"
+            ],
+            "xref_corresp": [
+              "c2"
+            ],
+            "xref_corresp_text": [
+              ""
+            ],
+            "xref_aff": [
+              "aff3"
+            ],
+            "xref_aff_text": [
+              "I"
+            ]
+          },
+          {
+            "contrib_bio": [],
+            "contrib_degrees": [],
+            "contrib_email": [],
+            "contrib_name": [
+              "Traebert Jefferson"
+            ],
+            "contrib_given_names": [
+              "Jefferson"
+            ],
+            "contrib_orcid": [
+              "0000-0002-7389-985X"
+            ],
+            "contrib_prefix": [],
+            "contrib_role": [],
+            "contrib_suffix": [],
+            "contrib_surname": [
+              "Traebert"
+            ],
+            "contrib_type": [
+              "author"
+            ],
+            "xref_corresp": [],
+            "xref_corresp_text": [],
+            "xref_aff": [
+              "aff3",
+              "aff4"
+            ],
+            "xref_aff_text": [
+              "I",
+              "II"
+            ]
+          },
+          {
+            "contrib_bio": [],
+            "contrib_degrees": [],
+            "contrib_email": [],
+            "contrib_name": [
+              "Nunes Rodrigo Dias"
+            ],
+            "contrib_given_names": [
+              "Rodrigo Dias"
+            ],
+            "contrib_orcid": [
+              "0000-0002-2261-8253"
+            ],
+            "contrib_prefix": [],
+            "contrib_role": [],
+            "contrib_suffix": [],
+            "contrib_surname": [
+              "Nunes"
+            ],
+            "contrib_type": [
+              "author"
+            ],
+            "xref_corresp": [],
+            "xref_corresp_text": [],
+            "xref_aff": [
+              "aff3",
+              "aff4"
+            ],
+            "xref_aff_text": [
+              "I",
+              "II"
+            ]
+          }
+        ],
+        "aff": [
+          {
+            "addr_city": [
+              "Palhoça"
+            ],
+            "addr_country": [
+              "Brasil"
+            ],
+            "addr_country_code": [
+              "BR"
+            ],
+            "addr_postal_code": [],
+            "addr_state": [
+              "SC"
+            ],
+            "aff_id": [
+              "aff3"
+            ],
+            "aff_text": [
+              "I Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+            ],
+            "aff_email": [],
+            "institution_original": [
+              "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+            ],
+            "institution_orgdiv1": [],
+            "institution_orgdiv2": [],
+            "institution_orgname": [],
+            "institution_orgname_rewritten": [],
+            "label": [
+              "I"
+            ],
+            "phone": []
+          },
+          {
+            "addr_city": [
+              "Palhoça"
+            ],
+            "addr_country": [
+              "Brasil"
+            ],
+            "addr_country_code": [
+              "BR"
+            ],
+            "addr_postal_code": [],
+            "addr_state": [
+              "SC"
+            ],
+            "aff_id": [
+              "aff4"
+            ],
+            "aff_text": [
+              "II Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+            ],
+            "aff_email": [],
+            "institution_original": [
+              "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+            ],
+            "institution_orgdiv1": [],
+            "institution_orgdiv2": [],
+            "institution_orgname": [],
+            "institution_orgname_rewritten": [],
+            "label": [
+              "II"
+            ],
+            "phone": []
+          }
+        ],
+        "pub_date": [],
+        "history_date": [],
+        "kwd_group": [
+          {
+            "lang": [
+              "pt"
+            ],
+            "title": [
+              "DESCRITORES:"
+            ],
+            "kwd": [
+              "Ultrassonografia Pré-Natal, psicologia",
+              "Escala de Ansiedade Frente a Teste",
+              "Inquéritos e Questionários, utilização",
+              "Traduções",
+              "Estudos de Validação"
+            ]
+          }
+        ],
+        "trans_abstract": [],
+        "sub_article": []
+      }
+    ],
+    "aff_contrib_full": [
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Kindermann Lucas"
+        ],
+        "contrib_given_names": [
+          "Lucas"
+        ],
+        "contrib_orcid": [
+          "0000-0002-9789-501X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Kindermann"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [
+          "c1"
+        ],
+        "xref_corresp_text": [
+          ""
+        ],
+        "xref_aff": [
+          "aff1"
+        ],
+        "xref_aff_text": [
+          "I"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Traebert Jefferson"
+        ],
+        "contrib_given_names": [
+          "Jefferson"
+        ],
+        "contrib_orcid": [
+          "0000-0002-7389-985X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Traebert"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff1"
+        ],
+        "aff_text": [
+          "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Faculdade de Medicina"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "I"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Nunes Rodrigo Dias"
+        ],
+        "contrib_given_names": [
+          "Rodrigo Dias"
+        ],
+        "contrib_orcid": [
+          "0000-0002-2261-8253"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Nunes"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff2"
+        ],
+        "aff_text": [
+          "II Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Programa de Pós-Graduação em Ciências da Saúde Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Programa de Pós-Graduação em Ciências da Saúde"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "II"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Traebert Jefferson"
+        ],
+        "contrib_given_names": [
+          "Jefferson"
+        ],
+        "contrib_orcid": [
+          "0000-0002-7389-985X"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Traebert"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      },
+      {
+        "addr_city": [
+          "Palhoça"
+        ],
+        "addr_country": [
+          "Brasil"
+        ],
+        "addr_country_code": [
+          "BR"
+        ],
+        "addr_postal_code": [],
+        "addr_state": [
+          "SC"
+        ],
+        "aff_id": [
+          "aff2"
+        ],
+        "aff_text": [
+          "II Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Programa de Pós-Graduação em Ciências da Saúde Palhoça SC Brasil Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "aff_email": [],
+        "institution_original": [
+          "Universidade do Sul de Santa Catarina. Programa de Pós-Graduação em Ciências da Saúde. Palhoça, SC, Brasil"
+        ],
+        "institution_orgdiv1": [
+          "Programa de Pós-Graduação em Ciências da Saúde"
+        ],
+        "institution_orgdiv2": [],
+        "institution_orgname": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "institution_orgname_rewritten": [
+          "Universidade do Sul de Santa Catarina"
+        ],
+        "label": [
+          "II"
+        ],
+        "phone": [],
+        "contrib_bio": [],
+        "contrib_degrees": [],
+        "contrib_email": [],
+        "contrib_name": [
+          "Nunes Rodrigo Dias"
+        ],
+        "contrib_given_names": [
+          "Rodrigo Dias"
+        ],
+        "contrib_orcid": [
+          "0000-0002-2261-8253"
+        ],
+        "contrib_prefix": [],
+        "contrib_role": [],
+        "contrib_suffix": [],
+        "contrib_surname": [
+          "Nunes"
+        ],
+        "contrib_type": [
+          "author"
+        ],
+        "xref_corresp": [],
+        "xref_corresp_text": [],
+        "xref_aff": [
+          "aff1",
+          "aff2"
+        ],
+        "xref_aff_text": [
+          "I",
+          "II"
+        ]
+      }
+    ]
+  }

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -217,7 +217,7 @@ class ArticleFactoryTests(unittest.TestCase):
             "kernel-document-front-s1518-8787.2019053000621.json"
         )
         self.document = ArticleFactory(
-            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front, "issue-1", "1", ""
+            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front, "issue-1", 621, ""
         )
 
     def tearDown(self):
@@ -303,7 +303,7 @@ class ArticleFactoryTests(unittest.TestCase):
 
     def test_has_order_attribute(self):
         self.assertTrue(hasattr(self.document, "order"))
-        self.assertEqual(1, self.document.order)
+        self.assertEqual(621, self.document.order)
 
     def test_has_xml_attribute(self):
         self.assertTrue(hasattr(self.document, "xml"))
@@ -322,35 +322,57 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertTrue(hasattr(self.document, "updated"))
         self.assertIsNotNone(self.document.updated)
 
-    def test_order_attribute_is_fixed_if_alnum(self):
+    def test_order_attribute_returns_last_five_digits_of_pid_v2_always(self):
+        for order in ("1bla", None, "1234"):
+            with self.subTest(order=order):
+                article = ArticleFactory(
+                    document_id="67TH7T7CyPPmgtVrGXhWXVs",
+                    data=self.document_front,
+                    issue_id="issue-1",
+                    document_order=order,
+                    document_xml_url=""
+                )
+                self.assertEqual(621, article.order)
+
+    def test_order_attribute_returns_zero_because_pid_v2_is_None_and_order_is_alnum(self):
+        front = load_json_fixture(
+            "kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json"
+        )
         article = ArticleFactory(
-            document_id=MagicMock(),
-            data=MagicMock(),
-            issue_id=MagicMock(),
-            document_order="1bla",
-            document_xml_url=MagicMock()
+            document_id="67TH7T7CyPPmgtVrGXhWXVs",
+            data=front,
+            issue_id="issue-1",
+            document_order="bla",
+            document_xml_url=""
         )
         self.assertEqual(0, article.order)
 
-    def test_order_attribute_is_fixed_if_None(self):
+    def test_order_attribute_returns_zero_because_pid_v2_is_None_and_order_is_None(self):
+        front = load_json_fixture(
+            "kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json"
+        )
         article = ArticleFactory(
             document_id=MagicMock(),
-            data=MagicMock(),
+            data=front,
             issue_id=MagicMock(),
             document_order=None,
             document_xml_url=MagicMock()
         )
         self.assertEqual(0, article.order)
 
-    def test_order_attribute_is_kept_if_number(self):
+    def test_order_attribute_returns_order(self):
+        front = load_json_fixture(
+            "kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json"
+        )
         article = ArticleFactory(
             document_id=MagicMock(),
-            data=MagicMock(),
+            data=front,
             issue_id=MagicMock(),
             document_order="1234",
             document_xml_url=MagicMock()
         )
         self.assertEqual(1234, article.order)
+
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -13,6 +13,7 @@ from operations.sync_kernel_to_website_operations import (
     try_register_documents_renditions,
 )
 from opac_schema.v1 import models
+from operations.exceptions import InvalidOrderValueError
 
 
 FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
@@ -322,8 +323,8 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertTrue(hasattr(self.document, "updated"))
         self.assertIsNotNone(self.document.updated)
 
-    def test_order_attribute_returns_last_five_digits_of_pid_v2_always(self):
-        for order in ("1bla", None, "1234"):
+    def test_order_attribute_returns_last_five_digits_of_pid_v2_if_document_order_is_invalid(self):
+        for order in ("1bla", None):
             with self.subTest(order=order):
                 article = ArticleFactory(
                     document_id="67TH7T7CyPPmgtVrGXhWXVs",
@@ -334,31 +335,31 @@ class ArticleFactoryTests(unittest.TestCase):
                 )
                 self.assertEqual(621, article.order)
 
-    def test_order_attribute_returns_zero_because_pid_v2_is_None_and_order_is_alnum(self):
+    def test_order_attribute_raise_invalid_order_value_error_because_pid_v2_is_None_and_order_is_alnum(self):
         front = load_json_fixture(
             "kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json"
         )
-        article = ArticleFactory(
-            document_id="67TH7T7CyPPmgtVrGXhWXVs",
-            data=front,
-            issue_id="issue-1",
-            document_order="bla",
-            document_xml_url=""
-        )
-        self.assertEqual(0, article.order)
+        with self.assertRaises(InvalidOrderValueError):
+            ArticleFactory(
+                document_id="67TH7T7CyPPmgtVrGXhWXVs",
+                data=front,
+                issue_id="issue-1",
+                document_order="bla",
+                document_xml_url=""
+            )
 
     def test_order_attribute_returns_zero_because_pid_v2_is_None_and_order_is_None(self):
         front = load_json_fixture(
             "kernel-document-front-s1518-8787.2019053000621_sem_pid_v2.json"
         )
-        article = ArticleFactory(
-            document_id=MagicMock(),
-            data=front,
-            issue_id=MagicMock(),
-            document_order=None,
-            document_xml_url=MagicMock()
-        )
-        self.assertEqual(0, article.order)
+        with self.assertRaises(InvalidOrderValueError):
+            ArticleFactory(
+                document_id="67TH7T7CyPPmgtVrGXhWXVs",
+                data=front,
+                issue_id="issue-1",
+                document_order=None,
+                document_xml_url=""
+            )
 
     def test_order_attribute_returns_order(self):
         front = load_json_fixture(


### PR DESCRIPTION
#### O que esse PR faz?
Usa como valor do "order" os 5 últimos dígitos do PID v2 em caso de o `document_order` fornecido ao `ArticleFactory` for inválido

#### Onde a revisão poderia começar?
pelo commit 446d24dab5ae7c8493c0f49434164cc613f0b682

#### Como este poderia ser testado manualmente?
Ver #230

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#230

### Referências
n/a