### PR TITLE
Substitui as tasks de registro documentos e a de registro de renditions por uma subdag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,4 +124,4 @@ travis_compose_up:
 	@docker-compose -f $(COMPOSE_FILE_PROD) up -d
 
 travis_compose_make_test:
-	@docker-compose -f $(COMPOSE_FILE_PROD) exec opac-airflow python -m unittest -v
+	@docker-compose -f $(COMPOSE_FILE_PROD) exec opac-airflow bash -c "export AIRFLOW__CORE__SQL_ALCHEMY_CONN=sqlite:////usr/local/airflow/airflow.db && airflow initdb && python -m unittest -v"

--- a/airflow/dags/operations/exceptions.py
+++ b/airflow/dags/operations/exceptions.py
@@ -34,6 +34,10 @@ class InvalidOrderValueError(Exception):
     ...
 
 
+class OldFormatKnownDocsError(Exception):
+    ...
+
+
 class LinkDocumentToDocumentsBundleException(Exception):
     def __init__(self, message, response=None, *args, **kwargs):
         self.message = message

--- a/airflow/dags/subdags/check_website_subdags.py
+++ b/airflow/dags/subdags/check_website_subdags.py
@@ -64,4 +64,17 @@ def create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(
                 op_args=(uri_items, dag_run_data),
                 dag=dag_subdag,
             )
+        if not groups:
+            Logger.info("Do nothing")
+            task_id = f'{child_dag_name}_do_nothing'
+            PythonOperator(
+                task_id=task_id,
+                python_callable=do_nothing,
+                dag=dag_subdag,
+            )
+
     return dag_subdag
+
+
+def do_nothing(**kwargs):
+    return True

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -1,3 +1,12 @@
+import logging
+
+from airflow import DAG
+from airflow.operators.python_operator import PythonOperator
+
+
+Logger = logging.getLogger(__name__)
+PARENT_DAG_NAME = 'sync_kernel_to_website'
+
 
 def _group_documents_by_bundle(document_ids, _get_relation_data):
     """Agrupa `document_ids` em grupos
@@ -9,3 +18,43 @@ def _group_documents_by_bundle(document_ids, _get_relation_data):
             groups[bundle_id] = groups.get(bundle_id) or []
             groups[bundle_id].append(doc_id)
     return groups
+
+
+def create_subdag_to_register_documents_grouped_by_bundle(
+        dag, register_docs_callable,
+        document_ids, _get_relation_data,
+        register_renditions_callable, renditions_documents_id,
+        args,
+        ):
+    """
+    Cria uma subdag para executar register_documents_grouped_by_bundle
+    para que se houver falha, será necessário reexecutar apenas os grupos
+    que falharam
+    """
+    CHILD_DAG_NAME = 'register_documents_groups_id'
+
+    Logger.info("Create register_documents_grouped_by_bundle subdag")
+
+    groups = _group_documents_by_bundle(document_ids, _get_relation_data)
+    Logger.info("Total groups: %i", len(groups))
+
+    dag_subdag = DAG(
+        dag_id='{}.{}'.format(PARENT_DAG_NAME, CHILD_DAG_NAME),
+        default_args=args,
+        schedule_interval=None,
+    )
+    with dag_subdag:
+        if not groups:
+            Logger.info("Do nothing")
+            task_id = f'{CHILD_DAG_NAME}_do_nothing'
+            PythonOperator(
+                task_id=task_id,
+                python_callable=do_nothing,
+                dag=dag_subdag,
+            )
+
+    return dag_subdag
+
+
+def do_nothing(**kwargs):
+    return True

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -74,7 +74,23 @@ def create_subdag_to_register_documents_grouped_by_bundle(
                 )
                 t1 >> t2
 
-        if not groups:
+        _renditions_documents_id = renditions_documents_id - set(document_ids)
+        Logger.info(
+                "Total renditions documents: %i",
+                len(_renditions_documents_id))
+        if _renditions_documents_id:
+            # registra `renditions` de ID de documentos que não estão em
+            # `documents_to_get`
+            task_id = f'{CHILD_DAG_NAME}_renditions'
+
+            t3 = PythonOperator(
+                task_id=task_id,
+                python_callable=register_renditions_callable,
+                op_kwargs={'renditions_to_get': _renditions_documents_id},
+                dag=dag_subdag,
+            )
+
+        elif not groups:
             Logger.info("Do nothing")
             task_id = f'{CHILD_DAG_NAME}_do_nothing'
             PythonOperator(

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -1,0 +1,11 @@
+
+def _group_documents_by_bundle(document_ids, _get_relation_data):
+    """Agrupa `document_ids` em grupos
+    """
+    groups = {}
+    for doc_id in document_ids:
+        bundle_id, doc = _get_relation_data(doc_id)
+        if bundle_id:
+            groups[bundle_id] = groups.get(bundle_id) or []
+            groups[bundle_id].append(doc_id)
+    return groups

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -44,6 +44,18 @@ def create_subdag_to_register_documents_grouped_by_bundle(
         schedule_interval=None,
     )
     with dag_subdag:
+        for bundle_id, doc_ids in groups.items():
+            task_id = f'{CHILD_DAG_NAME}_{bundle_id}_docs'
+
+            Logger.info("%s", bundle_id)
+            Logger.info("Total: %i", len(doc_ids))
+
+            t1 = PythonOperator(
+                task_id=task_id,
+                python_callable=register_docs_callable,
+                op_args=(doc_ids, _get_relation_data),
+                dag=dag_subdag,
+            )
         if not groups:
             Logger.info("Do nothing")
             task_id = f'{CHILD_DAG_NAME}_do_nothing'

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -649,6 +649,53 @@ def _remodel_known_documents(known_documents):
     return remodeled_known_documents
 
 
+def _get_relation_data_old(known_documents, document_id: str) -> Tuple[str, Dict]:
+    """Recupera informações sobre o relacionamento entre o
+    DocumentsBundle e o Document.
+
+    Retorna uma tupla contendo o identificador da issue onde o
+    documento está relacionado e o item do relacionamento.
+
+    >> _get_relation_data("67TH7T7CyPPmgtVrGXhWXVs")
+    ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+
+    :param known_documents: Dicionário cujas chaves são `issue_id` e
+        valores são lista de dicionários no padrão 
+            `{'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'}`
+    :param document_id: Identificador único de um documento
+    """
+    for issue_id, docs in known_documents.items():
+        for doc in docs:
+            if document_id == doc["id"]:
+                return (issue_id, doc)
+
+    return (None, {})
+
+
+def _get_relation_data_new(known_documents, document_id: str) -> Tuple[str, Dict]:
+    """Recupera informações sobre o relacionamento entre o
+    DocumentsBundle e o Document.
+
+    Retorna uma tupla contendo o identificador da issue onde o
+    documento está relacionado e o item do relacionamento.
+
+    >> _get_relation_data("67TH7T7CyPPmgtVrGXhWXVs")
+    ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+
+    :param known_documents: Dicionário cujas chaves são `document_id` e
+        valores é `{'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'}`
+    :param document_id: Identificador único de um documento
+    """
+    data = known_documents.get(document_id)
+    if data:
+        return data
+    for value in known_documents.values():
+        if not isinstance(value, tuple):
+            return None
+        break
+    return (None, {})
+
+
 def _get_relation_data(known_documents, document_id: str) -> Tuple[str, Dict]:
     """Recupera informações sobre o relacionamento entre o
     DocumentsBundle e o Document.
@@ -664,13 +711,9 @@ def _get_relation_data(known_documents, document_id: str) -> Tuple[str, Dict]:
             `{'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'}`
     :param document_id: Identificador único de um documento
     """
-
-    for issue_id, docs in known_documents.items():
-        for doc in docs:
-            if document_id == doc["id"]:
-                return (issue_id, doc)
-
-    return (None, {})
+    return (
+        _get_relation_data_new(known_documents, document_id) or
+        _get_relation_data_old(known_documents, document_id))
 
 
 def register_documents_alt(**kwargs):

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -716,6 +716,25 @@ def _get_relation_data(known_documents, document_id: str) -> Tuple[str, Dict]:
         _get_relation_data_old(known_documents, document_id))
 
 
+def pre_register_documents(**kwargs):
+    """Agrupa documentos em lotes menores para serem registrados no Kernel"""
+
+    logging.info("pre_register_documents - IN")
+    tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
+    Variable.set(
+        "read_changes_task__tasks", tasks, serialize_json=True)
+    logging.info("Tasks Total: %i", len(tasks or []))
+
+    known_documents = kwargs["ti"].xcom_pull(
+        key="i_documents", task_ids="register_issues_task"
+    )
+    Variable.set(
+        "register_issues_task__i_documents",
+        known_documents, serialize_json=True)
+    logging.info("Tasks Total: %i", len(known_documents or {}))
+    logging.info("pre_register_documents - OUT")
+
+
 def register_documents_alt(**kwargs):
     """Agrupa documentos em lotes menores para serem registrados no Kernel"""
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -813,30 +813,35 @@ def _register_documents(documents_to_get, _get_relation_data, **kwargs):
     :param documents_to_get: sequência de PID v3 de documentos
     :param _get_relation_data: callable, que dado um doc id,
         retorna (issue_id, dados do documento), por exemplo,
-        ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+        ('0034-8910-2019-v53',
+         {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
     """
