### PR TITLE
Nova sincronização de pacotes e documentos

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,20 @@ $ airflow webserver
 * Login: login do Object Store
 * Extra: `{"host": "<endereço do host:porta>"}`
 
+## Conexão com MongoDB:
+
+* Conn Id: `mongo_default`
+* Conn Type: `MongoDB`
+* Host: endereço do host MongoDB
+* Schema: `airflow-data`
+* Port: porta do host MongoDB
+* Extra: `{"authentication_source": "admin"}`
+
 ## Variáveis:
 
 * `BASE_TITLE_FOLDER_PATH`: Diretório de origem da base ISIS title
 * `BASE_ISSUE_FOLDER_PATH`: Diretório de origem da base ISIS issue
 * `WORK_FOLDER_PATH`: Diretório para a cópia das bases ISIS
-* `SCILISTA_FILE_PATH`: Caminho onde o arquivo `scilista` deverá ser lido
 * `XC_SPS_PACKAGES_DIR`: Diretório de origem dos pacotes SPS a serem sincronizados
 * `PROC_SPS_PACKAGES_DIR`: Diretório de destino dos pacotes SPS a serem sincronizados
 * `NEW_SPS_ZIP_DIR`: Diretório de destino dos pacotes SPS otimizados
@@ -107,6 +115,9 @@ $ airflow webserver
 
 * `AIRFLOW_HOME`: Diretório de instalação da aplicação 
 * `EMIAL_ON_FAILURE_RECIPIENTS`: Conta de e-mail para envio de falha, padrão: infra@scielo.org
+* `AIRFLOW__CORE__EXECUTOR`: Executor padrão para as tarefas do Airflow, padrão: LocalExecutor
+* `AIRFLOW__CORE__PARALLELISM`: Número máximo de tarefas executadas simultaneamente, a depender do número de workers/executors
+* `AIRFLOW__WEBSERVER__WORKERS`: Número de workers a rodar no Webserver Gunicorn, padrão: 1
 * `AIRFLOW__SMTP__SMTP_HOST`: Endereço do servidor de e-mail
 * `AIRFLOW__SMTP__SMTP_USER`: Endereço de e-mail responsável pelo envio de e-mails
 * `AIRFLOW__SMTP__SMTP_PASSWORD`: Endereço de e-mail responsável pelo envio de e-mails

--- a/airflow/dags/collect_scilista_packages.py
+++ b/airflow/dags/collect_scilista_packages.py
@@ -1,0 +1,115 @@
+# conding: utf-8
+"""
+    DAG responsável por preparar os pacotes SPS vindos do fluxo de ingestão para atualização do Kernel.
+
+    Passos:
+        a. Ler Scilista e determinar ação de cada fascículo
+        b. Se for comando para deleção de fascículo, ignora comando para fascículo
+        c. Senão
+            1. Move pacotes SPS referentes ao fascículo da Scilista, ordenados pelo nome
+               com data e hora
+            2. Dispara execução de DAG de sincronização para cada bundle
+"""
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
+from airflow.utils import timezone
+from airflow.api.common.experimental.trigger_dag import trigger_dag
+
+from operations import pre_sync_documents_to_kernel_operations
+from common.hooks import clear_existing_dag_run
+
+
+Logger = logging.getLogger(__name__)
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 7, 22),
+}
+
+
+def get_sps_packages(dag_run, **kwargs):
+    """Obtém os pacotes SPS para o diretório de trabalho com base na scilista."""
+
+    _gerapadrao_id = dag_run.conf.get("GERAPADRAO_ID")
+    if not _gerapadrao_id:
+        Logger.error("GERAPADRAO_ID is None and must be informed.")
+        return False
+
+    _xc_sps_packages_dir = Path(Variable.get("XC_SPS_PACKAGES_DIR"))
+    _proc_sps_packages_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / _gerapadrao_id
+    if not _proc_sps_packages_dir.is_dir():
+        _proc_sps_packages_dir.mkdir()
+
+    _scilista_file_path = pre_sync_documents_to_kernel_operations.get_scilista_file_path(
+        _xc_sps_packages_dir,
+        _proc_sps_packages_dir,
+        _gerapadrao_id,
+    )
+    _sps_packages = pre_sync_documents_to_kernel_operations.get_sps_packages_on_scilista(
+        _scilista_file_path,
+        _xc_sps_packages_dir,
+        _proc_sps_packages_dir,
+    )
+
+    if _sps_packages:
+        kwargs["ti"].xcom_push(key="sps_packages", value=_sps_packages)
+        return True
+    else:
+        return False
+
+
+def start_sync_packages(dag_run, **kwargs):
+    """Executa trigger de dags de extração de informações dos pacotes SPS."""
+
+    _sps_packages = kwargs["ti"].xcom_pull(
+        key="sps_packages", task_ids="get_sps_packages_task"
+    ) or {}
+    for bundle_label, bundle_packages in _sps_packages.items():
+        Logger.info(
+            'Triggering an external dag from "%s", gerapadrao_id "%s" with "%s" packages'
+            ': %s', kwargs.get("run_id"), dag_run.conf.get("GERAPADRAO_ID"), bundle_label, bundle_packages
+        )
+        dag_id = "extract_packages_info"
+        run_id = f'trig__{dag_run.conf.get("GERAPADRAO_ID")}_{bundle_label}'
+        if not clear_existing_dag_run(dag_id, run_id):
+            now = timezone.utcnow()
+            trigger_dag(
+                dag_id=dag_id,
+                run_id=run_id,
+                execution_date=now,
+                replace_microseconds=False,
+                conf={
+                    "bundle_label": bundle_label,
+                    "sps_packages": bundle_packages,
+                    "pre_syn_dag_run_id": kwargs.get("run_id"),
+                    "gerapadrao_id": dag_run.conf.get("GERAPADRAO_ID")
+                },
+            )
+
+
+with DAG(
+    dag_id="collect_scilista_packages", default_args=default_args, schedule_interval=None
+) as dag:
+
+    get_sps_packages_task = ShortCircuitOperator(
+        task_id="get_sps_packages_task",
+        provide_context=True,
+        python_callable=get_sps_packages,
+        dag=dag,
+    )
+
+    start_sync_packages_task = PythonOperator(
+        task_id="start_sync_packages_task",
+        provide_context=True,
+        python_callable=start_sync_packages,
+        dag=dag,
+    )
+    
+    get_sps_packages_task >> start_sync_packages_task

