### PR TITLE
Troca `lxml.etree.Error` por `etree.XMLSyntaxError, etree.Error`

### DIFF
--- a/airflow/dags/operations/docs_utils.py
+++ b/airflow/dags/operations/docs_utils.py
@@ -66,12 +66,12 @@ def get_document_sps_package(current_version):
         return SPS_Package(xml_tree, '')
     except (
             AttributeError,
-            lxml.etree.Error,
+            etree.XMLSyntaxError,
+            etree.Error,
             ) as e:
         raise GetSPSPackageFromDocManifestException(
-                "Unable to get SPS Package of %s: %s",
-                current_version["data"],
-                e
+                "Unable to get SPS Package of %s: %s" %
+                (current_version["data"], e)
             )
 
 


### PR DESCRIPTION
#### O que esse PR faz?
Troca `lxml.etree.Error` por `etree.XMLSyntaxError`, `etree.Error`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Veja #250

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#250

### Referências
n/a
