### PR TITLE
Adiciona configuração para timeout de requisições de consulta com o Kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ $ airflow webserver
 * `NEW_SPS_ZIP_DIR`: Diretório de destino dos pacotes SPS otimizados
 * `WEBSITE_URL_LIST`: Lista de URL de SciELO Website para validar a disponibilidade de recursos. Exemplo: ["http://www.scielo.br", "https://new.scielo.br"]
 * `OBJECT_STORE_URL`: URL do Object Store para filtrar os URI existentes nos HTML para que sejam usados na verificação de presença/ausência de menção dos ativos digitais e manifestações do documento no código HTML
+* `KERNEL_FETCH_DATA_TIMEOUT`: Timeout para requisições de leitura do Kernel
 
 
 ## Variáveis opcionais:

--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -51,7 +51,7 @@ def http_hook_run(api_hook, method, endpoint, data=None, headers=DEFAULT_HEADER,
     return response
 
 
-def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=10):
+def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=13):
     api_hook = HttpHook(http_conn_id="kernel_conn", method=method)
     response = http_hook_run(
         api_hook=api_hook,

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -115,7 +115,14 @@ def fetch_data(endpoint):
     """
     Obtém o JSON do endpoint do Kernel
     """
-    return kernel_connect(endpoint=endpoint, method="GET").json()
+    kwargs = {
+        "endpoint": endpoint,
+        "method": "GET",
+    }
+    kernel_timeout = Variable.get("KERNEL_FETCH_DATA_TIMEOUT", default_var=None)
+    if kernel_timeout:
+        kwargs["timeout"] = int(kernel_timeout)
+    return kernel_connect(**kwargs).json()
 
 
 def fetch_changes(since):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR possibilita a configuração de timeout para as requisições `GET` feitas ao Kernel para a DAG `sync_kernel_to_website`. Também foi alterado o timeout padrão da conexão com o Kernel no módulo `hook`.

#### Onde a revisão poderia começar?
Pelo commit 33c4c07 ou módulo `airflow/dags/common/hooks.py`

#### Como este poderia ser testado manualmente?
- Configure um servidor HTTP de teste para simular uma não resposta ou resposta com tempo maior que 13 segundos
- Dispare a DAG `sync_kernel_to_website`
- Verifique se o erro de timeout ocorre e qual o timeout usado no log, como na imagem [1]
- Configure a variável `KERNEL_FETCH_DATA_TIMEOUT` nas variáveis do Airflow com um valor numérico
- Repita o passo 2 e 3

#### Algum cenário de contexto que queira dar?
.

### Screenshots
[1] - Log do Airflow com ocorrência de timeout na requisição com o Kernel

<img width="1025" alt="Screen Shot 2020-11-05 at 11 41 26" src="https://user-images.githubusercontent.com/18053487/98255297-04a05200-1f5c-11eb-8319-bd3efbb3182a.png">

#### Quais são tickets relevantes?
#239 

### Referências
.