--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -121,6 +121,27 @@ def save_document_in_database(
             Logger.error(exc)
 
 
+def get_documents_in_database(
+    collection: str,
+    filter: dict,
+    order_by: list,
+    connection_id: str = "mongo_default",
+):
+    """Retorna documentos em coleção MongoDB."""
+    with MongoHook(conn_id=connection_id) as hook: 
+        try:
+            Logger.info(
+                'Getting document filter %s from "%s" collection, ordered by %s',
+                filter, collection, order_by
+            )
+            cursor = hook.find(collection, filter, sort=order_by)
+        except (AirflowException, ProgrammingError) as exc:
+            Logger.error(exc)
+        else:
+            documents = [document for document in cursor]
+            return documents
+
+
 def add_execution_in_database(
     table, data={}, connection_id="postgres_report_connection"
 ):

--- a/airflow/dags/extract_packages_info.py
+++ b/airflow/dags/extract_packages_info.py
@@ -1,0 +1,172 @@
+"""DAG responsável por extrair dados dos pacote SPS para publicação."""
+
+import logging
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.models import Variable
+from airflow.operators.python_operator import ShortCircuitOperator
+from airflow.utils import timezone
+from airflow.api.common.experimental.trigger_dag import trigger_dag
+
+from operations import sync_documents_to_kernel_operations
+from common.hooks import save_document_in_database, clear_existing_dag_run
+
+
+Logger = logging.getLogger(__name__)
+
+
+def optimize_packages(dag_run, **kwargs):
+    """
+    Otimiza os pacotes SPS do bundle para WEB. Registra a lista de pacotes 
+    `sps_packages` atualizada no XCom, com os caminhos de pacotes que foram otimizados.
+
+    :param dag_run: Dados do DAG Run. Serão usados bundle_label, sps_packages e 
+        gerapadrao_id
+    """
+    bundle_label = dag_run.conf.get("bundle_label")
+    sps_packages = dag_run.conf.get("sps_packages") or []
+    gerapadrao_id = dag_run.conf.get("gerapadrao_id")
+    new_sps_pkg_zip_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / gerapadrao_id / "optimized"
+    if not new_sps_pkg_zip_dir.is_dir():
+        new_sps_pkg_zip_dir.mkdir()
+
+    packages_after_optimization = []
+    for sps_package in sps_packages:
+        new_sps_pkg_zip_file = sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file(
+            sps_package, new_sps_pkg_zip_dir
+        )
+        if new_sps_pkg_zip_file:
+            Logger.info(
+                "[%s] Package %s optimized in %s",
+                bundle_label,
+                sps_package,
+                new_sps_pkg_zip_file,
+            )
+            packages_after_optimization.append(new_sps_pkg_zip_file)
+        else:
+            Logger.warning("[%s] Package %s not optimized", bundle_label, sps_package)
+            packages_after_optimization.append(sps_package)
+
+    if packages_after_optimization:
+        kwargs["ti"].xcom_push(key="optimized_packages", value=packages_after_optimization)
+        return True
+    else:
+        return False
+
+
+def extract_packages_data(dag_run, run_id, execution_date, **kwargs):
+    """
+    Executa a extração de metadados dos documentos XMLs contidos nos pacotes SPS.
+    Os dados serão usados para a syncronização com o Kernel e o Object Store.
+
+    :param run_id: Run ID da DAG Run atual
+    :param dag_run: Dados do DAG Run. Serão usados bundle_label e pre_syn_dag_run_id
+    """
+    sps_packages = kwargs["ti"].xcom_pull(
+        key="optimized_packages", task_ids="optimize_packages_task"
+    )
+    data_to_complete = {
+        "bundle_label": dag_run.conf.get("bundle_label"),
+        "gerapadrao_id": dag_run.conf.get("gerapadrao_id"),
+        "pre_sync_dag_run": run_id,
+        "execution_date": execution_date,
+    }
+
+    scielo_ids = []
+    for sps_package in sps_packages:
+        # Extrai os dados de cada pacote
+        documents_info, fields_filter = \
+            sync_documents_to_kernel_operations.extract_package_data(sps_package)
+
+        for xml_filename, document_record in documents_info.items():
+            Logger.info(
+                'Saving "%s" extracted document info from "%s" package',
+                xml_filename, sps_package
+            )
+
+            # Completa os dados de cada documento com dados da Dag Run
+            filter = {
+                field: value
+                for field, value in document_record.items()
+                if field in fields_filter
+            }
+            filter.update(data_to_complete)
+            document_record.update(data_to_complete)
+            save_document_in_database("e_documents", filter, document_record)
+
+            # Adiciona o pid na lista para carga de documentos
+            if document_record.get("pid"):
+                scielo_ids.append(document_record["pid"])
+
+    if scielo_ids:
+        kwargs["ti"].xcom_push(key="scielo_ids", value=set(scielo_ids))
+        return True
+    else:
+        return False
+
+
+def start_sync_documents(dag_run, run_id, **kwargs):
+    """Executa trigger de dags de carregamento dos dados por documento."""
+
+    bundle_label = dag_run.conf.get("bundle_label")
+    scielo_ids = kwargs["ti"].xcom_pull(
+        key="scielo_ids", task_ids="extract_packages_data_task"
+    )
+    for i, scielo_id in enumerate(scielo_ids, 1):
+        Logger.info(
+            "[%s] Triggering an external dag for XML file [%d/%d]: %s",
+            bundle_label, i, len(scielo_ids), scielo_id,
+        )
+
+        dag_id = "sync_docs_to_kernel"
+        trigger_run_id = f'trig__{dag_run.conf.get("gerapadrao_id")}_{scielo_id}'
+        if not clear_existing_dag_run(dag_id, trigger_run_id):
+            now = timezone.utcnow()
+            trigger_dag(
+                dag_id=dag_id,
+                run_id=trigger_run_id,
+                execution_date=now,
+                replace_microseconds=False,
+                conf={
+                    "scielo_id": scielo_id,
+                    "pre_syn_dag_run_id": run_id,
+                },
+            )
+
+
+DAG_NAME = "extract_packages_info"
+args = {
+    'owner': 'airflow',
+    "depends_on_past": False,
+    "start_date": datetime(2019, 7, 21),
+}
+
+
+with DAG(
+        dag_id=DAG_NAME, default_args=args, schedule_interval=None
+    ) as dag:
+
+    optimize_packages_task = ShortCircuitOperator(
+        task_id="optimize_packages_task",
+        provide_context=True,
+        python_callable=optimize_packages,
+        dag=dag,
+    )
+
+    extract_packages_data_task = ShortCircuitOperator(
+        task_id="extract_packages_data_task",
+        provide_context=True,
+        python_callable=extract_packages_data,
+        dag=dag,
+    )
+
+    start_sync_documents_task = ShortCircuitOperator(
+        task_id="start_sync_documents_task",
+        provide_context=True,
+        python_callable=start_sync_documents,
+        dag=dag,
+    )
+
+    optimize_packages_task >> extract_packages_data_task >> start_sync_documents_task

--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import shutil
+import json
 from pathlib import Path
 
 Logger = logging.getLogger(__name__)
@@ -98,6 +99,71 @@ def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
     if sps_packages_list:
         Logger.info('Saving SPS packages list in "%s" file', package_paths_list)
         package_paths_list.write_text("\n".join(sps_packages_list))
+
+    Logger.debug("get_sps_packages OUT")
+    return sps_packages_list
+
+
+def get_sps_packages_on_scilista(scilista_file_path, xc_dir_name, proc_dir_name):
+    """
+    Obtém Pacotes SPS através da Scilista, movendo os pacotes para o diretório de 
+    processamento do Airflow e gera lista dos paths dos pacotes SPS no diretório de 
+    processamento.
+
+    Retorna sps_packages_list: dict com as listas de paths dos pacotes SPS no diretório de
+    processamento agrupadas por bundle
+    """
+    Logger.debug("get_sps_packages IN")
+
+    xc_dir_path = Path(xc_dir_name)
+    proc_dir_path = Path(proc_dir_name)
+    sps_packages_list = {}
+
+    package_paths_list = proc_dir_path / "sps_packages.lst"
+    if package_paths_list.is_file():
+        Logger.info(
+            'Pre-sync already done. Returning packages from "%s" file',
+            package_paths_list,
+        )
+        with package_paths_list.open() as sps_list_file:
+            return json.load(sps_list_file)
+
+    with open(scilista_file_path) as scilista:
+        for scilista_item in scilista.readlines():
+            acron_issue = scilista_item.strip().split()
+            if len(acron_issue) != 2:
+                continue
+            bundle_label = "_".join(acron_issue)
+            filename_pattern = "{}_{}.zip".format(
+                PREFIX_PATTERN, bundle_label)
+            Logger.info("Reading ZIP files pattern: %s", filename_pattern)
+
+            # verifica na origem
+            for item in xc_dir_path.glob(filename_pattern):
+                dest_file_path = str(proc_dir_path / item.name)
+                if os.path.isfile(dest_file_path):
+                    Logger.info("Skip %s", str(item))
+                    continue
+                Logger.info("Moving %s to %s", str(item), str(proc_dir_path))
+                shutil.move(str(item), str(proc_dir_path))
+
+            # verifica no destino
+            acron_issue_list = []
+            for item in sorted(proc_dir_path.glob(filename_pattern)):
+                Logger.info("Found %s", str(proc_dir_path / item.name))
+                acron_issue_list.append(str(proc_dir_path / item.name))
+
+            if acron_issue_list:
+                sps_packages_list[bundle_label] = acron_issue_list
+            else:
+                Logger.exception(
+                    "Missing files which pattern is '%s' in %s and in %s",
+                    filename_pattern, str(xc_dir_path), str(proc_dir_path))
+
+    if sps_packages_list:
+        Logger.info('Saving SPS packages list in "%s" file', package_paths_list)
+        with package_paths_list.open('w') as sps_list_file:
+            json.dump(sps_packages_list, sps_list_file)
 
     Logger.debug("get_sps_packages OUT")
     return sps_packages_list

--- a/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/pre_sync_documents_to_kernel_operations.py
@@ -10,6 +10,33 @@ PREFIX_PATTERN += ("-" + ("[0-9]" * 2)) * 5
 PREFIX_PATTERN += "-" + ("[0-9]" * 6)
 
 
+def get_scilista_file_path(
+    xc_sps_packages_dir: Path, proc_sps_packages_dir: Path, gerapadrao_id: str
+) -> str:
+    """Garante que a scilista usada será a do diretório de PROC. Quando for a primeira
+    execução da DAG, a lista será copiada para o diretório de PROC. Caso contrário, a 
+    mesma será mantida.
+    """
+    proc_dir_scilista_list = list(proc_sps_packages_dir.glob(f"scilista-*.lst"))
+    if proc_dir_scilista_list:
+        _proc_scilista_file_path = proc_dir_scilista_list[0]
+        Logger.info('Proc scilista "%s" already exists', _proc_scilista_file_path)
+    else:
+        _scilista_filename = f"scilista-{gerapadrao_id}.lst"
+        _origin_scilista_file_path = xc_sps_packages_dir / _scilista_filename
+        if not _origin_scilista_file_path.is_file():
+            raise FileNotFoundError(_origin_scilista_file_path)
+
+        _proc_scilista_file_path = proc_sps_packages_dir / _scilista_filename
+        Logger.info(
+            'Copying original scilista "%s" to proc "%s"',
+            _origin_scilista_file_path,
+            _proc_scilista_file_path,
+        )
+        shutil.copy(_origin_scilista_file_path, _proc_scilista_file_path)
+    return str(_proc_scilista_file_path)
+
+
 def get_sps_packages(scilista_file_path, xc_dir_name, proc_dir_name):
     """
     Obtém Pacotes SPS através da Scilista, movendo os pacotes para o diretório de 

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -126,21 +126,20 @@ def optimize_sps_pkg_zip_file(sps_pkg_zip_file, new_sps_zip_dir):
     Recebe um zip `sps_pkg_zip_file` e
     Retorna seu zip otimizado `new_sps_pkg_zip_file`
     """
-    Logger.debug("optimize_sps_pkg_zip_file IN")
     basename = os.path.basename(sps_pkg_zip_file)
     new_sps_pkg_zip_file = os.path.join(new_sps_zip_dir, basename)
 
-    package = SPPackage.from_file(sps_pkg_zip_file, mkdtemp())
-    package.optimise(
-        new_package_file_path=new_sps_pkg_zip_file,
-        preserve_files=False
-    )
+    # Apaga arquivo se já existe antes de otimizar
+    if os.path.isfile(new_sps_pkg_zip_file):
+        os.unlink(new_sps_pkg_zip_file)
+
+    with ZipFile(sps_pkg_zip_file) as zip_file:
+        package = SPPackage(zip_file, new_sps_zip_dir)
+        package.optimise(new_package_file_path=new_sps_pkg_zip_file, preserve_files=False)
 
     if os.path.isfile(new_sps_pkg_zip_file):
         Logger.debug("optimize_sps_pkg_zip_file OUT")
         return new_sps_pkg_zip_file
-
-    Logger.debug("optimize_sps_pkg_zip_file OUT")
 
 
 def register_update_documents(sps_package, xmls_to_preserve):
@@ -210,6 +209,7 @@ def register_update_documents(sps_package, xmls_to_preserve):
     Logger.debug("register_update_documents OUT")
 
     return (synchronized_docs_metadata, executions)
+
 
 def link_documents_to_documentsbundle(sps_package, documents, issn_index_json_path):
     """

--- a/airflow/dags/operations/sync_documents_to_kernel_operations.py
+++ b/airflow/dags/operations/sync_documents_to_kernel_operations.py
@@ -408,3 +408,54 @@ def get_document_data(zip_file: ZipFile, xml_filename: str) -> Dict[str, Any]:
             document_data.update({"failed": True, "error": error})
 
     return document_data
+
+
+def extract_package_data(sps_package: str) -> Dict[str, dict]:
+    """
+    Lê todos os documentos XML do ``sps_package`` informado e extrai as informações 
+    contidas em cada um deles.
+
+    :param zip_file: Instância ZipFile de SPS Package
+
+    :return: Dict com os dados extraídos por arquivo XML presente no pacote SPS.
+    :return: List com os campos de identificação para cada versão do documento
+    Ex.:
+    {
+        "pidv3-0001.xml": {
+            "file_name": "pidv3-0001.xml",
+            "package_path": "acron-v1n1-1",
+            "bundle_id": "0001-0002-2020-v1-n1",
+            "deletion": "true",
+        },
+        "pidv3-0002.xml": {
+            "file_name": "pidv3-0002.xml",
+            "package_path": "acron-v1n1-2",
+            "bundle_id": "0001-0002-2020-v1-n1",
+            "deletion": "false",
+            "payload": {"field": "data"}
+        },
+        "pidv3-0002.xml": {
+            "file_name": "pidv3-000n.xml",
+            "package_path": "acron-v1n1-3",
+            "bundle_id": "0001-0002-2020-v1-n1",
+            "deletion": "false",
+            "payload": {"field": "data"}
+        },
+    }
+    """
+    documents_info = {}
+    with ZipFile(sps_package) as zip_file:
+        xmls_filenames = [
+            xml_filename
+            for xml_filename in zip_file.namelist()
+            if os.path.splitext(xml_filename)[-1] == ".xml"
+        ]
+        for i, xml_filename in enumerate(xmls_filenames, 1):
+            Logger.info(
+                'Reading document "%s" from "%s" [%d/%d]',
+                xml_filename, sps_package, i, len(xmls_filenames)
+            )
+            document_data = get_document_data(zip_file, xml_filename)
+            document_data.update({"package_path": sps_package})
+            documents_info[xml_filename] = document_data
+    return documents_info, ["file_name", "package_path"]

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -39,33 +39,6 @@ dag = DAG(
 )
 
 
-def get_scilista_file_path(
-    xc_sps_packages_dir: Path, proc_sps_packages_dir: Path, gerapadrao_id: str
-) -> str:
-    """Garante que a scilista usada será a do diretório de PROC. Quando for a primeira
-    execução da DAG, a lista será copiada para o diretório de PROC. Caso contrário, a 
-    mesma será mantida.
-    """
-    proc_dir_scilista_list = list(proc_sps_packages_dir.glob(f"scilista-*.lst"))
-    if proc_dir_scilista_list:
-        _proc_scilista_file_path = proc_dir_scilista_list[0]
-        Logger.info('Proc scilista "%s" already exists', _proc_scilista_file_path)
-    else:
-        _scilista_filename = f"scilista-{gerapadrao_id}.lst"
-        _origin_scilista_file_path = xc_sps_packages_dir / _scilista_filename
-        if not _origin_scilista_file_path.is_file():
-            raise FileNotFoundError(_origin_scilista_file_path)
-
-        _proc_scilista_file_path = proc_sps_packages_dir / _scilista_filename
-        Logger.info(
-            'Copying original scilista "%s" to proc "%s"',
-            _origin_scilista_file_path,
-            _proc_scilista_file_path,
-        )
-        shutil.copy(_origin_scilista_file_path, _proc_scilista_file_path)
-    return str(_proc_scilista_file_path)
-
-
 def get_sps_packages(conf, **kwargs):
     """Executa ``pre_sync_documents_to_kernel_operations.get_sps_packages`` com a 
     scilista referente à DagRun. Todos os pacotes obtidos serão armazenados em 
@@ -79,7 +52,7 @@ def get_sps_packages(conf, **kwargs):
     if not _proc_sps_packages_dir.is_dir():
         _proc_sps_packages_dir.mkdir()
 
-    _scilista_file_path = get_scilista_file_path(
+    _scilista_file_path = pre_sync_documents_to_kernel_operations.get_scilista_file_path(
         _xc_sps_packages_dir,
         _proc_sps_packages_dir,
         Variable.get("GERAPADRAO_ID_FOR_SCILISTA"),

--- a/airflow/dags/sync_docs_to_kernel.py
+++ b/airflow/dags/sync_docs_to_kernel.py
@@ -1,0 +1,60 @@
+"""
+DAG responsável por sincronizar informações dos documentos com o Kernel e Object Store
+"""
+import os
+import logging
+from datetime import datetime
+from tempfile import mkdtemp
+
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
+from airflow.models import Variable
+
+from operations import sync_documents_to_kernel_operations
+from common.hooks import get_documents_in_database, add_execution_in_database
+
+
+Logger = logging.getLogger(__name__)
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime(2019, 7, 21),
+}
+
+
+def apply_document_change(dag_run, run_id, **kwargs):
+    scielo_id = dag_run.conf.get("scielo_id")
+    pre_syn_dag_run_id = dag_run.conf.get("pre_syn_dag_run_id")
+
+    document_records = get_documents_in_database(
+        "e_documents",
+        {"pid": scielo_id, "pre_sync_dag_run": pre_syn_dag_run_id},
+        order_by=[("package_path", 1)],
+    )
+
+    document_data, executions = sync_documents_to_kernel_operations.sync_document(
+        document_records
+    )
+
+    for execution in executions:
+        execution["dag_run"] = run_id
+        execution["pre_sync_dag_run"] = dag_run.conf.get("pre_syn_dag_run_id")
+        add_execution_in_database(table="xml_documents", data=execution)
+
+    if document_data:
+        kwargs["ti"].xcom_push(key="document_data", value=document_data)
+        return True
+    else:
+        return False
+
+
+with DAG(
+    dag_id="sync_docs_to_kernel", default_args=default_args, schedule_interval=None
+) as dag:
+    apply_document_change_task = ShortCircuitOperator(
+        task_id="apply_document_change_task",
+        provide_context=True,
+        python_callable=apply_document_change,
+        dag=dag,
+    )

--- a/airflow/tests/test_collect_scilista_packages.py
+++ b/airflow/tests/test_collect_scilista_packages.py
@@ -1,0 +1,108 @@
+import tempfile
+import shutil
+import pathlib
+from unittest import TestCase, main
+from unittest.mock import patch, MagicMock, ANY
+
+from airflow import DAG
+
+from collect_scilista_packages import (
+    get_sps_packages,
+    start_sync_packages,
+)
+
+
+class TestGetSPSPackages(TestCase):
+    def setUp(self):
+        self.dir_source = tempfile.mkdtemp()
+        self.dir_dest = tempfile.mkdtemp()
+        self.id_proc_gerapadrao = "2020-01-01-16412600000000"
+        self._scilista_basename = f"scilista-{self.id_proc_gerapadrao}.lst"
+        self._scilista_path = pathlib.Path(self.dir_source) / self._scilista_basename
+        self._scilista_path.write_text("package 01")
+        self.mk_dag_run = MagicMock(conf={"GERAPADRAO_ID": self.id_proc_gerapadrao})
+        self.kwargs = {
+            "ti": MagicMock(),
+            "dag_run": self.mk_dag_run,
+            "run_id": "test_run_id",
+        }
+
+    def tearDown(self):
+        shutil.rmtree(self.dir_source)
+        shutil.rmtree(self.dir_dest)
+
+    @patch("collect_scilista_packages.Variable.get")
+    def test_get_sps_packages_raises_error_if_no_xc_dir_from_variable(
+        self, mk_variable_get
+    ):
+        mk_variable_get.side_effect = KeyError
+        self.assertRaises(KeyError, get_sps_packages, **self.kwargs)
+
+    @patch("collect_scilista_packages.pre_sync_documents_to_kernel_operations.get_sps_packages_on_scilista")
+    @patch("collect_scilista_packages.Variable.get")
+    def test_get_sps_packages_returns_true_to_execute_trigger_dags(
+        self, mk_variable_get, mk_get_sps_packages_on_scilista
+    ):
+        mk_variable_get.side_effect = [
+            self.dir_source,
+            self.dir_dest,
+            self.id_proc_gerapadrao,
+        ]
+        _sps_packages = ["package_01", "package_02", "package_03"]
+        mk_get_sps_packages_on_scilista.return_value = _sps_packages
+        _exec_start_sync_packages = get_sps_packages(**self.kwargs)
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key='sps_packages', value=_sps_packages
+        )
+        self.assertTrue(_exec_start_sync_packages)
+
+    @patch("collect_scilista_packages.pre_sync_documents_to_kernel_operations.get_sps_packages_on_scilista")
+    @patch("collect_scilista_packages.Variable.get")
+    def test_get_sps_packages_returns_false_to_execute_trigger_dags(
+        self, mk_variable_get, mk_get_sps_packages_on_scilista
+    ):
+        mk_variable_get.side_effect = [
+            self.dir_source,
+            self.dir_dest,
+            self.id_proc_gerapadrao,
+        ]
+        mk_get_sps_packages_on_scilista.return_value = []
+        _exec_start_sync_packages = get_sps_packages(**self.kwargs)
+        self.kwargs["ti"].xcom_push.assert_not_called()
+        self.assertFalse(_exec_start_sync_packages)
+
+
+class TestStartSyncPackages(TestCase):
+    @patch("collect_scilista_packages.Variable.get")
+    @patch("collect_scilista_packages.trigger_dag")
+    def test_start_sync_packages_calls_trigger_dag_for_each_package(
+        self, mk_trigger_dag, mk_variable_get
+    ):
+        mk_dag_run = MagicMock(conf={"GERAPADRAO_ID": "2020-01-01-16412600000000"})
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run, "run_id": "run_id-1234"}
+        mk_sps_packages = {
+            "abc_v50": ["dir/destination/abc_v50.zip"],
+            "rba_2018nahead": ["dir/destination/rba_2018nahead.zip"],
+            "rba_v53n1": ["dir/destination/rba_v53n1.zip"],
+            "rsp_v10n2-3": ["dir/destination/rsp_v10n2-3.zip"],
+        }
+        kwargs["ti"].xcom_pull.return_value = mk_sps_packages
+        start_sync_packages(**kwargs)
+        for bundle_label, sps_packages in mk_sps_packages.items():
+            with self.subTest(bundle_label=bundle_label, sps_packages=sps_packages):
+                mk_trigger_dag.assert_any_call(
+                    dag_id="extract_packages_info",
+                    run_id=ANY,
+                    execution_date=ANY,
+                    replace_microseconds=False,
+                    conf={
+                        "bundle_label": bundle_label,
+                        "sps_packages": sps_packages,
+                        "pre_syn_dag_run_id": "run_id-1234",
+                        "gerapadrao_id": "2020-01-01-16412600000000",
+                    },
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/airflow/tests/test_extract_packages_info.py
+++ b/airflow/tests/test_extract_packages_info.py
@@ -1,0 +1,265 @@
+import tempfile
+import shutil
+import pathlib
+from datetime import datetime
+from unittest import TestCase, main
+from unittest.mock import patch, MagicMock, ANY, call
+
+from airflow import DAG
+from airflow.models import Variable
+
+from extract_packages_info import (
+    optimize_packages,
+    extract_packages_data,
+    start_sync_documents,
+)
+
+
+@patch(
+    "extract_packages_info.sync_documents_to_kernel_operations.optimize_sps_pkg_zip_file"
+)
+@patch("extract_packages_info.Variable")
+class TestOptimizePackages(TestCase):
+    def setUp(self):
+        self.id_proc_gerapadrao = "2020-01-01-16412600000000"
+        self.sps_pkg_zip_dir = tempfile.mkdtemp()
+        self.optimize_path = pathlib.Path(self.sps_pkg_zip_dir) / self.id_proc_gerapadrao
+        self.optimize_path.mkdir()
+        self.mk_dag_run = MagicMock(
+            conf={
+                "bundle_label": "acron_v1n1",
+                "gerapadrao_id": self.id_proc_gerapadrao,
+            }
+        )
+        self.kwargs = {
+            "ti": MagicMock(),
+            "dag_run": self.mk_dag_run,
+            "run_id": "test_run_id",
+        }
+
+    def tearDown(self):
+        shutil.rmtree(self.sps_pkg_zip_dir)
+
+    def test_returns_false_if_no_sps_packages(
+        self, mk_variable, mk_optimize_sps_pkg_zip_file
+    ):
+        mk_variable.get.return_value = self.sps_pkg_zip_dir
+        self.kwargs["dag_run"].conf["sps_packages"] = []
+        ret = optimize_packages(**self.kwargs)
+        self.assertFalse(ret)
+        self.kwargs["ti"].xcom_push.assert_not_called()
+
+    def test_returns_true_and_pushes_optimized_list(
+        self, mk_variable, mk_optimize_sps_pkg_zip_file
+    ):
+        mk_variable.get.return_value = self.sps_pkg_zip_dir
+        mk_optimize_sps_pkg_zip_file.side_effect = [
+            "optimized_package1.zip",
+            None,
+            "optimized_package3.zip",
+            None,
+            "optimized_package5.zip",
+        ]
+        self.kwargs["dag_run"].conf["sps_packages"] = [
+            "package1.zip",
+            "package2.zip",
+            "package3.zip",
+            "package4.zip",
+            "package5.zip",
+        ]
+        ret = optimize_packages(**self.kwargs)
+        self.assertTrue(ret)
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key="optimized_packages",
+            value=[
+                "optimized_package1.zip",
+                "package2.zip",
+                "optimized_package3.zip",
+                "package4.zip",
+                "optimized_package5.zip",
+            ]
+        )
+
+
+@patch("extract_packages_info.save_document_in_database")
+@patch("extract_packages_info.sync_documents_to_kernel_operations.extract_package_data")
+class TestExtractPackagesData(TestCase):
+    def setUp(self):
+        self.id_proc_gerapadrao = "2020-01-01-16412600000000"
+        self.kwargs = {
+            "ti": MagicMock(),
+            "dag_run": MagicMock(
+                conf={
+                    "bundle_label": "acron_v1n1",
+                    "gerapadrao_id": self.id_proc_gerapadrao,
+                }
+            ),
+            "run_id": "test_run_id",
+            "execution_date": datetime.utcnow().astimezone().isoformat()
+        }
+        self.kwargs["ti"].xcom_pull.return_value = [
+            "optimized_package1.zip",
+            "package2.zip",
+            "optimized_package3.zip",
+        ]
+        self.extracted_data = [
+            (
+                {
+                    "doc-xml-1.xml": {
+                        "pid": "pid-v3-1",
+                        "deletion": False,
+                        "file_name": "doc-xml-1.xml",
+                        "package_path": "optimized_package1.zip",
+                    }
+                },
+                ["file_name", "package_path"],
+            ),
+            (
+                {
+                    "doc-xml-1.xml": {
+                        "pid": "pid-v3-1",
+                        "deletion": True,
+                        "file_name": "doc-xml-1.xml",
+                        "package_path": "package2.zip",
+                    },
+                    "doc-xml-2.xml": {
+                        "pid": "pid-v3-2",
+                        "deletion": False,
+                        "file_name": "doc-xml-2.xml",
+                        "package_path": "package2.zip",
+                    },
+                },
+                ["file_name", "package_path"],
+            ),
+            (
+                {
+                    "doc-xml-1.xml": {
+                        "pid": "pid-v3-1",
+                        "deletion": False,
+                        "file_name": "doc-xml-1.xml",
+                        "package_path": "optimized_package3.zip",
+                    },
+                    "doc-xml-2.xml": {
+                        "pid": "pid-v3-2",
+                        "deletion": False,
+                        "file_name": "doc-xml-2.xml",
+                        "package_path": "optimized_package3.zip",
+                    },
+                    "doc-xml-3.xml": {
+                        "pid": "pid-v3-3",
+                        "deletion": False,
+                        "file_name": "doc-xml-3.xml",
+                        "package_path": "optimized_package3.zip",
+                    },
+                },
+                ["file_name", "package_path"],
+            ),
+        ]
+
+
+    def test_returns_false_if_no_documents_info(
+        self, mk_extract_package_data, mk_save_document_in_database
+    ):
+        mk_extract_package_data.return_value = ({}, [])
+
+        ret = extract_packages_data(**self.kwargs)
+
+        self.assertFalse(ret)
+        mk_save_document_in_database.assert_not_called()
+        self.kwargs["ti"].xcom_push.assert_not_called()
+
+    def test_calls_save_document_in_database_for_each_doc_in_each_package(
+        self, mk_extract_package_data, mk_save_document_in_database
+    ):
+        mk_extract_package_data.side_effect = self.extracted_data
+        ret = extract_packages_data(**self.kwargs)
+
+        self.assertTrue(ret)
+        data_to_complete = {
+            "bundle_label": self.kwargs["dag_run"].conf["bundle_label"],
+            "gerapadrao_id": self.id_proc_gerapadrao,
+            "pre_sync_dag_run": self.kwargs["run_id"],
+            "execution_date": self.kwargs["execution_date"],
+        }
+        filter = {"file_name": "doc-xml-1.xml", "package_path": "package1.zip"}
+        filter.update(data_to_complete)
+
+        for documents_info, fields_filter in self.extracted_data:
+            for document_record in documents_info.values():
+                filter = {
+                    field: value
+                    for field, value in document_record.items()
+                    if field in fields_filter
+                }
+                filter.update(data_to_complete)
+                document_record.update(data_to_complete)
+                with self.subTest(document_record=document_record):
+                    mk_save_document_in_database.assert_any_call(
+                        "e_documents", filter, document_record
+                    )
+
+    def test_returns_true_and_pushes_scielo_ids_list(
+        self, mk_extract_package_data, mk_save_document_in_database
+    ):
+        mk_extract_package_data.side_effect = self.extracted_data
+
+        ret = extract_packages_data(**self.kwargs)
+
+        self.assertTrue(ret)
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key="scielo_ids",
+            value=set(["pid-v3-1", "pid-v3-2", "pid-v3-3"]),
+        )
+
+
+@patch("extract_packages_info.trigger_dag")
+class TestStartSyncDocuments(TestCase):
+    def test_start_sync_packages_calls_trigger_dag_for_each_package(
+        self, mk_trigger_dag
+    ):
+        mk_dag_run = MagicMock(conf={"bundle_label": "acron_v1n1", "gerapadrao_id": "2020-01-01-162512123"},)
+        kwargs = {"ti": MagicMock(), "dag_run": mk_dag_run, "run_id": "run_id-1234"}
+        mk_scielo_pids = {"pid-v3-1", "pid-v3-2", "pid-v3-3"}
+        kwargs["ti"].xcom_pull.return_value = mk_scielo_pids
+
+        start_sync_documents(**kwargs)
+
+        mk_trigger_dag.assert_has_calls(
+            [
+                call(
+                    dag_id="sync_docs_to_kernel",
+                    run_id=f"trig__2020-01-01-162512123_pid-v3-1",
+                    execution_date=ANY,
+                    replace_microseconds=False,
+                    conf={
+                        "scielo_id": "pid-v3-1",
+                        "pre_syn_dag_run_id": "run_id-1234",
+                    },
+                ),
+                call(
+                    dag_id="sync_docs_to_kernel",
+                    run_id=f"trig__2020-01-01-162512123_pid-v3-2",
+                    execution_date=ANY,
+                    replace_microseconds=False,
+                    conf={
+                        "scielo_id": "pid-v3-2",
+                        "pre_syn_dag_run_id": "run_id-1234",
+                    },
+                ),
+                call(
+                    dag_id="sync_docs_to_kernel",
+                    run_id=f"trig__2020-01-01-162512123_pid-v3-3",
+                    execution_date=ANY,
+                    replace_microseconds=False,
+                    conf={
+                        "scielo_id": "pid-v3-3",
+                        "pre_syn_dag_run_id": "run_id-1234",
+                    },
+                ),
+            ],
+            any_order=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/airflow/tests/test_pre_sync_documents_to_kernel.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel.py
@@ -4,63 +4,12 @@ import pathlib
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock, ANY
 
-import pendulum
 from airflow import DAG
 
 from pre_sync_documents_to_kernel import (
-    get_scilista_file_path,
     get_sps_packages,
     start_sync_packages,
 )
-
-
-class TestGetScilistaFilePath(TestCase):
-    def setUp(self):
-        self.gate_dir = tempfile.mkdtemp()
-        self.proc_dir = tempfile.mkdtemp()
-
-    def tearDown(self):
-        shutil.rmtree(self.gate_dir)
-        shutil.rmtree(self.proc_dir)
-
-    def test_scilista_does_not_exist_in_origin(self):
-        with self.assertRaises(FileNotFoundError) as exc_info:
-            get_scilista_file_path(
-                pathlib.Path("no/dir/path"),
-                pathlib.Path(self.proc_dir),
-                "2020-12-31-08172297086458",
-            )
-        self.assertIn(str(exc_info.exception), "no/dir/path/scilista-2020-12-31-08172297086458.lst")
-
-    def test_scilista_already_exists_in_proc(self):
-        scilista_path_origin = pathlib.Path(self.gate_dir) / "scilista-2020-01-01-12204897086458.lst"
-        scilista_path_origin.write_text("acron v1n22")
-        scilista_path_proc = pathlib.Path(self.proc_dir) / "scilista-2020-01-01-10204897086458.lst"
-        scilista_path_proc.write_text("acron v1n20")
-        _scilista_file_path = get_scilista_file_path(
-            pathlib.Path(self.gate_dir),
-            pathlib.Path(self.proc_dir),
-            "2020-01-01-10204897086458",
-        )
-
-        self.assertEqual(
-            _scilista_file_path,
-            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01-10204897086458.lst")
-        )
-        self.assertEqual(scilista_path_proc.read_text(), "acron v1n20")
-
-    def test_scilista_must_be_copied(self):
-        scilista_path = pathlib.Path(self.gate_dir) / "scilista-2020-01-01-19032697086458.lst"
-        scilista_path.write_text("acron v1n20")
-        _scilista_file_path = get_scilista_file_path(
-            pathlib.Path(self.gate_dir),
-            pathlib.Path(self.proc_dir),
-            "2020-01-01-19032697086458",
-        )
-        self.assertEqual(
-            _scilista_file_path,
-            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01-19032697086458.lst")
-        )
 
 
 class TestGetSPSPackages(TestCase):

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -86,99 +86,78 @@ class TestGetSPSPackages(TestCase):
         mk_open.side_effect = FileNotFoundError
         self.assertRaises(FileNotFoundError, get_sps_packages, *self.kwargs)
 
-    def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(self):
-        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
-        source_filenames = []
+    def _create_fake_sps_packages(self, scilista_lines):
+        """
+        Cria 3 pacotes fake para entrada para cada linha da scilista fake.
+        Também cria a lista esperada ao final do teste, que conterá o caminho completo
+        """
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        fake_sps_packages = []
+        proc_dir_path = pathlib.Path(self.proc_dir_name)
         with scilista_file_path.open("w") as scilista_file:
             for line in scilista_lines:
                 scilista_file.write(line + "\n")
-                source_filenames += [
-                    "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
-                    for i in range(1, 4)
-                ]
-        for filename in source_filenames:
-            zip_filename = pathlib.Path(self.xc_dir_name) / filename
-            with zipfile.ZipFile(zip_filename, "w") as zip_file:
-                zip_file.write(self.test_filepath)
+                bundle_label = "_".join(line.split())
+                if not line.endswith("del"):
+                    for i in range(1, 4):
+                        filename = "_".join(
+                            [f"2020-01-01-00-0{i}-09-090901"] + line.split()
+                        ) + ".zip"
+                        zip_filename = pathlib.Path(self.xc_dir_name) / filename
+                        with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                            zip_file.write(self.test_filepath)
+                        fake_sps_packages.append(
+                            str(proc_dir_path.joinpath(filename))
+                        )
+        return fake_sps_packages
+
+    def test_get_sps_packages_moves_from_xc_dir_to_proc_dir(self):
+        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
 
         sps_packages = get_sps_packages(**self.kwargs)
-        for filename in source_filenames:
+
+        self.assertEqual(sps_packages, fake_sps_packages)
+        for filename in fake_sps_packages:
             with self.subTest(filename=filename):
                 self.assertTrue(
                     pathlib.Path(self.kwargs["proc_dir_name"])
                     .joinpath(filename)
                     .exists()
                 )
-        self.assertEqual(
-            sps_packages,
-            [
-                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
-                for filename in source_filenames
-            ],
-        )
 
     def test_get_sps_packages_creates_sps_packages_list_file(self):
         scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
-        source_filenames = []
-        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
-        with scilista_file_path.open("w") as scilista_file:
-            for line in scilista_lines:
-                scilista_file.write(line + "\n")
-                source_filenames += [
-                    "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
-                    for i in range(1, 4)
-                ]
-        for filename in source_filenames:
-            zip_filename = pathlib.Path(self.xc_dir_name) / filename
-            with zipfile.ZipFile(zip_filename, "w") as zip_file:
-                zip_file.write(self.test_filepath)
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
 
         sps_packages = get_sps_packages(**self.kwargs)
+
         package_paths_list = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
         self.assertTrue(package_paths_list.is_file())
         sps_packages_list = package_paths_list.read_text().split("\n")
-        self.assertEqual(
-            sps_packages_list,
-            [
-                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
-                for filename in source_filenames
-            ],
-        )
-
+        self.assertEqual(sps_packages_list, fake_sps_packages)
 
     def test_get_sps_packages_ignores_del_command_in_scilista(self):
-        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1 del", "rsp v10n4s1", "csp v35nspe del"]
-        source_filenames = []
-        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
-        with scilista_file_path.open("w") as scilista_file:
-            for line in scilista_lines:
-                scilista_file.write(line + "\n")
-                if not line.endswith("del"):
-                    source_filenames += [
-                        "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
-                        for i in range(1, 4)
-                    ]
-        for filename in source_filenames:
-            zip_filename = pathlib.Path(self.xc_dir_name) / filename
-            with zipfile.ZipFile(zip_filename, "w") as zip_file:
-                zip_file.write(self.test_filepath)
+        scilista_lines = [
+            "rba v53n1",
+            "rba 2019nahead",
+            "rsp v10n4s1 del",
+            "rsp v10n4s1",
+            "csp v35nspe del",
+        ]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
 
         sps_packages = get_sps_packages(**self.kwargs)
-        self.assertEqual(
-            sps_packages,
-            [
-                str(pathlib.Path(self.proc_dir_name).joinpath(filename))
-                for filename in source_filenames
-            ],
-        )
+        self.assertEqual(sps_packages, fake_sps_packages)
 
     def test_get_sps_packages_moves_nothing_if_no_source_file(self):
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
         package = "rba v53n2"
         scilista_file_path.write_text(package)
         source_filenames = [
-            "2020-05-22-10-00-34-480190_rba_v53n1", "2020-05-22-10-00-34-480190_rba_2019nahead", "2020-05-22-10-00-34-480190_rsp_v10n4s1"
+            "2020-05-22-10-00-34-480190_rba_v53n1",
+            "2020-05-22-10-00-34-480190_rba_2019nahead",
+            "2020-05-22-10-00-34-480190_rsp_v10n4s1",
         ]
         for filename in source_filenames:
             zip_filename = pathlib.Path(self.xc_dir_name) / filename
@@ -196,18 +175,19 @@ class TestGetSPSPackages(TestCase):
         scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
         package = "ag 2019nahead"
         scilista_file_path.write_text(package)
+        ag_package_filename = "2020-05-22-10-00-34-480190_ag_2019nahead.zip"
         source_filenames = ("2020-05-22-10-00-34-480190_brag_2019nahead.zip\n"
-                            "2020-05-22-10-00-34-480190_ag_2019nahead.zip").splitlines()
+                            + ag_package_filename).splitlines()
         for filename in source_filenames:
             zip_filename = pathlib.Path(self.xc_dir_name) / filename
             with zipfile.ZipFile(zip_filename, "w") as zip_file:
                 zip_file.write(self.test_filepath)
 
         result = get_sps_packages(**self.kwargs)