+    logging.info("_register_documents: mongo_connect")
     mongo_connect()
-
+    logging.info("_register_documents: try_register_documents")
     orphans = try_register_documents(
-        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory
+        documents_to_get, _get_relation_data, fetch_documents_front,
+        ArticleFactory
     )
-
-    _orphans = Variable.get("orphan_documents", [], deserialize_json=True)
-    Variable.set("orphan_documents", _orphans + orphans, serialize_json=True)
+    logging.info("_register_documents: xcom_push")
+    kwargs["ti"].xcom_push(key="orphan_documents", value=orphans)
+    logging.info("_register_documents: return")
     return True
 
 
 def _register_documents_renditions(renditions_to_get, **kwargs):
     """
     """
+    logging.info("_register_documents_renditions: mongo_connect")
     mongo_connect()
-
+    logging.info(
+        "_register_documents_renditions: try_register_documents_renditions")
     orphans = try_register_documents_renditions(
         renditions_to_get, fetch_documents_renditions, ArticleRenditionFactory
     )
-
-    _orphans = Variable.get("orphan_renditions", [], deserialize_json=True)
-    Variable.set("orphan_renditions", _orphans + orphans, serialize_json=True)
+    logging.info("_register_documents_renditions: xcom_push")
+    kwargs["ti"].xcom_push(key="orphan_renditions", value=orphans)
+    logging.info("_register_documents_renditions: return")
     return True
 
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -645,13 +645,7 @@ def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     # percorre os issues mais recentes e atualiza `known_documents[issue_id]`
     # com os documentos retornados por `fetch_bundles`
     for issue_id in issues_recently_updated:
-        known_documents.setdefault(issue_id, [])
-        known_documents[issue_id] = list(
-            itertools.chain(
-                known_documents[issue_id],
-                fetch_bundles(issue_id).get("items", [])
-            )
-        )
+        known_documents[issue_id] = fetch_bundles(issue_id).get("items", [])
     return known_documents
 
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -638,6 +638,31 @@ def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     return known_documents
 
 
+
+def _get_relation_data(known_documents, document_id: str) -> Tuple[str, Dict]:
+    """Recupera informações sobre o relacionamento entre o
+    DocumentsBundle e o Document.
+
+    Retorna uma tupla contendo o identificador da issue onde o
+    documento está relacionado e o item do relacionamento.
+
+    >> _get_relation_data("67TH7T7CyPPmgtVrGXhWXVs")
+    ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+
+    :param known_documents: Dicionário cujas chaves são `issue_id` e
+        valores são lista de dicionários no padrão 
+            `{'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'}`
+    :param document_id: Identificador único de um documento
+    """
+
+    for issue_id, docs in known_documents.items():
+        for doc in docs:
+            if document_id == doc["id"]:
+                return (issue_id, doc)
+
+    return (None, {})
+
+
 def register_documents_alt(**kwargs):
     """Agrupa documentos em lotes menores para serem registrados no Kernel"""
 
@@ -660,7 +685,7 @@ def register_documents_alt(**kwargs):
 
         for issue_id, docs in known_documents.items():
             for doc in docs:
-                if document_id == docs["id"]:
+                if document_id == doc["id"]:
                     return (issue_id, doc)
 
         return (None, {})
@@ -745,7 +770,7 @@ def register_documents(**kwargs):
 
         for issue_id, docs in known_documents.items():
             for doc in docs:
-                if document_id == docs["id"]:
+                if document_id == doc["id"]:
                     return (issue_id, doc)
 
         return (None, {})

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -822,14 +822,20 @@ def register_documents_subdag(dag, args):
         (get_id(task["id"]) for task in filter_changes(tasks, "renditions", "get")),
     )
 
-    # converte gerador para sequencia
+    # converte geradores para sequencias
     documents_to_get = set(documents_to_get)
+    renditions_to_get = set(renditions_to_get)
+
+    # reseta os órfãos
+    Variable.set("orphan_renditions", [], serialize_json=True)
+    Variable.set("orphan_documents", [], serialize_json=True)
+
     logging.info(documents_to_get)
     # cria SubDag para registrar grupos de documentos e renditions
     subdag = create_subdag_to_register_documents_grouped_by_bundle(
         dag, _register_documents,
         documents_to_get, _get_relation_data,
-        _register_documents_renditions, set(renditions_to_get),
+        _register_documents_renditions, renditions_to_get,
         args,
         )
     return subdag

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -631,10 +631,10 @@ def register_documents(**kwargs):
         :param document_id: Identificador único de um documento
         """
 
-        for issue_id, items in known_documents.items():
-            for item in items:
-                if document_id == item["id"]:
-                    return (issue_id, item)
+        for issue_id, docs in known_documents.items():
+            for doc in docs:
+                if document_id == docs["id"]:
+                    return (issue_id, doc)
 
         return (None, {})
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -775,7 +775,11 @@ def register_documents_alt(**kwargs):
 
     mongo_connect()
 
-    tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
+    tasks = Variable.get(
+        "read_changes_task__tasks", default_var=[], deserialize_json=True)
+    known_documents = Variable.get(
+        "register_issues_task__i_documents",
+        default_var={}, deserialize_json=True)
 
     def _get_relation_data(document_id: str) -> Tuple[str, Dict]:
         """Recupera informações sobre o relacionamento entre o
@@ -792,9 +796,6 @@ def register_documents_alt(**kwargs):
 
         return _get_relation_data_new(remodeled_known_documents, document_id)
 
