### PR TITLE
Adiciona reexecuções para tasks que interagem com Kernel e Minio

### DIFF
--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -21,7 +21,7 @@
 """
 import os
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from tempfile import mkdtemp
 
 from airflow import DAG
@@ -38,6 +38,8 @@ default_args = {
     "owner": "airflow",
     "depends_on_past": False,
     "start_date": datetime(2019, 7, 21),
+    "retries": 5,
+    "retry_delay": timedelta(minutes=5),
 }
 
 dag = DAG(dag_id="sync_documents_to_kernel", default_args=default_args, schedule_interval=None)

--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -77,7 +77,7 @@ default_args = {
     "email": ["airflow@example.com"],
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 1,
+    "retries": 5,
     "retry_delay": timedelta(minutes=5),
 }
 


### PR DESCRIPTION
#### O que esse PR faz?

Este pull request permite que tasks que falharam durante a execução, por qualquer que seja o motivo (ex: _timeout_), possam ser reexecutadas automaticamente pelo _scheduler_ do airflow.

Essa estratégia vai nos garantir mais robustez na hora de executar tarefas que alteram o estado do `kernel` (ex: `sync_documents_to_kernel`), assim,  por exemplo se houve uma falha na hora inserção de um documento, a task será reexecutada por até 5 vezes com um espaço de tempo de 5 minutos entre cada execução.

#### Onde a revisão poderia começar?
A partir do commit 4227d35

#### Como este poderia ser testado manualmente?
Para testar este PR manualmente, deve-se:
- Suba uma instância do airflow;
- Desligue algum ponto de integração (minio, kernel);
- Execute a sincronização de um pacote SPS;
- Observe as tasks falharem;
- Observe o _scheduler_ marcar a task como `up_for_retry`;
- Observe que as taks `up_for_retry` são executadas por até 5x com espaços de 5 minutos;
- Se o ponto de integração voltar a funcionar a task deverá passar a ficar verde;

#### Algum cenário de contexto que queira dar?
Este PR é um meio paliativo para melhorar o nosso processamento de pacotes SPS enquanto as integração com kernel e minio não estão 100%.

### Screenshots
![output](https://user-images.githubusercontent.com/4604104/96932652-9789b880-1495-11eb-96cf-0cddebb26b45.gif)


#### Quais são tickets relevantes?
N/A

### Referências
N/A