+
         self.assertEqual(
-            [str(pathlib.Path(
-                self.kwargs["proc_dir_name"]) / "2020-05-22-10-00-34-480190_ag_2019nahead.zip")],
-            result
+            result,
+            [str(pathlib.Path(self.kwargs["proc_dir_name"]) / ag_package_filename)]
         )
 
     def test_get_sps_packages_must_return_packages_list_if_sps_packages_lst_exists(self):

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -10,7 +10,8 @@ from airflow import DAG
 
 from operations.pre_sync_documents_to_kernel_operations import (
     get_scilista_file_path,
-    get_sps_packages
+    get_sps_packages,
+    get_sps_packages_on_scilista,
 )
 
 
@@ -217,6 +218,154 @@ class TestGetSPSPackages(TestCase):
         package_paths_list_file = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
         package_paths_list_file.write_text("\n".join(package_paths_list))
         result = get_sps_packages(**self.kwargs)
+        self.assertEqual(result, package_paths_list)
+
+
+class TestGetSPSPackagesOnScilista(TestCase):
+    def setUp(self):
+        self.xc_dir_name = tempfile.mkdtemp()
+        self.proc_dir_name = tempfile.mkdtemp()
+        self.kwargs = {
+            "scilista_file_path": str(pathlib.Path(self.xc_dir_name) / "scilista.lst"),
+            "xc_dir_name": self.xc_dir_name,
+            "proc_dir_name": self.proc_dir_name,
+        }
+        self.test_filepath = pathlib.Path(self.xc_dir_name) / "test.txt"
+        with self.test_filepath.open("w") as test_file:
+            test_file.write("Text test file")
+
+    def tearDown(self):
+        shutil.rmtree(self.xc_dir_name)
+        shutil.rmtree(self.proc_dir_name)
+
+    @patch("operations.pre_sync_documents_to_kernel_operations.open")
+    def test_raises_error_if_scilista_open_error(self, mk_open):
+        mk_open.side_effect = FileNotFoundError
+        self.assertRaises(FileNotFoundError, get_sps_packages_on_scilista, *self.kwargs)
+
+    def _create_fake_sps_packages(self, scilista_lines):
+        """
+        Cria 3 pacotes fake para entrada para cada linha da scilista fake.
+        Também cria a lista esperada ao final do teste, que conterá o caminho completo
+        """
+        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        fake_sps_packages = {}
+        proc_dir_path = pathlib.Path(self.proc_dir_name)
+        with scilista_file_path.open("w") as scilista_file:
+            for line in scilista_lines:
+                scilista_file.write(line + "\n")
+                bundle_label = "_".join(line.split())
+                source_filenames = []
+                if not line.endswith("del"):
+                    for i in range(1, 4):
+                        filename = "_".join(
+                            [f"2020-01-01-00-0{i}-09-090901"] + line.split()
+                        ) + ".zip"
+                        source_filenames.append(filename)
+                        zip_filename = pathlib.Path(self.xc_dir_name) / filename
+                        with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                            zip_file.write(self.test_filepath)
+                    fake_sps_packages[bundle_label] = [
+                        str(proc_dir_path.joinpath(filename))
+                        for filename in source_filenames
+                    ]
+        return fake_sps_packages
+
+    def test_moves_from_xc_dir_to_proc_dir(self):
+        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
+
+        sps_packages = get_sps_packages_on_scilista(**self.kwargs)
+
+        self.assertEqual(sps_packages, fake_sps_packages)
+        for fake_filenames in fake_sps_packages.values():
+            for filename in fake_filenames:
+                with self.subTest(filename=filename):
+                    self.assertTrue(
+                        pathlib.Path(self.kwargs["proc_dir_name"])
+                        .joinpath(filename)
+                        .exists()
+                    )
+
+    def test_creates_sps_packages_list_file(self):
+        scilista_lines = ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
+
+        sps_packages = get_sps_packages_on_scilista(**self.kwargs)
+
+        package_paths_list = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
+        self.assertTrue(package_paths_list.is_file())
+        with package_paths_list.open() as sps_list_file:
+            sps_packages_list = json.load(sps_list_file)
+        self.assertEqual(sps_packages_list, fake_sps_packages)
+
+
+    def test_ignores_del_command_in_scilista(self):
+        scilista_lines = [
+            "rba v53n1",
+            "rba 2019nahead",
+            "rsp v10n4s1 del",
+            "rsp v10n4s1",
+            "csp v35nspe del",
+        ]
+        fake_sps_packages = self._create_fake_sps_packages(scilista_lines)
+
+        sps_packages = get_sps_packages_on_scilista(**self.kwargs)
+        self.assertEqual(sps_packages, fake_sps_packages)
+
+    def test_moves_nothing_if_no_source_file(self):
+        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        package = "rba v53n2"
+        scilista_file_path.write_text(package)
+        source_filenames = [
+            "2020-05-22-10-00-34-480190_rba_v53n1",
+            "2020-05-22-10-00-34-480190_rba_2019nahead",
+            "2020-05-22-10-00-34-480190_rsp_v10n4s1",
+        ]
+        for filename in source_filenames:
+            zip_filename = pathlib.Path(self.xc_dir_name) / filename
+            with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                zip_file.write(self.test_filepath)
+
+        get_sps_packages_on_scilista(**self.kwargs)
+        self.assertFalse(
+            pathlib.Path(self.kwargs["proc_dir_name"])
+            .joinpath("_".join(package.split()) + ".zip")
+            .exists()
+        )
+
+    def test_must_not_move_brag_if_there_is_ag_in_scilista(self):
+        scilista_file_path = pathlib.Path(self.kwargs["scilista_file_path"])
+        package = "ag 2019nahead"
+        scilista_file_path.write_text(package)
+        ag_package_filename = "2020-05-22-10-00-34-480190_ag_2019nahead.zip"
+        source_filenames = ("2020-05-22-10-00-34-480190_brag_2019nahead.zip\n"
+                            + ag_package_filename).splitlines()
+        for filename in source_filenames:
+            zip_filename = pathlib.Path(self.xc_dir_name) / filename
+            with zipfile.ZipFile(zip_filename, "w") as zip_file:
+                zip_file.write(self.test_filepath)
+
+        result = get_sps_packages_on_scilista(**self.kwargs)
+
+        expected = {
+            "_".join(package.split()): [
+                str(
+                    pathlib.Path(self.kwargs["proc_dir_name"]) / ag_package_filename
+                )
+            ]
+        }
+        self.assertEqual(result, expected)
+
+    def test_must_return_packages_list_if_sps_packages_lst_exists(self):
+        package_paths_list = [
+            str(pathlib.Path(self.proc_dir_name) / f"package_0{seq}.zip")
+            for seq in range(1, 4)
+        ]
+        package_paths_list_file = pathlib.Path(self.proc_dir_name) / "sps_packages.lst"
+        with package_paths_list_file.open("w") as sps_list_file:
+            json.dump(package_paths_list, sps_list_file)
+        result = get_sps_packages_on_scilista(**self.kwargs)
         self.assertEqual(result, package_paths_list)
 
 

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -2,12 +2,65 @@ import tempfile
 import shutil
 import pathlib
 import zipfile
