### PR TITLE
Ajusta a data de publicação do formato "31 01 2019" para "2019-01-31".

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -237,7 +237,14 @@ def ArticleFactory(
     ]
 
     article.original_language = _get_original_language(data)
-    article.publication_date = _nestget(data, "pub_date", 0, "text", 0)
+    publication_date = _nestget(data, "pub_date", 0, "text", 0)
+
+    if publication_date:
+        publication_date_list = publication_date.split(" ")
+        publication_date_list.reverse()
+        publication_date = "-".join(publication_date_list)
+
+    article.publication_date = publication_date
 
     article.type = _nestget(data, "article", 0, "type", 0)
 
@@ -284,13 +291,13 @@ def try_register_documents(
     relação serão considerados órfãos.
 
     Args:
-        documents (Iterable): iterável com os identicadores dos documentos 
+        documents (Iterable): iterável com os identicadores dos documentos
             a serem registrados.
-        get_relation_data (callable): função que identifica o fasículo 
+        get_relation_data (callable): função que identifica o fasículo
             e o item de relacionamento que está sendo registrado.
-        fetch_document_front (callable): função que recupera os dados de 
+        fetch_document_front (callable): função que recupera os dados de
             `front` do documento a partir da API do Kernel.
-        article_factory (callable): função que cria uma instância do modelo 
+        article_factory (callable): função que cria uma instância do modelo
             de dados do Artigo na base do OPAC.
 
     Returns:
@@ -356,11 +363,11 @@ def ArticleRenditionFactory(article_id: str, data: List[dict]) -> models.Article
     A partir do article_id uma instância de Artigo é recuperada da base OPAC e
     seus assets são populados. Se o Artigo não existir na base OPAC a exceção
     models.ArticleDoesNotExists é lançada.
-    
+
     Args:
         article_id (str): Identificador do artigo a ser recuperado
         data (List[dict]): Lista de renditions do artigo
-    
+
     Returns:
         models.Article: Artigo recuperado e atualizado com uma nova lista de assets."""
 
@@ -389,7 +396,7 @@ def try_register_documents_renditions(
     órfãos.
 
     Args:
-        documents (Iterable): iterável com os identicadores dos documentos 
+        documents (Iterable): iterável com os identicadores dos documentos
             a serem registrados.
         get_rendition_data (callable): Recupera os dados de manifestações
             de um documento.

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -296,7 +296,103 @@ class ArticleFactoryTests(unittest.TestCase):
 
     def test_has_publication_date_attribute(self):
         self.assertTrue(hasattr(self.document, "publication_date"))
-        self.assertEqual("31 01 2019", self.document.publication_date)
+        self.assertEqual("2019-01-31", self.document.publication_date)
+
+    def test_has_publication_date_attribute_with_just_year(self):
+
+        document_dict = {"pub_date": [
+                          {
+                            "text": [
+                              "2019"
+                            ],
+                            "pub_type": [
+                              "epub"
+                            ],
+                            "pub_format": [],
+                            "date_type": [],
+                            "day": [
+                              "31"
+                            ],
+                            "month": [
+                              "01"
+                            ],
+                            "year": [
+                              "2019"
+                            ],
+                            "season": []
+                          }
+                        ]}
+
+        document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", document_dict, "issue-1", 621, ""
+        )
+
+        self.assertTrue(hasattr(document, "publication_date"))
+        self.assertEqual("2019", document.publication_date)
+
+    def test_has_publication_date_attribute_with_just_month(self):
+
+        document_dict = {"pub_date": [
+                          {
+                            "text": [
+                              "01"
+                            ],
+                            "pub_type": [
+                              "epub"
+                            ],
+                            "pub_format": [],
+                            "date_type": [],
+                            "day": [
+                              "31"
+                            ],
+                            "month": [
+                              "01"
+                            ],
+                            "year": [
+                              "2019"
+                            ],
+                            "season": []
+                          }
+                        ]}
+
+        document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", document_dict, "issue-1", 621, ""
+        )
+
+        self.assertTrue(hasattr(document, "publication_date"))
+        self.assertEqual("01", document.publication_date)
+
+    def test_has_publication_date_attribute_with_just_month_year(self):
+
+        document_dict = {"pub_date": [
+                          {
+                            "text": [
+                              "01 2019"
+                            ],
+                            "pub_type": [
+                              "epub"
+                            ],
+                            "pub_format": [],
+                            "date_type": [],
+                            "day": [
+                              "31"
+                            ],
+                            "month": [
+                              "01"
+                            ],
+                            "year": [
+                              "2019"
+                            ],
+                            "season": []
+                          }
+                        ]}
+
+        document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", document_dict, "issue-1", 621, ""
+        )
+
+        self.assertTrue(hasattr(document, "publication_date"))
+        self.assertEqual("2019-01", document.publication_date)
 
     def test_has_type_attribute(self):
         self.assertTrue(hasattr(self.document, "type"))
@@ -1075,7 +1171,7 @@ class TestRegisterDocuments(unittest.TestCase):
             "run_id": "test_run_id",
         }
 
-    def test__register_documents(self, mock_mongo, mock_try_reg, 
+    def test__register_documents(self, mock_mongo, mock_try_reg,
             mock_fetch):
         documents_to_get = [
             "QTsr9VQHDd4DL5zqWqkwyjk", "LL13V9MHSKmp6Msj5CPBZRb"]


### PR DESCRIPTION
#### O que esse PR faz?
Ajusta a data de publicação do artigo "pub" para um formato esperado pelo site ``yyyy-mm-dd``.

#### Onde a revisão poderia começar?

Através módulo: `sync_kernel_to_website_operations.py`

#### Como este poderia ser testado manualmente?

Realizando manualmente a execução da **dag** de sincronização com o site.

`docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest -v`

#### Algum cenário de contexto que queira dar?

A data é utilizada nos seguintes trechos do site: 

https://github.com/scieloorg/opac/search?q=publication_date

### Screenshots
N/A

#### Quais são tickets relevantes?

https://github.com/scieloorg/opac/issues/1665

### Referências
N/A