-    known_documents = kwargs["ti"].xcom_pull(
-            key="i_documents", task_ids="register_issues_task"
-        )
     known_documents = _get_known_documents(known_documents, task)
     remodeled_known_documents = _remodel_known_documents(known_documents)
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -631,22 +631,10 @@ def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     conhecidos a partir da lista de eventos de `get` de `bundles`.
     """
 
-    # known_documents = kwargs["ti"].xcom_pull(
-    #     key="i_documents", task_ids="register_issues_task"
-    # )
-
-    # obtém os issues mais recentes
-    issues_recently_updated = []
     for task in filter_changes(tasks, "bundles", "get"):
         issue_id = get_id(task["id"])
         if known_documents.get(issue_id) is None:
-            issues_recently_updated.append(issue_id)
-
-    logging.info(issues_recently_updated)
-    # percorre os issues mais recentes e atualiza `known_documents[issue_id]`
-    # com os documentos retornados por `fetch_bundles`
-    for issue_id in issues_recently_updated:
-        known_documents[issue_id] = fetch_bundles(issue_id).get("items", [])
+            known_documents[issue_id] = fetch_bundles(issue_id).get("items", [])
     return known_documents
 
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -827,8 +827,12 @@ def register_documents_subdag(dag, args):
     renditions_to_get = set(renditions_to_get)
 
     # reseta os órfãos
-    Variable.set("orphan_renditions", [], serialize_json=True)
-    Variable.set("orphan_documents", [], serialize_json=True)
+    try:
+        Variable.set("orphan_renditions", [], serialize_json=True)
+        Variable.set("orphan_documents", [], serialize_json=True)
+    except Exception as e:
+        # tenta contornar possivel erro que acontece no travis
+        logging.info("Excecao em register_documents_subdag: %s", e)
 
     logging.info(documents_to_get)
     # cria SubDag para registrar grupos de documentos e renditions

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -756,6 +756,20 @@ def _register_documents(documents_to_get, _get_relation_data, **kwargs):
     return True
 
 
+def _register_documents_renditions(renditions_to_get, **kwargs):
+    """
+    """
+    mongo_connect()
+
+    orphans = try_register_documents_renditions(
+        renditions_to_get, fetch_documents_renditions, ArticleRenditionFactory
+    )
+
+    _orphans = Variable.get("orphan_renditions", [], deserialize_json=True)
+    Variable.set("orphan_renditions", _orphans + orphans, serialize_json=True)
+    return True
+
+
 def register_documents_alt(**kwargs):
     """Agrupa documentos em lotes menores para serem registrados no Kernel"""
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -609,6 +609,89 @@ register_issues_task = PythonOperator(
 )
 
 
+def register_documents_alt(**kwargs):
+    """Agrupa documentos em lotes menores para serem registrados no Kernel"""
+
+    mongo_connect()
+
+    tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
+
+    def _get_relation_data(document_id: str) -> Tuple[str, Dict]:
+        """Recupera informações sobre o relacionamento entre o
+        DocumentsBundle e o Document.
+
+        Retorna uma tupla contendo o identificador da issue onde o
+        documento está relacionado e o item do relacionamento.
+
+        >> _get_relation_data("67TH7T7CyPPmgtVrGXhWXVs")
+        ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+
+        :param document_id: Identificador único de um documento
+        """
+
+        for issue_id, docs in known_documents.items():
+            for doc in docs:
+                if document_id == docs["id"]:
+                    return (issue_id, doc)
+
+        return (None, {})
+
+    def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
+        """Recupera a lista de todos os documentos que estão relacionados com
+        um `DocumentsBundle`.
+
+        Levando em consideração que a DAG que detecta mudanças na API do Kernel
+        roda de forma assíncrona em relação a DAG de espelhamento/sincronização.
+
+        É possível que algumas situações especiais ocorram onde em uma rodada
+        **anterior** o **evento de registro** de um `Document` foi capturado mas a
+        atualização de seu `DocumentsBundle` não ocorreu (elas ocorrem em transações
+        distintas e possuem timestamps também distintos). O documento será
+        registrado como **órfão** e sua `task` não será processada na próxima
+        execução.
+
+        Na próxima execução a task `register_issue_task` entenderá que o
+        `bundle` é órfão e não conhecerá os seus documentos (known_documents)
+        e consequentemente o documento continuará órfão.
+
+        Uma solução para este problema é atualizar a lista de documentos
+        conhecidos a partir da lista de eventos de `get` de `bundles`.
+        """
+
+        known_documents = kwargs["ti"].xcom_pull(
+            key="i_documents", task_ids="register_issues_task"
+        )
+
+        issues_recently_updated = [
+            get_id(task["id"]) for task in filter_changes(tasks, "bundles", "get")
+            if known_documents.get(get_id(task["id"])) is None
+        ]
+
+        for issue_id in issues_recently_updated:
+            known_documents.setdefault(issue_id, [])
+            known_documents[issue_id] = list(
+                itertools.chain(
+                    known_documents[issue_id], fetch_bundles(issue_id).get("items", [])
+                )
+            )
+        return known_documents
+
+    known_documents = _get_known_documents(**kwargs)
+
+    # TODO: Em caso de um update no document é preciso atualizar o registro
+    # Precisamos de uma nova task?
+
+    documents_to_get = itertools.chain(
+        Variable.get("orphan_documents", default_var=[], deserialize_json=True),
+        (get_id(task["id"]) for task in filter_changes(tasks, "documents", "get")),
+    )
+    orphans = try_register_documents(
+        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory
+    )
+
+    Variable.set("orphan_documents", orphans, serialize_json=True)
+
+
 def register_documents(**kwargs):
     """Registra documentos na base de dados do OPAC a partir de
     informações vindas da API do `Kernel`. Armazena como órfãos nas variáveis

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -796,7 +796,7 @@ def register_documents_alt(**kwargs):
 
         return _get_relation_data_new(remodeled_known_documents, document_id)
 
-    known_documents = _get_known_documents(known_documents, task)
+    known_documents = _get_known_documents(known_documents, tasks)
     remodeled_known_documents = _remodel_known_documents(known_documents)
 
     # TODO: Em caso de um update no document é preciso atualizar o registro

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -638,6 +638,16 @@ def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     return known_documents
 
 
+def _remodel_known_documents(known_documents):
+    """Remodela `known_documents` para que a recuperação seja mais eficiente.
+    (`_get_relation_data`)
+    """
+    remodeled_known_documents = {}
+    for issue_id, issue_docs in known_documents.items():
+        for issue_doc in issue_docs:
+            remodeled_known_documents[issue_doc["id"]] = (issue_id, issue_doc)
+    return remodeled_known_documents
+
 
 def _get_relation_data(known_documents, document_id: str) -> Tuple[str, Dict]:
     """Recupera informações sobre o relacionamento entre o

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -636,10 +636,11 @@ def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     # )
 
     # obtém os issues mais recentes
-    issues_recently_updated = [
-        get_id(task["id"]) for task in filter_changes(tasks, "bundles", "get")
-        if known_documents.get(get_id(task["id"])) is None
-    ]
+    issues_recently_updated = []
+    for task in filter_changes(tasks, "bundles", "get"):
+        issue_id = get_id(task["id"])
+        if known_documents.get(issue_id) is None:
+            issues_recently_updated.append(issue_id)
 
     logging.info(issues_recently_updated)
     # percorre os issues mais recentes e atualiza `known_documents[issue_id]`

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -783,6 +783,9 @@ def register_documents_alt(**kwargs):
             )
         return known_documents
 
+    known_documents = kwargs["ti"].xcom_pull(
+            key="i_documents", task_ids="register_issues_task"
+        )
     known_documents = _get_known_documents(**kwargs)
 
     # TODO: Em caso de um update no document é preciso atualizar o registro

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -609,7 +609,7 @@ register_issues_task = PythonOperator(
 )
 
 
-def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
+def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     """Recupera a lista de todos os documentos que estão relacionados com
     um `DocumentsBundle`.
 
@@ -631,20 +631,21 @@ def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
     conhecidos a partir da lista de eventos de `get` de `bundles`.
     """
 
-    known_documents = kwargs["ti"].xcom_pull(
-        key="i_documents", task_ids="register_issues_task"
-    )
+    # known_documents = kwargs["ti"].xcom_pull(
+    #     key="i_documents", task_ids="register_issues_task"
+    # )
 
     issues_recently_updated = [
         get_id(task["id"]) for task in filter_changes(tasks, "bundles", "get")
         if known_documents.get(get_id(task["id"])) is None
     ]
-
+    logging.info(issues_recently_updated)
     for issue_id in issues_recently_updated:
         known_documents.setdefault(issue_id, [])
         known_documents[issue_id] = list(
             itertools.chain(
-                known_documents[issue_id], fetch_bundles(issue_id).get("items", [])
+                known_documents[issue_id],
+                fetch_bundles(issue_id).get("items", [])
             )
         )
     return known_documents

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -736,17 +736,13 @@ def register_documents_alt(**kwargs):
         :param document_id: Identificador único de um documento
         """
 
-        for issue_id, docs in known_documents.items():
-            for doc in docs:
-                if document_id == doc["id"]:
-                    return (issue_id, doc)
-
-        return (None, {})
+        return _get_relation_data_new(remodeled_known_documents, document_id)
 
     known_documents = kwargs["ti"].xcom_pull(
             key="i_documents", task_ids="register_issues_task"
         )
     known_documents = _get_known_documents(known_documents, task)
+    remodeled_known_documents = _remodel_known_documents(known_documents)
 
     # TODO: Em caso de um update no document é preciso atualizar o registro
     # Precisamos de uma nova task?

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -635,11 +635,15 @@ def _get_known_documents(known_documents, tasks) -> Dict[str, List[str]]:
     #     key="i_documents", task_ids="register_issues_task"
     # )
 
+    # obtém os issues mais recentes
     issues_recently_updated = [
         get_id(task["id"]) for task in filter_changes(tasks, "bundles", "get")
         if known_documents.get(get_id(task["id"])) is None
     ]
+
     logging.info(issues_recently_updated)
