### PR TITLE
Corrige verificação de valores do dicionário known_documents

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -701,12 +701,13 @@ def _get_relation_data_new(known_documents, document_id: str) -> Tuple[str, Dict
     if data:
         return data
     for value in known_documents.values():
-        if isinstance(value, list):
-            # old format of known_documents
-            # `_get_relation_data_old`
-            raise OldFormatKnownDocsError("Formato antigo de known_documents")
-        else:
-            return (None, {})
+        if value:
+            if all([isinstance(doc, dict) for doc in value]):
+                # old format of known_documents
+                # `_get_relation_data_old`
+                raise OldFormatKnownDocsError("Formato antigo de known_documents")
+            else:
+                return (None, {})
     return (None, {})
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Obtém um dos valores do dicionário que tem lista não vazia. Se os itens  da lista forem todos dicionários, é o formato antigo e lança a exceção para que a leitura seja feita de forma adequada. Caso contrário, retorna `(None, {})` pois não foi possível encontrar o PID do documento em `known_documents`, que está no novo formato.

#### Onde a revisão poderia começar?
Commit da654ee

#### Como este poderia ser testado manualmente?
1. Insira novos documentos no Kernel
2. Execute a DAG `sync_kernel_to_website`
3. Verifique se a DAG conclui com sucesso

#### Algum cenário de contexto que queira dar?
.

### Screenshots
N/A

#### Quais são tickets relevantes?
#246 

### Referências
.