+import json
 from unittest import TestCase, main
 from unittest.mock import patch, MagicMock
 
 from airflow import DAG
 
-from operations.pre_sync_documents_to_kernel_operations import get_sps_packages
+from operations.pre_sync_documents_to_kernel_operations import (
+    get_scilista_file_path,
+    get_sps_packages
+)
+
+
+class TestGetScilistaFilePath(TestCase):
+    def setUp(self):
+        self.gate_dir = tempfile.mkdtemp()
+        self.proc_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.gate_dir)
+        shutil.rmtree(self.proc_dir)
+
+    def test_scilista_does_not_exist_in_origin(self):
+        with self.assertRaises(FileNotFoundError) as exc_info:
+            get_scilista_file_path(
+                pathlib.Path("no/dir/path"),
+                pathlib.Path(self.proc_dir),
+                "2020-12-31-08172297086458",
+            )
+        self.assertIn(str(exc_info.exception), "no/dir/path/scilista-2020-12-31-08172297086458.lst")
+
+    def test_scilista_already_exists_in_proc(self):
+        scilista_path_origin = pathlib.Path(self.gate_dir) / "scilista-2020-01-01-12204897086458.lst"
+        scilista_path_origin.write_text("acron v1n22")
+        scilista_path_proc = pathlib.Path(self.proc_dir) / "scilista-2020-01-01-10204897086458.lst"
+        scilista_path_proc.write_text("acron v1n20")
+        _scilista_file_path = get_scilista_file_path(
+            pathlib.Path(self.gate_dir),
+            pathlib.Path(self.proc_dir),
+            "2020-01-01-10204897086458",
+        )
+
+        self.assertEqual(
+            _scilista_file_path,
+            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01-10204897086458.lst")
+        )
+        self.assertEqual(scilista_path_proc.read_text(), "acron v1n20")
+
+    def test_scilista_must_be_copied(self):
+        scilista_path = pathlib.Path(self.gate_dir) / "scilista-2020-01-01-19032697086458.lst"
+        scilista_path.write_text("acron v1n20")
+        _scilista_file_path = get_scilista_file_path(
+            pathlib.Path(self.gate_dir),
+            pathlib.Path(self.proc_dir),
+            "2020-01-01-19032697086458",
+        )
+        self.assertEqual(
+            _scilista_file_path,
+            str(pathlib.Path(self.proc_dir) / "scilista-2020-01-01-19032697086458.lst")
+        )
 
 
 class TestGetSPSPackages(TestCase):