+    # percorre os issues mais recentes e atualiza `known_documents[issue_id]`
+    # com os documentos retornados por `fetch_bundles`
     for issue_id in issues_recently_updated:
         known_documents.setdefault(issue_id, [])
         known_documents[issue_id] = list(

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -609,6 +609,47 @@ register_issues_task = PythonOperator(
 )
 
 
+def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
+    """Recupera a lista de todos os documentos que estão relacionados com
+    um `DocumentsBundle`.
+
+    Levando em consideração que a DAG que detecta mudanças na API do Kernel
+    roda de forma assíncrona em relação a DAG de espelhamento/sincronização.
+
+    É possível que algumas situações especiais ocorram onde em uma rodada
+    **anterior** o **evento de registro** de um `Document` foi capturado mas a
+    atualização de seu `DocumentsBundle` não ocorreu (elas ocorrem em transações
+    distintas e possuem timestamps também distintos). O documento será
+    registrado como **órfão** e sua `task` não será processada na próxima
+    execução.
+
+    Na próxima execução a task `register_issue_task` entenderá que o
+    `bundle` é órfão e não conhecerá os seus documentos (known_documents)
+    e consequentemente o documento continuará órfão.
+
+    Uma solução para este problema é atualizar a lista de documentos
+    conhecidos a partir da lista de eventos de `get` de `bundles`.
+    """
+
+    known_documents = kwargs["ti"].xcom_pull(
+        key="i_documents", task_ids="register_issues_task"
+    )
+
+    issues_recently_updated = [
+        get_id(task["id"]) for task in filter_changes(tasks, "bundles", "get")
+        if known_documents.get(get_id(task["id"])) is None
+    ]
+
+    for issue_id in issues_recently_updated:
+        known_documents.setdefault(issue_id, [])
+        known_documents[issue_id] = list(
+            itertools.chain(
+                known_documents[issue_id], fetch_bundles(issue_id).get("items", [])
+            )
+        )
+    return known_documents
+
+
 def register_documents_alt(**kwargs):
     """Agrupa documentos em lotes menores para serem registrados no Kernel"""
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -735,6 +735,27 @@ def pre_register_documents(**kwargs):
     logging.info("pre_register_documents - OUT")
 
 
+def _register_documents(documents_to_get, _get_relation_data, **kwargs):
+    """
+    Registra os documentos da sequencia `documents_to_get` no Kernel
+    Armazena em Variable "orphan_documents", os documentos que não
+    vinculados a um `bundle`.
+    :param documents_to_get: sequência de PID v3 de documentos
+    :param _get_relation_data: callable, que dado um doc id,
+        retorna (issue_id, dados do documento), por exemplo,
+        ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+    """
+    mongo_connect()
+
+    orphans = try_register_documents(
+        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory
+    )
+
+    _orphans = Variable.get("orphan_documents", [], deserialize_json=True)
+    Variable.set("orphan_documents", _orphans + orphans, serialize_json=True)
+    return True
+
+
 def register_documents_alt(**kwargs):
     """Agrupa documentos em lotes menores para serem registrados no Kernel"""
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -757,6 +757,89 @@ class TestGetRelationData(unittest.TestCase):
         result = _get_relation_data(known_documents, document_id)
         self.assertEqual(expected, result)
 
+    def test__get_relation_data_uses_remodeled_known_documents_and_returns_bundle_and_document(self):
+        known_documents = {
+            "RCgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CGgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LLgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+            "RC13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CG13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJ13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LL13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+        }
+        document_id = "HJgFV9MHSKmp6Msj5CPBZRb"
+        expected = (
+            "issue_id",
+            {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"}
+        )
+        result = _get_relation_data(known_documents, document_id)
+        self.assertEqual(expected, result)
+
+    def test__get_relation_data_uses_remodeled_known_documents_and_returns_none_and_no_docs(self):
+        known_documents = {
+            "RCgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CGgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LLgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+            "RC13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CG13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJ13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LL13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+        }
+        document_id = "AAAAAAMHSKmp6Msj5CPBZRb"
+        expected = (None, {})
+        result = _get_relation_data(known_documents, document_id)
+        self.assertEqual(expected, result)
+
 
 class TestRemodelKnownDocuments(unittest.TestCase):
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -25,7 +25,10 @@ from operations.sync_kernel_to_website_operations import (
     try_register_documents_renditions,
 )
 from opac_schema.v1 import models
-from operations.exceptions import InvalidOrderValueError
+from operations.exceptions import (
+    InvalidOrderValueError,
+    OldFormatKnownDocsError,
+)
 
 
 FIXTURES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
@@ -849,7 +852,7 @@ class TestGetRelationData(unittest.TestCase):
 
 class TestGetRelationDataNew(unittest.TestCase):
 
-    def test__get_relation_data_new_returns_None(self):
+    def test__get_relation_data_new_raise_OldFormatKnownDocsError(self):
         known_documents = {
             "issue_id": [
                 {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
@@ -865,9 +868,8 @@ class TestGetRelationDataNew(unittest.TestCase):
             ]
         }
         document_id = "HJgFV9MHSKmp6Msj5CPBZRb"
-        expected = None
-        result = _get_relation_data_new(known_documents, document_id)
-        self.assertEqual(expected, result)
+        with self.assertRaises(OldFormatKnownDocsError):
+            _get_relation_data_new(known_documents, document_id)
 
     def test__get_relation_data_new_returns_none_and_no_docs(self):
         known_documents = {}
@@ -919,8 +921,7 @@ class TestGetRelationDataNew(unittest.TestCase):
         result = _get_relation_data_new(known_documents, document_id)
         self.assertEqual(expected, result)
 
-    @patch("sync_kernel_to_website.isinstance")
-    def test__get_relation_data_new_calls_isinstance_once(self, mock_isinstance):
+    def test__get_relation_data_new_calls_isinstance_once(self):
         known_documents = {
             "RCgFV9MHSKmp6Msj5CPBZRb": (
                 "issue_id",
@@ -959,7 +960,6 @@ class TestGetRelationDataNew(unittest.TestCase):
         expected = (None, {})
         result = _get_relation_data_new(known_documents, document_id)
         self.assertEqual(expected, result)
-        mock_isinstance.assert_called_once()
 
 
 class TestGetRelationDataOld(unittest.TestCase):

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -1249,8 +1249,11 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
         mock_dag = MockDAG(ANY)
         args = mock_default_args
         args.update(self.kwargs)
+        
         # closure
         ANY_get_relation_data = ANY
+        
+        # funcoes reais
         actual_register_documents = _register_documents
         actual_register_documents_renditions = _register_documents_renditions
 
@@ -1269,8 +1272,11 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
             "5zyjkqWqkwsr9VQHDdQTL4D",
         }
 
+        # chamada para a função que está sob teste
         register_documents_subdag(mock_dag, args, **self.kwargs)
 
+        # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
+        # chamada com os parâmetros esperados
         mock_create_subdag.assert_called_once_with(
             mock_dag,
             actual_register_documents,
@@ -1280,3 +1286,223 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
             renditions_to_get,
             args
         )
+
+    def test_register_documents_subdag_for_no_renditions(self,
+            mock_mongo,
+            mock_get,
+            mock_create_subdag,
+            mock_default_args,
+            ):
+        MockDAG = MagicMock(spec=DAG)
+        mock_default_args.return_value = {}
+
+        # dados de entrada
+        tasks = [
+            {"id": "/documents/QTsr9VQHDd4DL5zqWqkwyjk",
+             "task": "get"},
+            {"id": "/bundles/2236-9996-2020-v22-n47",
+             "task": "get"},
+            {"id": "/documents/S0104-42302020000500589",
+             "task": "get"},
+        ]
+        # dados de entrada
+        i_docs = {
+            "2236-9996-2020-v22-n47":
+                [{"id": "QTsr9VQHDd4DL5zqWqkwyjk", "order": "00017"}],
+            "0034-8910-1974-v8-s0": [],
+            "0034-8910-1976-v10-s1": [],
+        }
+        # dados de entrada
+        orphan_docs = [
+            "QTL5zyjkqWqkwsr9VQHDd4D", "S0104-42302020000500589",
+        ]
+        # dados de entrada
+        orphan_rends = [
+        ]
+        # dados de entrada resultantes de Variable.get
+        mock_get.side_effect = [
+            tasks,
+            i_docs,
+            orphan_docs,
+            orphan_rends,
+        ]
+        mock_dag = MockDAG(ANY)
+        args = mock_default_args
+        args.update(self.kwargs)
+
+        # closure
+        ANY_get_relation_data = ANY
+
+        # funcoes reais
+        actual_register_documents = _register_documents
+        actual_register_documents_renditions = _register_documents_renditions
+
+        # obtido dependendo dos dados de entrada fornecidos por Variable.get
+        documents_to_get = {
+            "QTL5zyjkqWqkwsr9VQHDd4D",
+            "QTsr9VQHDd4DL5zqWqkwyjk",
+            "S0104-42302020000500589",
+        }
+
+        # obtido dependendo dos dados de entrada fornecidos por Variable.get
+        renditions_to_get = set()
+
+        # chamada para a função que está sob teste
+        register_documents_subdag(mock_dag, args, **self.kwargs)
+
+        # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
+        # chamada com os parâmetros esperados
+        mock_create_subdag.assert_called_once_with(
+            mock_dag,
+            actual_register_documents,
+            documents_to_get,
+            ANY_get_relation_data,
+            actual_register_documents_renditions,
+            renditions_to_get,
+            args
+        )
+
+    def test_register_documents_subdag_for_no_docs(self,
+            mock_mongo,
+            mock_get,
+            mock_create_subdag,
+            mock_default_args,
+            ):
+        MockDAG = MagicMock(spec=DAG)
+        mock_default_args.return_value = {}
+
+        # dados de entrada
+        tasks = [
+            {"id": "/documents/QTsr9VQHDd4DL5zqWqkwyjk/renditions",
+             "task": "get"},
+            {"id": "/bundles/2236-9996-2020-v22-n47",
+             "task": "get"},
+            {"id": "/documents/S0104-42302020000500589/renditions",
+             "task": "get"},
+            {"id": "/documents/5zyjkqWqkwsr9VQHDdQTL4D/renditions",
+             "task": "get"},
+        ]
+        # dados de entrada
+        i_docs = {
+            "2236-9996-2020-v22-n47":
+                [{"id": "QTsr9VQHDd4DL5zqWqkwyjk", "order": "00017"}],
+            "0034-8910-1974-v8-s0": [],
+            "0034-8910-1976-v10-s1": [],
+        }
+        # dados de entrada
+        orphan_docs = [
+        ]
+        # dados de entrada
+        orphan_rends = [
+            "kwsr9VQHDd4DQTL5zyjkqWq", "S0104-42302020000500589",
+        ]
+        # dados de entrada resultantes de Variable.get
+        mock_get.side_effect = [
+            tasks,
+            i_docs,
+            orphan_docs,
+            orphan_rends,
+        ]
+        mock_dag = MockDAG(ANY)
+        args = mock_default_args
+        args.update(self.kwargs)
+
+        # closure
+        ANY_get_relation_data = ANY
+
+        # funcoes reais
+        actual_register_documents = _register_documents
+        actual_register_documents_renditions = _register_documents_renditions
+
+        # obtido dependendo dos dados de entrada fornecidos por Variable.get
+        documents_to_get = set()
+
+        # obtido dependendo dos dados de entrada fornecidos por Variable.get
+        renditions_to_get = {
+            "kwsr9VQHDd4DQTL5zyjkqWq",
+            "S0104-42302020000500589",
+            "QTsr9VQHDd4DL5zqWqkwyjk",
+            "5zyjkqWqkwsr9VQHDdQTL4D",
+        }
+
+        # chamada para a função que está sob teste
+        register_documents_subdag(mock_dag, args, **self.kwargs)
+
+        # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
+        # chamada com os parâmetros esperados
+        mock_create_subdag.assert_called_once_with(
+            mock_dag,
+            actual_register_documents,
+            documents_to_get,
+            ANY_get_relation_data,
+            actual_register_documents_renditions,
+            renditions_to_get,
+            args
+        )
+
+    def test_register_documents_subdag_for_no_docs_and_no_rends(self,
+            mock_mongo,
+            mock_get,
+            mock_create_subdag,
+            mock_default_args,
+            ):
+        MockDAG = MagicMock(spec=DAG)
+        mock_default_args.return_value = {}
+
+        # dados de entrada
+        tasks = [
+            {"id": "/bundles/2236-9996-2020-v22-n47",
+             "task": "get"},
+        ]
+        # dados de entrada
+        i_docs = {
+            "2236-9996-2020-v22-n47":
+                [{"id": "QTsr9VQHDd4DL5zqWqkwyjk", "order": "00017"}],
+            "0034-8910-1974-v8-s0": [],
+            "0034-8910-1976-v10-s1": [],
+        }
+        # dados de entrada
+        orphan_docs = [
+        ]
+        # dados de entrada
+        orphan_rends = [
+        ]
+        # dados de entrada resultantes de Variable.get
+        mock_get.side_effect = [
+            tasks,
+            i_docs,
+            orphan_docs,
+            orphan_rends,
+        ]
+        mock_dag = MockDAG(ANY)
+        args = mock_default_args
+        args.update(self.kwargs)
+
+        # closure
+        ANY_get_relation_data = ANY
+
+        # funcoes reais
+        actual_register_documents = _register_documents
+        actual_register_documents_renditions = _register_documents_renditions
+
+        # obtido dependendo dos dados de entrada fornecidos por Variable.get
+        documents_to_get = set()
+
+        # obtido dependendo dos dados de entrada fornecidos por Variable.get
+        renditions_to_get = set()
+
+        # chamada para a função que está sob teste
+        register_documents_subdag(mock_dag, args, **self.kwargs)
+
+        # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
+        # chamada com os parâmetros esperados
+        mock_create_subdag.assert_called_once_with(
+            mock_dag,
+            actual_register_documents,
+            documents_to_get,
+            ANY_get_relation_data,
+            actual_register_documents_renditions,
+            renditions_to_get,
+            args
+        )
+

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -10,6 +10,7 @@ from sync_kernel_to_website import (
     IssueFactory,
     _get_known_documents,
     _get_relation_data,
+    _remodel_known_documents,
 )
 from operations.sync_kernel_to_website_operations import (
     ArticleFactory,
@@ -755,3 +756,59 @@ class TestGetRelationData(unittest.TestCase):
         expected = (None, {})
         result = _get_relation_data(known_documents, document_id)
         self.assertEqual(expected, result)
+
+
+class TestRemodelKnownDocuments(unittest.TestCase):
+
+    def test__remodel_known_documents(self):
+        known_documents = {
+            "issue_id": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ],
+            "issue_id_2": [
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ]
+        }
+        expected = {
+            "RCgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CGgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LLgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+            "RC13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CG13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJ13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LL13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+        }
+        result = _remodel_known_documents(known_documents)
+        self.assertEqual(expected, result)
+

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -9,6 +9,7 @@ from sync_kernel_to_website import (
     JournalFactory,
     IssueFactory,
     _get_known_documents,
+    _get_relation_data,
 )
 from operations.sync_kernel_to_website_operations import (
     ArticleFactory,
@@ -708,3 +709,49 @@ class TestGetKnownDocuments(unittest.TestCase):
         result = _get_known_documents(known_documents, tasks)
         self.assertDictEqual(expected, result)
         self.assertIs(known_documents, result)
+
+
+class TestGetRelationData(unittest.TestCase):
+
+    def test__get_relation_data_returns_bundle_and_document(self):
+        known_documents = {
+            "issue_id": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ],
+            "issue_id_2": [
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ]
+        }
+        document_id = "HJgFV9MHSKmp6Msj5CPBZRb"
+        expected = (
+            "issue_id",
+            {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"}
+        )
+        result = _get_relation_data(known_documents, document_id)
+        self.assertEqual(expected, result)
+
+    def test__get_relation_data_returns_none_and_no_docs(self):
+        known_documents = {
+            "issue_id": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ],
+            "issue_id_2": [
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ]
+        }
+        document_id = "AAAAAAMHSKmp6Msj5CPBZRb"
+        expected = (None, {})
+        result = _get_relation_data(known_documents, document_id)
+        self.assertEqual(expected, result)

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -15,6 +15,7 @@ from sync_kernel_to_website import (
     _get_relation_data_old,
     pre_register_documents,
     _register_documents,
+    _register_documents_renditions,
 )
 from operations.sync_kernel_to_website_operations import (
     ArticleFactory,
@@ -1123,15 +1124,13 @@ class TestRegisterDocuments(unittest.TestCase):
         documents_to_get = [
             "QTsr9VQHDd4DL5zqWqkwyjk", "LL13V9MHSKmp6Msj5CPBZRb"]
         _get_relation_data = MagicMock(spec=callable)
-        
+
         mock_try_reg.return_value = ["LL13V9MHSKmp6Msj5CPBZRb"]
         mock_get.return_value = ["6Msj5CPBZRbLL13V9MHSKmp"]
 
         _register_documents(
             documents_to_get, _get_relation_data, **self.kwargs)
 
-        print("")
-        print(mock_try_reg.call_args_list)
         mock_try_reg.assert_called_once_with(
             documents_to_get, _get_relation_data,
             mock_fetch, ArticleFactory
@@ -1141,6 +1140,47 @@ class TestRegisterDocuments(unittest.TestCase):
         )
         mock_set.assert_called_once_with(
             "orphan_documents",
+            ["6Msj5CPBZRbLL13V9MHSKmp", "LL13V9MHSKmp6Msj5CPBZRb"],
+            serialize_json=True
+        )
+
+
+@patch("sync_kernel_to_website.fetch_documents_renditions")
+@patch("sync_kernel_to_website.Variable.set")
+@patch("sync_kernel_to_website.Variable.get")
+@patch("sync_kernel_to_website.try_register_documents_renditions")
+@patch("sync_kernel_to_website.mongo_connect")
+class TestRegisterDocumentsRenditions(unittest.TestCase):
+
+    def setUp(self):
+        self.kwargs = {
+            "ti": MagicMock(),
+            "conf": None,
+            "run_id": "test_run_id",
+        }
+
+    def test__register_documents_renditions(self, mock_mongo, mock_try_reg,
+            mock_get,
+            mock_set, mock_fetch):
+        documents_to_get = [
+            "QTsr9VQHDd4DL5zqWqkwyjk", "LL13V9MHSKmp6Msj5CPBZRb"]
+        _get_relation_data = MagicMock(spec=callable)
+
+        mock_try_reg.return_value = ["LL13V9MHSKmp6Msj5CPBZRb"]
+        mock_get.return_value = ["6Msj5CPBZRbLL13V9MHSKmp"]
+
+        _register_documents_renditions(
+            documents_to_get, **self.kwargs)
+
+        mock_try_reg.assert_called_once_with(
+            documents_to_get,
+            mock_fetch, ArticleRenditionFactory
+        )
+        mock_get.assert_called_once_with(
+            "orphan_renditions", [], deserialize_json=True
+        )
+        mock_set.assert_called_once_with(
+            "orphan_renditions",
             ["6Msj5CPBZRbLL13V9MHSKmp", "LL13V9MHSKmp6Msj5CPBZRb"],
             serialize_json=True
         )

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -11,6 +11,7 @@ from sync_kernel_to_website import (
     _get_known_documents,
     _get_relation_data,
     _remodel_known_documents,
+    _get_relation_data_new,
 )
 from operations.sync_kernel_to_website_operations import (
     ArticleFactory,
@@ -839,6 +840,121 @@ class TestGetRelationData(unittest.TestCase):
         expected = (None, {})
         result = _get_relation_data(known_documents, document_id)
         self.assertEqual(expected, result)
+
+
+class TestGetRelationDataNew(unittest.TestCase):
+
+    def test__get_relation_data_new_returns_None(self):
+        known_documents = {
+            "issue_id": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ],
+            "issue_id_2": [
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ]
+        }
+        document_id = "HJgFV9MHSKmp6Msj5CPBZRb"
+        expected = None
+        result = _get_relation_data_new(known_documents, document_id)
+        self.assertEqual(expected, result)
+
+    def test__get_relation_data_new_returns_none_and_no_docs(self):
+        known_documents = {}
+        document_id = "AAAAAAMHSKmp6Msj5CPBZRb"
+        expected = (None, {})
+        result = _get_relation_data_new(known_documents, document_id)
+        self.assertEqual(expected, result)
+
+    def test__get_relation_data_new_returns_bundle_and_document(self):
+        known_documents = {
+            "RCgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CGgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LLgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+            "RC13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CG13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJ13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LL13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+        }
+        document_id = "HJgFV9MHSKmp6Msj5CPBZRb"
+        expected = (
+            "issue_id",
+            {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"}
+        )
+        result = _get_relation_data_new(known_documents, document_id)
+        self.assertEqual(expected, result)
+
+    @patch("sync_kernel_to_website.isinstance")
+    def test__get_relation_data_new_calls_isinstance_once(self, mock_isinstance):
+        known_documents = {
+            "RCgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CGgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LLgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+            "RC13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CG13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJ13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LL13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+        }
+        document_id = "AAAAAAMHSKmp6Msj5CPBZRb"
+        expected = (None, {})
+        result = _get_relation_data_new(known_documents, document_id)
+        self.assertEqual(expected, result)
+        mock_isinstance.assert_called_once()
 
 
 class TestRemodelKnownDocuments(unittest.TestCase):

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -1273,7 +1273,7 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
         }
 
         # chamada para a função que está sob teste
-        register_documents_subdag(mock_dag, args, **self.kwargs)
+        register_documents_subdag(mock_dag, args)
 
         # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
         # chamada com os parâmetros esperados
@@ -1348,7 +1348,7 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
         renditions_to_get = set()
 
         # chamada para a função que está sob teste
-        register_documents_subdag(mock_dag, args, **self.kwargs)
+        register_documents_subdag(mock_dag, args)
 
         # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
         # chamada com os parâmetros esperados
@@ -1426,7 +1426,7 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
         }
 
         # chamada para a função que está sob teste
-        register_documents_subdag(mock_dag, args, **self.kwargs)
+        register_documents_subdag(mock_dag, args)
 
         # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
         # chamada com os parâmetros esperados
@@ -1492,7 +1492,7 @@ class TestRegisterDocumentsSubDag(unittest.TestCase):
         renditions_to_get = set()
 
         # chamada para a função que está sob teste
-        register_documents_subdag(mock_dag, args, **self.kwargs)
+        register_documents_subdag(mock_dag, args)
 
         # testa se `create_subdag_to_register_documents_grouped_by_bundle` foi
         # chamada com os parâmetros esperados

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -1057,4 +1057,3 @@ class TestRemodelKnownDocuments(unittest.TestCase):
         }
         result = _remodel_known_documents(known_documents)
         self.assertEqual(expected, result)
-

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -12,6 +12,7 @@ from sync_kernel_to_website import (
     _get_relation_data,
     _remodel_known_documents,
     _get_relation_data_new,
+    _get_relation_data_old,
 )
 from operations.sync_kernel_to_website_operations import (
     ArticleFactory,
@@ -955,6 +956,52 @@ class TestGetRelationDataNew(unittest.TestCase):
         result = _get_relation_data_new(known_documents, document_id)
         self.assertEqual(expected, result)
         mock_isinstance.assert_called_once()
+
+
+class TestGetRelationDataOld(unittest.TestCase):
+
+    def test__get_relation_data_old_returns_bundle_and_document(self):
+        known_documents = {
+            "issue_id": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ],
+            "issue_id_2": [
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ]
+        }
+        document_id = "HJgFV9MHSKmp6Msj5CPBZRb"
+        expected = (
+            "issue_id",
+            {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"}
+        )
+        result = _get_relation_data_old(known_documents, document_id)
+        self.assertEqual(expected, result)
+
+    def test__get_relation_data_old_returns_none_and_no_docs(self):
+        known_documents = {
+            "issue_id": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ],
+            "issue_id_2": [
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ]
+        }
+        document_id = "AAAAAAMHSKmp6Msj5CPBZRb"
+        expected = (None, {})
+        result = _get_relation_data_old(known_documents, document_id)
+        self.assertEqual(expected, result)
 
 
 class TestRemodelKnownDocuments(unittest.TestCase):

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -586,7 +586,7 @@ class RegisterDocumentRenditionsTest(unittest.TestCase):
 @patch("sync_kernel_to_website.fetch_bundles")
 class TestGetKnownDocuments(unittest.TestCase):
 
-    def test__get_known_documents_(
+    def test__get_known_documents_adds_and_returns_new_issue_and_its_documents_in_input_dict(
             self, mock_fetch_bundles, mock_filter_changes):
         mock_issue = {
             "_id": "0001-3714-1999-v60-n2",
@@ -630,3 +630,81 @@ class TestGetKnownDocuments(unittest.TestCase):
 
         result = _get_known_documents(known_documents, tasks)
         self.assertDictEqual(expected, result)
+        self.assertIs(known_documents, result)
+
+    def test__get_known_documents_adds_and_returns_new_issue_and_no_documents_in_input_dict(
+            self, mock_fetch_bundles, mock_filter_changes):
+        mock_issue = {}
+        mock_fetch_bundles.side_effect = [mock_issue]
+        mock_filter_changes.return_value = [
+            {
+                "id": "/bundles/0001-3714-1999-v60-n2",
+                "timestamp": "2020-11-05T16:54:12.236462Z",
+                "change_id": "5fa42e34c1e393cec121d6b5"
+
+            },
+        ]
+        tasks = MagicMock()
+        known_documents = {
+            "0001-3714-1998-v29-n3": [],
+        }
+        expected = {
+            "0001-3714-1998-v29-n3": [],
+            "0001-3714-1999-v60-n2": [],
+        }
+
+        result = _get_known_documents(known_documents, tasks)
+        self.assertDictEqual(expected, result)
+
+    def test__get_known_documents_returns_unchanged_input_dict(
+            self, mock_fetch_bundles, mock_filter_changes):
+        mock_filter_changes.return_value = []
+        tasks = MagicMock()
+        known_documents = {
+            "0001-3714-1998-v29-n3": [],
+        }
+        expected = known_documents.copy()
+
+        result = _get_known_documents(known_documents, tasks)
+        self.assertDictEqual(expected, result)
+
+    def test__get_known_documents_do_nothing_because_input_dict_has_already_documents(
+            self, mock_fetch_bundles, mock_filter_changes):
+        mock_issue = {
+            "_id": "0001-3714-1999-v60-n2",
+            "id": "0001-3714-1999-v60-n2",
+            "created": "2020-10-06T15:15:04.310621Z",
+            "updated": "2020-10-06T15:15:04.311271Z",
+            "items": [
+                {"id": "9CgFRVMHSKmp6Msj5CPBZRb", "order": "00502"},
+                {"id": "c4H4TjsZS7YzjTjyYD5f5Ct", "order": "00501"},
+                {"id": "QXJwLFnG565Prww5YdqqpTq", "order": "00504"},
+            ],
+            "metadata": {
+                "publication_months": {"range": [9, 10]},
+                "publication_year": "2020",
+                "volume": "67",
+                "number": "5",
+                "pid": "0034-737X20200005"
+            }
+        }
+        mock_fetch_bundles.side_effect = [mock_issue]
+        mock_filter_changes.return_value = [
+            {
+                "id": "/bundles/0001-3714-1999-v60-n2",
+                "timestamp": "2020-11-05T16:54:12.236462Z",
+                "change_id": "5fa42e34c1e393cec121d6b5"
+
+            },
+        ]
+        tasks = MagicMock()
+        known_documents = {
+            "0001-3714-1999-v60-n2": [
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ],
+        }
+        expected = known_documents.copy()
+
+        result = _get_known_documents(known_documents, tasks)
+        self.assertDictEqual(expected, result)
+        self.assertIs(known_documents, result)

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -1064,8 +1064,6 @@ class TestRemodelKnownDocuments(unittest.TestCase):
 
 
 @patch("sync_kernel_to_website.fetch_documents_front")
-@patch("sync_kernel_to_website.Variable.set")
-@patch("sync_kernel_to_website.Variable.get")
 @patch("sync_kernel_to_website.try_register_documents")
 @patch("sync_kernel_to_website.mongo_connect")
 class TestRegisterDocuments(unittest.TestCase):
@@ -1077,14 +1075,13 @@ class TestRegisterDocuments(unittest.TestCase):
             "run_id": "test_run_id",
         }
 
-    def test__register_documents(self, mock_mongo, mock_try_reg, mock_get,
-            mock_set, mock_fetch):
+    def test__register_documents(self, mock_mongo, mock_try_reg, 
+            mock_fetch):
         documents_to_get = [
             "QTsr9VQHDd4DL5zqWqkwyjk", "LL13V9MHSKmp6Msj5CPBZRb"]
         _get_relation_data = MagicMock(spec=callable)
 
         mock_try_reg.return_value = ["LL13V9MHSKmp6Msj5CPBZRb"]
-        mock_get.return_value = ["6Msj5CPBZRbLL13V9MHSKmp"]
 
         _register_documents(
             documents_to_get, _get_relation_data, **self.kwargs)
@@ -1093,19 +1090,13 @@ class TestRegisterDocuments(unittest.TestCase):
             documents_to_get, _get_relation_data,
             mock_fetch, ArticleFactory
         )
-        mock_get.assert_called_once_with(
-            "orphan_documents", [], deserialize_json=True
-        )
-        mock_set.assert_called_once_with(
-            "orphan_documents",
-            ["6Msj5CPBZRbLL13V9MHSKmp", "LL13V9MHSKmp6Msj5CPBZRb"],
-            serialize_json=True
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key="orphan_documents",
+            value=["LL13V9MHSKmp6Msj5CPBZRb"]
         )
 
 
 @patch("sync_kernel_to_website.fetch_documents_renditions")
-@patch("sync_kernel_to_website.Variable.set")
-@patch("sync_kernel_to_website.Variable.get")
 @patch("sync_kernel_to_website.try_register_documents_renditions")
 @patch("sync_kernel_to_website.mongo_connect")
 class TestRegisterDocumentsRenditions(unittest.TestCase):
@@ -1118,14 +1109,12 @@ class TestRegisterDocumentsRenditions(unittest.TestCase):
         }
 
     def test__register_documents_renditions(self, mock_mongo, mock_try_reg,
-            mock_get,
-            mock_set, mock_fetch):
+            mock_fetch):
         documents_to_get = [
             "QTsr9VQHDd4DL5zqWqkwyjk", "LL13V9MHSKmp6Msj5CPBZRb"]
         _get_relation_data = MagicMock(spec=callable)
 
         mock_try_reg.return_value = ["LL13V9MHSKmp6Msj5CPBZRb"]
-        mock_get.return_value = ["6Msj5CPBZRbLL13V9MHSKmp"]
 
         _register_documents_renditions(
             documents_to_get, **self.kwargs)
@@ -1134,13 +1123,9 @@ class TestRegisterDocumentsRenditions(unittest.TestCase):
             documents_to_get,
             mock_fetch, ArticleRenditionFactory
         )
