### PR TITLE
Modifica a DAG check_website, nas tarefas relacionadas com verificar os documentos em profundidade

### DIFF
--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -1443,3 +1443,12 @@ def format_document_availability_data_to_register(
                 webpages_availability[0],
                 rendition_availability, extra_data):
             add_execution_in_database("availability", row)
+
+
+def group_documents_by_issue_pid_v2(uri_items):
+    groups = {}
+    for uri in uri_items:
+        pid_j, pid_i, pid_d = get_journal_issue_doc_pids(uri)
+        groups[pid_i] = groups.get(pid_i, [])
+        groups[pid_i].append(uri)
+    return groups

--- a/airflow/dags/subdags/check_website_subdags.py
+++ b/airflow/dags/subdags/check_website_subdags.py
@@ -1,0 +1,65 @@
+import logging
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator
+
+from operations.check_website_operations import (
+    group_documents_by_issue_pid_v2,
+)
+
+
+Logger = logging.getLogger(__name__)
+
+
+def _group_documents_by_issue_pid_v2(args, default_uri_items=None):
+    Logger.info(args)
+    try:
+        uri_items = Variable.get(
+            "_sci_arttext", default_var=[], deserialize_json=True)
+        Logger.info("Variable: %s", uri_items)
+    except Exception:
+        uri_items = args.get("_sci_arttext") or []
+        Logger.info("args: %s", uri_items)
+    uri_items = uri_items or default_uri_items
+    Logger.info("create_subdag for %i", len(uri_items))
+    return group_documents_by_issue_pid_v2(uri_items)
+
+
+def create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(
+        dag, subdag_callable, group_documents_callable, args):
+    """
+    Cria uma subdag para executar check_documents_deeply em lotes menores
+    para facilitar a reexecução
+    """
+    Logger.info("Create check_documents_deeply subdag")
+
+    groups = group_documents_callable(args)
+    Logger.info("%s", groups)
+    parent_dag_name = 'check_website'
+    child_dag_name = 'check_documents_deeply_grouped_by_issue_pid_v2_id'
+
+    dag_subdag = DAG(
+        dag_id='{}.{}'.format(parent_dag_name, child_dag_name),
+        default_args=args,
+        schedule_interval=None,
+    )
+    # FIXME
+    dag_run_data = {}
+    with dag_subdag:
+        Logger.info("%i", len(groups.items()))
+        for k, uri_items in groups.items():
+            id = k
+            task_id = '{}_{}'.format(child_dag_name, id)
+
+            Logger.info("%s", k)
+            Logger.info("%s", uri_items)
+            Logger.info("%s", task_id)
+
+            PythonOperator(
+                task_id=task_id,
+                python_callable=subdag_callable,
+                op_args=(uri_items, dag_run_data),
+                dag=dag_subdag,
+            )
+    return dag_subdag

--- a/airflow/dags/subdags/check_website_subdags.py
+++ b/airflow/dags/subdags/check_website_subdags.py
@@ -19,9 +19,11 @@ def _group_documents_by_issue_pid_v2(args, default_uri_items=None):
             "_sci_arttext", default_var=[], deserialize_json=True)
         Logger.info("Variable: %s", uri_items)
     except Exception:
+        # sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) 
+        # could not connect to server: Connection refused
         uri_items = args.get("_sci_arttext") or []
         Logger.info("args: %s", uri_items)
-    uri_items = uri_items or default_uri_items
+    uri_items = uri_items or default_uri_items or []
     Logger.info("create_subdag for %i", len(uri_items))
     return group_documents_by_issue_pid_v2(uri_items)
 

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -28,7 +28,6 @@ from check_website import (
     merge_uri_items_from_different_sources,
     check_input_vs_processed_pids,
     check_documents_deeply,
-    create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2,
     check_documents_deeply_grouped_by_issue_pid_v2,
 )
 
@@ -1937,45 +1936,6 @@ class TestCheckDocumentsDeeply(TestCase):
             call("Checked %i PID v2 items", 0),
             mock_logger.info.call_args_list
         )
-
-
-class TestCreateSubdagToCheckDocumentsDeeplyGroupedByIssuePidV2(TestCase):
-
-    @patch("check_website.DAG")
-    @patch("check_website.Variable.get")
-    @patch("check_website.PythonOperator")
-    def test_create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2_(
-            self, mock_python_op, mock_get, mock_dag):
-        dag = MagicMock(spec=DAG)
-        mock_dag.return_value = MagicMock(spec=DAG)
-        mock_get.side_effect = [
-            [
-                "/scielo.php?script=sci_arttext&pid=S0001-30352020000501101",
-                "/scielo.php?script=sci_arttext&pid=S0203-19982020000501101",
-                "/scielo.php?script=sci_arttext&pid=S0203-19982020000511111",
-            ]
-        ]
-
-        create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(dag)
-        calls = [
-            call(task_id='check_documents_deeply_grouped_by_issue_pid_v2_id_1',
-                 python_callable=check_documents_deeply_grouped_by_issue_pid_v2,
-                 op_args=(
-                    ["/scielo.php?script=sci_arttext&pid=S0001-30352020000501101"],
-                    {}
-                 ),
-                 dag=mock_dag()),
-            call(task_id='check_documents_deeply_grouped_by_issue_pid_v2_id_2',
-                 python_callable=check_documents_deeply_grouped_by_issue_pid_v2,
-                 op_args=(
-                    ["/scielo.php?script=sci_arttext&pid=S0203-19982020000501101",
-                     "/scielo.php?script=sci_arttext&pid=S0203-19982020000511111",],
-                    {}
-                    ),
-                 dag=mock_dag()),
-        ]
-        self.assertListEqual(calls, mock_python_op.call_args_list)
-
 
 
 @patch("check_website.check_website_operations.add_execution_in_database")