--- a/airflow/tests/test_sync_docs_to_kernel.py
+++ b/airflow/tests/test_sync_docs_to_kernel.py
@@ -6,6 +6,7 @@ from airflow import DAG
 
 from sync_docs_to_kernel import (
     apply_document_change,
+    update_document_in_bundle,
 )
 
 
@@ -103,3 +104,76 @@ class TestApplyDocumentChange(TestCase):
             key="document_data", value=document_data
         )
 
+
+@patch(
+    "sync_docs_to_kernel.sync_documents_to_kernel_operations.update_document_in_bundle"
+)
+@patch("sync_docs_to_kernel.add_execution_in_database")
+class TestUpdateDocumentInBundle(TestCase):
+    def setUp(self):
+        self.kwargs = {"ti": MagicMock(), "dag_run": MagicMock(), "run_id": "test_run_id"}
+        self.kwargs["dag_run"].conf = {"pre_syn_dag_run_id": "test_pre_run_id"}
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            {"scielo_id": "pid-v3-1", "deletion": False},
+            "/json/title.json",
+        ]
+
+    def test_calls_update_document_in_bundle(
+        self, mk_add_execution_in_database, mk_update_document_in_bundle
+    ):
+        mk_update_document_in_bundle.return_value = {}, []
+        update_document_in_bundle(**self.kwargs)
+
+        mk_update_document_in_bundle.assert_called_once_with(
+            {"scielo_id": "pid-v3-1", "deletion": False},
+            "/json/title.json",
+        )
+
+    def test_adds_execution_in_database(
+        self, mk_add_execution_in_database, mk_update_document_in_bundle
+    ):
+        executions = [
+            {
+                "package_name": "package-1.zip",
+                "pid": "pid-v3-1",
+                "bundle_id": "0101-0101-2020-v1-n1",
+            },
+            {
+                "pid": "pid-v3-1",
+                "bundle_id": "0101-0101-2020-v1-n1",
+                "ex_ahead": True,
+                "removed": True,
+            },
+        ]
+        mk_update_document_in_bundle.return_value = {}, executions
+        updated_executions = deepcopy(executions)
+        for execution in updated_executions:
+            execution.update({
+                "dag_run": self.kwargs["run_id"],
+                "pre_sync_dag_run": self.kwargs["dag_run"].conf["pre_syn_dag_run_id"],
+            })
+
+        update_document_in_bundle(**self.kwargs)
+
+        mk_add_execution_in_database.assert_has_calls([
+            call(table="xml_documentsbundle", data=execution)
+            for execution in updated_executions
+        ])
+
+    def test_pushes_document_data(
+        self, mk_add_execution_in_database, mk_update_document_in_bundle
+    ):
+        result = {
+            "scielo_id": "pid-v3-1",
+            "deletion": False,
+        }
+        mk_update_document_in_bundle.return_value = result, []
+        update_document_in_bundle(**self.kwargs)
+
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key="result", value=result
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/airflow/tests/test_sync_docs_to_kernel.py
+++ b/airflow/tests/test_sync_docs_to_kernel.py
@@ -1,0 +1,105 @@
+from unittest import TestCase, main
+from unittest.mock import patch, MagicMock, call
+from copy import deepcopy
+
+from airflow import DAG
+
+from sync_docs_to_kernel import (
+    apply_document_change,
+)
+
+
+@patch("sync_docs_to_kernel.sync_documents_to_kernel_operations.sync_document")
+@patch("sync_docs_to_kernel.add_execution_in_database")
+@patch("sync_docs_to_kernel.get_documents_in_database")
+class TestApplyDocumentChange(TestCase):
+    def setUp(self):
+        self.kwargs = {"ti": MagicMock(), "dag_run": MagicMock(), "run_id": "test_run_id"}
+        self.kwargs["dag_run"].conf = {
+            "scielo_id": "pid-v3-1",
+            "pre_syn_dag_run_id": "test_pre_run_id",
+        }
+
+    def test_calls_sync_document_operation(
+        self,
+        mk_get_documents_in_database,
+        mk_add_execution_in_database,
+        mk_sync_document,
+    ):
+        mk_sync_document.return_value = ({}, [])
+
+        apply_document_change(**self.kwargs)
+
+        mk_sync_document.assert_called_once_with(
+            mk_get_documents_in_database.return_value
+        )
+
+    def test_adds_execution_in_database(
+        self,
+        mk_get_documents_in_database,
+        mk_add_execution_in_database,
+        mk_sync_document,
+    ):
+        executions = [
+            {
+                "package_name": "package-1.zip",
+                "file_name": "document.xml",
+                "failed": False,
+                "deletion": True,
+                "pid": "pid-v3-1",
+                "payload": {"scielo_id": "pid-v3-1"},
+            },
+            {
+                "package_name": "package-1.zip",
+                "file_name": "document.xml",
+                "failed": True,
+                "error": "Connection error",
+                "deletion": False,
+                "pid": "pid-v3-1",
+            },
+        ]
+        mk_sync_document.return_value = {}, executions
+        updated_executions = deepcopy(executions)
+        for execution in updated_executions:
+            execution.update({
+                "dag_run": self.kwargs["run_id"],
+                "pre_sync_dag_run": self.kwargs["dag_run"].conf["pre_syn_dag_run_id"],
+            })
+
+        apply_document_change(**self.kwargs)
+
+        mk_add_execution_in_database.assert_has_calls([
+            call(table="xml_documents", data=execution)
+            for execution in updated_executions
+        ])
+
+    def test_does_not_push_if_no_documents_into_kernel(
+        self,
+        mk_get_documents_in_database,
+        mk_add_execution_in_database,
+        mk_sync_document,
+    ):
+        mk_sync_document.return_value = {}, []
+        ret = apply_document_change(**self.kwargs)
+
+        self.assertFalse(ret)
+        self.kwargs["ti"].xcom_push.assert_not_called()
+
+    def test_pushes_document_data(
+        self,
+        mk_get_documents_in_database,
+        mk_add_execution_in_database,
+        mk_sync_document,
+    ):
+        document_data = {
+            "scielo_id": "pid-v3-1",
+            "deletion": False,
+        }
+        mk_sync_document.return_value = document_data, []
+        ret = apply_document_change(**self.kwargs)
+
+        self.assertTrue(ret)
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key="document_data", value=document_data
+        )
+