-        mock_get.assert_called_once_with(
-            "orphan_renditions", [], deserialize_json=True
-        )
-        mock_set.assert_called_once_with(
-            "orphan_renditions",
-            ["6Msj5CPBZRbLL13V9MHSKmp", "LL13V9MHSKmp6Msj5CPBZRb"],
-            serialize_json=True
+        self.kwargs["ti"].xcom_push.assert_called_once_with(
+            key="orphan_renditions",
+            value=["LL13V9MHSKmp6Msj5CPBZRb"]
         )
 
 

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -123,13 +123,19 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
         document_ids = ("XXX3V9MHSKmp6Msj5CPBZRb", )
         renditions_documents_id = ("XXX3V9MHSKmp6Msj5CPBZRb", )
-
+        mock_get_data = MagicMock()
+        mock_get_data.return_value = [
+            document_ids,
+            renditions_documents_id,
+            self.mock_get_relation_data_which_returns_none
+        ]
         create_subdag_to_register_documents_grouped_by_bundle(
-            self.mock_dag, self.mock_register_docs_callable,
-            document_ids, self.mock_get_relation_data_which_returns_none,
-            self.mock_register_renditions_callable, renditions_documents_id,
+            self.mock_dag,
+            self.mock_register_docs_callable,
+            self.mock_register_renditions_callable,
+            mock_get_data,
             self.mock_args,
-            )
+        )
 
         calls = [
             call(
@@ -159,12 +165,19 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
             "CGgFV9MHSKmp6Msj5CPBZRb"
         ]
         renditions_documents_id = []
+        mock_get_data = MagicMock()
+        mock_get_data.return_value = [
+            document_ids,
+            renditions_documents_id,
+            self.mock_get_relation_data
+        ]
         create_subdag_to_register_documents_grouped_by_bundle(
-            self.mock_dag, self.mock_register_docs_callable,
-            document_ids, self.mock_get_relation_data,
-            self.mock_register_renditions_callable, renditions_documents_id,
+            self.mock_dag,
+            self.mock_register_docs_callable,
+            self.mock_register_renditions_callable,
+            mock_get_data,
             self.mock_args,
-            )
+        )
 
         calls = [
             call(
@@ -211,10 +224,17 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
             "LL13V9MHSKmp6Msj5CPBZRb",
             "HJgFV9MHSKmp6Msj5CPBZRb",
         ]
+        mock_get_data = MagicMock()
+        mock_get_data.return_value = [
+            document_ids,
+            renditions_documents_id,
+            self.mock_get_relation_data
+        ]
         create_subdag_to_register_documents_grouped_by_bundle(
-            self.mock_dag, self.mock_register_docs_callable,
-            document_ids, self.mock_get_relation_data,
-            self.mock_register_renditions_callable, renditions_documents_id,
+            self.mock_dag,
+            self.mock_register_docs_callable,
+            self.mock_register_renditions_callable,
+            mock_get_data,
             self.mock_args,
             )
 
@@ -281,10 +301,17 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
             "LL13V9MHSKmp6Msj5CPBZRb",
             "HJgFV9MHSKmp6Msj5CPBZRb",
         ]