--- a/airflow/tests/test_check_website.py
+++ b/airflow/tests/test_check_website.py
@@ -482,6 +482,7 @@ class TestGetUriItemsFromPidFiles(TestCase):
         self.kwargs["ti"].xcom_push.assert_not_called()
 
 
+@patch("check_website.Variable.set")
 class TestGetUriItemsGroupedByScriptName(TestCase):
     def setUp(self):
         self.kwargs = {
@@ -491,7 +492,7 @@ class TestGetUriItemsGroupedByScriptName(TestCase):
         }
 
     @patch("check_website.Logger.info")
-    def test_get_uri_items_grouped_by_script_name_returns_true(self, mock_info):
+    def test_get_uri_items_grouped_by_script_name_returns_true(self, mock_info, mock_set):
         uri_list = [
             "/scielo.php?script=sci_arttext&pid=S0001-30352020000501101",
             "/scielo.php?script=sci_arttext&pid=S0001-37652020000501101",
@@ -599,7 +600,7 @@ class TestGetUriItemsGroupedByScriptName(TestCase):
         )
 
     @patch("check_website.Logger.info")
-    def test_get_uri_items_grouped_by_script_name_returns_false(self, mock_info):
+    def test_get_uri_items_grouped_by_script_name_returns_false(self, mock_info, mock_set):
         bad_uri_list = [
             "/scielo.php?param1=sci_arttext&pid=S0001-30352020000501101",
         ]

--- a/airflow/tests/test_check_website_subdag.py
+++ b/airflow/tests/test_check_website_subdag.py
@@ -1,0 +1,70 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, call
+
+from airflow import DAG
+from airflow.utils.dates import days_ago
+
+from subdags.check_website_subdags import (
+    create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2,
+)
+
+
+class TestCreateSubdagToCheckDocumentsDeeplyGroupedByIssuePidV2(TestCase):
+
+    @patch("subdags.check_website_subdags.DAG")
+    @patch("subdags.check_website_subdags.PythonOperator")
+    def test_create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2_(
+            self, mock_python_op, mock_DAG):
+        mock_DAG.return_value = MagicMock(spec=DAG)
+        mock_dag = mock_DAG()
+
+        default_args = {
+            "owner": "airflow",
+            "start_date": days_ago(2),
+            "provide_context": True,
+            "depends_on_past": False,
+        }
+
+        def _subdag_callable(uri_items, dag_run_data):
+            return "do anything"
+
+        def _group_callable(args, op=None):
+            return {
+                "0001-303520200005": [
+                    "/scielo.php?script=sci_arttext"
+                    "&pid=S0001-30352020000501101",
+                ],
+                "0203-199820200005": [
+                    "/scielo.php?script=sci_arttext"
+                    "&pid=S0203-19982020000501101",
+                    "/scielo.php?script=sci_arttext"
+                    "&pid=S0203-19982020000511111",
+                ],
+            }
+
+        subdag_name = "check_documents_deeply_grouped_by_issue_pid_v2_id"
+        create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(
+            mock_dag, _subdag_callable, _group_callable, default_args)
+        calls = [
+            call(task_id='{}_{}'.format(subdag_name, "0001-303520200005"),
+                 python_callable=_subdag_callable,
+                 op_args=(
+                    ["/scielo.php?script=sci_arttext"
+                     "&pid=S0001-30352020000501101"],
+                    {}
+                 ),
+                 dag=mock_dag),
+            call(task_id='{}_{}'.format(subdag_name, "0203-199820200005"),
+                 python_callable=_subdag_callable,
+                 op_args=(
+                    ["/scielo.php?script=sci_arttext"
+                     "&pid=S0203-19982020000501101",
+                     "/scielo.php?script=sci_arttext"
+                     "&pid=S0203-19982020000511111",
+                     ],
+                    {}
+                    ),
+                 dag=mock_dag),
+        ]
+        self.assertListEqual(calls, mock_python_op.call_args_list)
+


### PR DESCRIPTION
#### O que esse PR faz?

Esta alteração resolve o problema de ter que reprocessar  N documentos devido a uma falha de uma tarefa, fazendo com que tudo fosse reprocessado mesmo que já tivesse passado com sucesso.

A nova abordagem divide em "fascículos" os N documentos de modo que se as tarefas pararem não seja necessário recomeçar a processar desde o início, mas sim apenas aqueles grupos que falharam.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Crie uma lista contendo PIDs e armazendo em um arquivo teste.csv que vc deve informar na Variable `PID_LIST_CSV_FILE_NAMES`(exemplo: `[ "teste.csv" ]`). Veja o README.

Dispare a DAG check_website.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
DAG check_website
<img width="1063" alt="Captura de Tela 2020-10-28 às 16 19 45" src="https://user-images.githubusercontent.com/505143/98023253-6c805c80-1de5-11eb-8a7f-8d89c0afb449.png">

ZOOM
<img width="602" alt="Captura de Tela 2020-10-28 às 16 21 21" src="https://user-images.githubusercontent.com/505143/98023260-6d18f300-1de5-11eb-8116-2e402e989e9a.png">

SubDags com falhas
<img width="1080" alt="Captura de Tela 2020-10-28 às 15 53 04" src="https://user-images.githubusercontent.com/505143/98023242-67bba880-1de5-11eb-9b2d-fa54e4c43d1a.png">

SubDags reexecutadas
<img width="1113" alt="Captura de Tela 2020-10-28 às 16 06 56" src="https://user-images.githubusercontent.com/505143/98023251-6b4f2f80-1de5-11eb-84b4-837064cdd130.png">

#### Quais são tickets relevantes?
#228
 
### Referências
n/a