### PR DESCRIPTION
#### O que esse PR faz?
Este PR implementa a terceira proposta para o issue #188, conforme descrita em https://github.com/scieloorg/opac-airflow/issues/188#issuecomment-715349405.

Além da implementação da proposta, também foi possível resolver o issue #213 por conta da melhoria realizada na otimização de pacotes.

Adicionalmente à proposta, também foi possível implementar a reexecução das DAGs disparadas caso execute-se `clear` em qualquer ponto do fluxo.

#### Onde a revisão poderia começar?
Pelo commit 50c348d

#### Como este poderia ser testado manualmente?
É recomendado que pacotes SPS já sincronizados sejam usados para o teste.

##### Preparação do Ambiente
- Copie as bases `title` e `issue` atualizadas (do homolog-metodologia ou do próprio OPAC-Airflow) para o ambiente de teste (diretórios configurados em `BASE_TITLE_FOLDER_PATH` e `BASE_ISSUE_FOLDER_PATH` respectivamente)
- Copie para o diretório configurado em `XC_SPS_PACKAGES_DIR`:
  - Pacotes para um mesmo bundle/fascículo. Ex: `2020-10-28-17-05-51-734348_tce_v29nspe.zip`, `2020-10-29-15-34-10-222753_tce_v29nspe.zip` e `2020-10-29-15-53-06-759365_tce_v29nspe.zip`
  - Pacotes com documentos para deleção. Ex: `2020-10-28-19-24-16-664730_rsp_v54.zip`, `2020-10-29-13-06-46-489080_rsp_v54.zip` e `2020-10-29-14-04-45-444453_rsp_v54.zip`
  - Pacotes com falhas, com deleção de documento que não existe e/ou falta de PID v3. Ex: `2020-09-22-13-15-41-346968_ar_v17n3.zip`