+        mock_get_data = MagicMock()
+        mock_get_data.return_value = [
+            document_ids,
+            renditions_documents_id,
+            self.mock_get_relation_data
+        ]
         create_subdag_to_register_documents_grouped_by_bundle(
-            self.mock_dag, self.mock_register_docs_callable,
-            document_ids, self.mock_get_relation_data,
-            self.mock_register_renditions_callable, renditions_documents_id,
+            self.mock_dag,
+            self.mock_register_docs_callable,
+            self.mock_register_renditions_callable,
+            mock_get_data,
             self.mock_args,
             )
 

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -76,6 +76,7 @@ class TestGroupDocumentsByBundle(unittest.TestCase):
         self.assertEqual(expected, result)
 
 
+@patch("subdags.sync_kernel_to_website_subdag.finish")
 @patch("subdags.sync_kernel_to_website_subdag.DAG")
 @patch("subdags.sync_kernel_to_website_subdag.PythonOperator")
 class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
@@ -110,6 +111,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
     def test_create_subdag_to_register_documents_grouped_by_bundle_creates_subdag_with_dummy_task(self,
             mock_python_op, MockSubDAG,
+            mock_finish,
             ):
         # mock de DAG
         MockDAG = MagicMock(spec=DAG)
@@ -139,8 +141,9 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
         calls = [
             call(
-                task_id="register_documents_groups_id_do_nothing",
-                python_callable=ANY,
+                task_id="register_documents_groups_id_finish",
+                provide_context=True,
+                python_callable=mock_finish,
                 dag=mock_subdag,
             ),
         ]
