### PR TITLE
Evitar a exceção quando não existe o ativo digital no manifest do documento e também apresenta a ausência nos relatórios

### DIFF
--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -270,6 +270,7 @@ def check_asset_uri_items_expected_in_webpage(existing_uri_items_in_html,
              for a in assets_data]),
         "total alternatives present in html": 0,
     }
+    incorrects = []
     for asset_data in assets_data:
         # {"prefix": prefix, "uri_alternatives": [],}
         uri_result = {}
@@ -282,13 +283,16 @@ def check_asset_uri_items_expected_in_webpage(existing_uri_items_in_html,
                 uri_result["present_in_html"].append(uri)
             else:
                 uri_result["absent_in_html"].append(uri)
+        if not uri_result["present_in_html"] and not uri_result["absent_in_html"]:
+            incorrects += [asset_data["prefix"]]
+            uri_result["incorrect"] = True
         results.append(uri_result)
-
         if not uri_result["present_in_html"]:
             summary["total missing"] += 1
         summary["total alternatives present in html"] += len(
             uri_result["present_in_html"])
-
+    if incorrects:
+        summary["total incorrect assets"] = len(incorrects)
     return results, summary
 
 

--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -736,7 +736,7 @@ def add_responses(doc_data_list, website_url=None, request=True, timeout=None):
         for doc_data in doc_data_list:
             doc_data["uri"] = website_url + doc_data["uri"]
             body = doc_data.get("format") == "html"
-    uri_items = (doc_data["uri"] for doc_data in doc_data_list)
+    uri_items = (doc_data["uri"] for doc_data in doc_data_list if doc_data["uri"])
 
     responses = {}
     if request:

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -122,9 +122,15 @@ def get_document_assets_data(current_version):
         prefix, ext = os.path.splitext(asset_id)
         prefix = prefix.replace(".thumbnail", "")
         assets_by_prefix[prefix] = assets_by_prefix.get(prefix) or []
+
+        try:
+            _uri = asset[LAST_VERSION][1]
+        except IndexError:
+            _uri = None
+
         uri = {
                 "asset_id": asset_id,
-                "uri": asset[LAST_VERSION][1],
+                "uri": _uri,
             }
         assets_by_prefix[prefix].append(uri)
         assets_data.append(uri)

--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -144,6 +144,7 @@ def get_document_assets_data(current_version):
                 "uri_alternatives": [
                     alternative["uri"]
                     for alternative in asset_alternatives
+                    if alternative["uri"]
                 ],
                 "asset_alternatives": asset_alternatives,
             }

--- a/airflow/tests/test_check_website_operations.py
+++ b/airflow/tests/test_check_website_operations.py
@@ -3396,6 +3396,53 @@ class TestCheckAssetUriItemsExpectedInWebpage(TestCase):
         self.assertEqual(expected, result)
         self.assertEqual(expected_summary, summary)
 
+    def test_check_asset_uri_items_expected_in_webpage_returns_incorrect_assets(self):
+        uri_items_in_html = [
+            "asset_uri_1.jpg",
+            "asset_uri_2.jpg",
+            "/j/xyz/a/lokiujyht?format=html&lang=en",
+            "/j/xyz/a/lokiujyht?format=pdf&lang=es",
+            "/j/xyz/a/lokiujyht?format=pdf&lang=en",
+        ]
+        assets_data = [
+            {
+                "prefix": "asset_uri_1",
+                "uri_alternatives": []
+            },
+            {
+                "prefix": "asset_uri_2",
+                "uri_alternatives": []
+            }
+        ]
+        expected = [
+            {
+                "type": "asset",
+                "id": "asset_uri_1",
+                "present_in_html": [],
+                "absent_in_html": [],
+                "incorrect": True,
+            },
+            {
+                "type": "asset",
+                "id": "asset_uri_2",
+                "present_in_html": [],
+                "absent_in_html": [],
+                "incorrect": True,
+            },
+        ]
+        expected_summary = {
+            "total expected": 2,
+            "total missing": 2,
+            "total alternatives": 0,
+            "total alternatives present in html": 0,
+            "total incorrect assets": 2,
+        }
+        result, summary = check_asset_uri_items_expected_in_webpage(
+                    uri_items_in_html,
+                    assets_data)
+        self.assertEqual(expected, result)
+        self.assertEqual(expected_summary, summary)
+
 
 class TestCalculateMissingAndTotalItems(TestCase):
     def test_calculate_missing_and_total_returns_no_missing(self):

--- a/airflow/tests/test_docs_utils.py
+++ b/airflow/tests/test_docs_utils.py
@@ -1235,6 +1235,39 @@ class TestGetDocumentAssetsData(TestCase):
         self.assertIs(assets_data[2], grouped_by_id[1]["asset_alternatives"][0])
         self.assertIs(assets_data[3], grouped_by_id[1]["asset_alternatives"][1])
 
+    def test_get_document_assets_data_returns_empty_list_of_alternatives(self):
+        data = {}
+        data["assets"] = {
+            "a01": [
+            ],
+            "a02.jpg": [
+                ["2020-08-10T11:38:46.759859Z", "https://vrsao2/a02.jpg"],
+            ],
+        }
+        expected = [
+            {
+                "prefix": "a01",
+                "uri_alternatives": [],
+                "asset_alternatives": [
+                    {"asset_id": "a01", "uri": None},
+                ],
+            },
+            {
+                "prefix": "a02",
+                "uri_alternatives": ["https://vrsao2/a02.jpg"],
+                "asset_alternatives": [
+                    {"asset_id": "a02.jpg", "uri": "https://vrsao2/a02.jpg"},
+                ],
+            },
+        ]
+        expected_assets_data = [
+            {"asset_id": "a01", "uri": None},
+            {"asset_id": "a02.jpg", "uri": "https://vrsao2/a02.jpg"},
+        ]
+        assets_data, grouped_by_id = get_document_assets_data(data)
+        self.assertEqual(expected, grouped_by_id)
+        self.assertEqual(expected_assets_data, assets_data)
+
 
 class Testget_document_renditions_data(TestCase):
 


### PR DESCRIPTION
#### O que esse PR faz?
Evitar a exceção quando não existe o ativo digital no manifest do documento e também apresenta a ausência nos relatórios

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
- veja como simular o erro #227
- aplique a DAG check_website do documento mencionado
- verifique que o problema foi corrigido
- no grafana, quando estiver programado, o documento deveria aparecer em "falha em menção de ativos digitais"

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#227 

### Referências
n/a