- Crie uma scilista com os acrônimos e fascículos para que os pacotes sejam sincronizados. Dê o nome de `scilista-teste-123456` e coloque-a no diretório configurado em XC_SPS_PACKAGES_DIR
- Configure as seguinte variáveis de ambiente (ao usar o docker-compose, adicione ao YAML):
  - `AIRFLOW__CORE__EXECUTOR=LocalExecutor`
  - `AIRFLOW__CORE__PARALLELISM=4`
  - `AIRFLOW__WEBSERVER__WORKERS=1`
- Acesse na interface WEB do opac-airflow o menu `Admin > Connection` e altere/crie conexão identificada com `Conn Id` = `mongo_default`. Informe a seguinte configuração:
  - `Conn Type` = `MongoDB`
  - `Host` = IP real da máquina com instância de MongoDB para o teste
  - `Schema` = airflow-data
  - `Port` = Porta do host para a instância do MongoDB
  - Demais configurações necessárias para a comunicação com o MongoDB usado para o teste

##### Execução das DAGs
- Execute a DAG `sync_isis_to_kernel` para espelhar as bases ISIS `title` e `issue` e ter o arquivo JSON atualizado
- Ao final da DAG acima, execute a DAG `collect_scilista_packages`, passando como `dag_run.conf` o JSON `{"GERAPADRAO_ID": "teste-123456"}`

##### Verificação dos resultados
- Verifique os resultados em relatório do Grafana, apontando para a base Postgres do ambiente de teste. 
- Verifique com os resultados:
  - Se todas as versões de um documento foram registradas no Kernel e na ordem.
  - Se os documentos para deleção foram deletados
  - Se os bundles foram atualizados
  - Se os ativos digitais e os PDFs foram registrados no MinIO
- Verifique se a a collection `e_documents` foi criada na base de dados MongoDB configurada e o número de documentos criados

##### Reexecução das DAGs
- Execute o `clear` da primeira DAG run de `collect_scilista_packages` e verifique se:
  - As DAGs executam sem problemas
  - O número de documentos na collection `e_documents` na base MongoDB não foi alterado
  - O número de documentos no Kernel permanece o mesmo

#### Algum cenário de contexto que queira dar?
Este PR não altera o disparo da DAG `pre_sync_documents_to_kernel` pela DAG `sync_isis_to_kernel`. Uma vez validado, é necessário fazer essa mudança.

### Screenshots
n/a

#### Quais são tickets relevantes?
#188 #213 

### Referências
.