@@ -148,6 +151,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
     def test_create_subdag_to_register_documents_grouped_by_bundle_creates_subdag_with_two_tasks(self,
             mock_python_op, MockSubDAG,
+            mock_finish,
             ):
         # mock de DAG
         MockDAG = MagicMock(spec=DAG)
@@ -181,6 +185,12 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
         calls = [
             call(
+                task_id='register_documents_groups_id_finish',
+                provide_context=True,
+                python_callable=mock_finish,
+                dag=mock_subdag,
+            ),
+            call(
                 task_id='register_documents_groups_id_issue_id_2_docs',
                 python_callable=self.mock_register_docs_callable,
                 op_args=(
@@ -203,6 +213,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
     def test_create_subdag_to_register_documents_grouped_by_bundle_creates_subdag_with_two_tasks_to_register_docs_and_other_two_to_register_renditions(self,
             mock_python_op, MockSubDAG,
+            mock_finish,
             ):
         # mock de DAG
         MockDAG = MagicMock(spec=DAG)
@@ -239,6 +250,12 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
             )
 
         calls = [
+            call(
+                task_id='register_documents_groups_id_finish',
+                provide_context=True,
+                python_callable=mock_finish,
+                dag=mock_subdag,
+            ),
             call(
                 task_id='register_documents_groups_id_issue_id_2_docs',
                 python_callable=self.mock_register_docs_callable,
@@ -284,6 +301,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
 
     def test_create_subdag_to_register_documents_grouped_by_bundle_creates_subdag_with_task_to_register_renditions(self,
             mock_python_op, MockSubDAG,
+            mock_finish,
             ):
         # mock de DAG
         MockDAG = MagicMock(spec=DAG)
@@ -316,6 +334,12 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
             )
 
         calls = [
+            call(
+                task_id='register_documents_groups_id_finish',
+                provide_context=True,
+                python_callable=mock_finish,
+                dag=mock_subdag,
+            ),
             call(
                 task_id='register_documents_groups_id_renditions',
                 python_callable=self.mock_register_renditions_callable,

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -206,6 +206,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
             "HJgFV9MHSKmp6Msj5CPBZRb",
             "CGgFV9MHSKmp6Msj5CPBZRb"
         ]
+        # nem todos os documents_id estão em ambas listas
         renditions_documents_id = [
             "LL13V9MHSKmp6Msj5CPBZRb",
             "HJgFV9MHSKmp6Msj5CPBZRb",
@@ -251,6 +252,50 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                 op_kwargs=(
                     {
                         "renditions_to_get": {
+                            "HJgFV9MHSKmp6Msj5CPBZRb",
+                        }
+                    }
+                ),
+                dag=mock_subdag,
+            ),
+        ]
+        self.assertListEqual(calls, mock_python_op.call_args_list)
+
+
+    def test_create_subdag_to_register_documents_grouped_by_bundle_creates_subdag_with_task_to_register_renditions(self,
+            mock_python_op, MockSubDAG,
+            ):
+        # mock de DAG
+        MockDAG = MagicMock(spec=DAG)
+
+        # instancia mock de DAG
+        mock_subdag = MockDAG(spec=DAG)
+
+        # mockSubDAG é mock da DAG que está em uso em
+        # `create_subdag_to_register_documents_grouped_by_bundle`
+        MockSubDAG.return_value = mock_subdag
+
+        # nem todos os documents_id estão em ambas listas
+        document_ids = []
+        renditions_documents_id = [
+            "LL13V9MHSKmp6Msj5CPBZRb",
+            "HJgFV9MHSKmp6Msj5CPBZRb",
+        ]
+        create_subdag_to_register_documents_grouped_by_bundle(
+            self.mock_dag, self.mock_register_docs_callable,
+            document_ids, self.mock_get_relation_data,
+            self.mock_register_renditions_callable, renditions_documents_id,
+            self.mock_args,
+            )
+
+        calls = [
+            call(
+                task_id='register_documents_groups_id_renditions',
+                python_callable=self.mock_register_renditions_callable,
+                op_kwargs=(
+                    {
+                        "renditions_to_get": {
+                            "LL13V9MHSKmp6Msj5CPBZRb",
                             "HJgFV9MHSKmp6Msj5CPBZRb",
                         }
                     }

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -1,0 +1,73 @@
+import unittest
+
+
+from subdags.sync_kernel_to_website_subdag import (
+    _group_documents_by_bundle,
+)
+
+
+class TestGroupDocumentsByBundle(unittest.TestCase):
+
+    def mock_get_relation_data(self, doc_id):
+        data = {
+            "RCgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "RCgFV9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CGgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "CGgFV9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "HJgFV9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LLgFV9MHSKmp6Msj5CPBZRb": (
+                "issue_id",
+                {"id": "LLgFV9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+            "RC13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "RC13V9MHSKmp6Msj5CPBZRb", "order": "00602"},
+            ),
+            "CG13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "CG13V9MHSKmp6Msj5CPBZRb", "order": "00604"},
+            ),
+            "HJ13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "HJ13V9MHSKmp6Msj5CPBZRb", "order": "00607"},
+            ),
+            "LL13V9MHSKmp6Msj5CPBZRb": (
+                "issue_id_2",
+                {"id": "LL13V9MHSKmp6Msj5CPBZRb", "order": "00609"},
+            ),
+        }
+        return data.get(doc_id)
+
+    def test__group_documents_by_bundle(self):
+        document_ids = (
+            "LL13V9MHSKmp6Msj5CPBZRb",
+            "HJgFV9MHSKmp6Msj5CPBZRb",
+            "CGgFV9MHSKmp6Msj5CPBZRb",
+        )
+
+        expected = {
+            "issue_id_2": ["LL13V9MHSKmp6Msj5CPBZRb"],
+            "issue_id": ["HJgFV9MHSKmp6Msj5CPBZRb", "CGgFV9MHSKmp6Msj5CPBZRb"],
+        }
+        result = _group_documents_by_bundle(
+            document_ids, self.mock_get_relation_data)
+        self.assertEqual(expected, result)
+
+    def test__group_documents_by_bundle_returns_empty_dict(self):
+        def mock_get_relation_data(doc_id):
+            return (None, {})
+
+        document_ids = (
+            "XXX3V9MHSKmp6Msj5CPBZRb",
+        )
+        expected = {}
+        result = _group_documents_by_bundle(
+            document_ids, mock_get_relation_data)
+        self.assertEqual(expected, result)


### PR DESCRIPTION
#### O que esse PR faz?
Substitui as tasks de registro documentos e a de registro de renditions por uma subdag para facilitar em caso de falha, reprocessar apenas os grupos que obtiveram falhas.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Execute a sincronização do kernel para o website, ou seja, dispare a DAG `sync_kernel_to_website`, mas antes observe o valor da variável `change_timestamp` que indica a data inicial a partir de quando obter as mudanças no kernel (se colocar uma data muito recente poderá não obter nenhum dado)

#### Algum cenário de contexto que queira dar?
Os grupos de documentos (ID de documentos) foi feito por _bundle_  pois a tendência é que se o documento de um _bundle_ falhar, possivelmente os demais também. Após a divisão em grupos, para cada grupo é executada a sequência de registro de documentos e depois registro de seus respectivos renditions. 
Poderia ocorrer de itens que estão em `renditions` mas não estão em `documents`. Eles também são registrados ao final.

### Screenshots
<img width="500" alt="Captura de Tela 2020-11-12 às 10 14 37" src="https://user-images.githubusercontent.com/505143/98944537-f4debb80-24cf-11eb-98f5-95ccdd07ad13.png">

ZOOM
<img width="451" alt="Captura de Tela 2020-11-12 às 10 14 53" src="https://user-images.githubusercontent.com/505143/98944531-f314f800-24cf-11eb-917d-94b038152d89.png">

#### Quais são tickets relevantes?
#241

### Referências
n/a