### PR TITLE
Adiciona retentativa em registro de documentos na sincronização do Kernel com o site

### DIFF
--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import timedelta
 
 from airflow import DAG
 from airflow.models import Variable
@@ -73,6 +74,8 @@ def create_subdag_to_register_documents_grouped_by_bundle(
                 task_id=task_id,
                 python_callable=register_docs_callable,
                 op_args=(doc_ids, _get_relation_data),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=dag_subdag,
             )
 
@@ -88,6 +91,8 @@ def create_subdag_to_register_documents_grouped_by_bundle(
                     task_id=task_id,
                     python_callable=register_renditions_callable,
                     op_kwargs={'renditions_to_get': _renditions_documents_id},
+                    retries=1,
+                    retry_delay=timedelta(minutes=1),
                     dag=dag_subdag,
                 )
                 t1 >> t2 >> t_finish

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import timedelta
 from unittest.mock import MagicMock, patch, call, ANY
 
 from airflow import DAG
@@ -197,6 +198,8 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                     ["LL13V9MHSKmp6Msj5CPBZRb"],
                     self.mock_get_relation_data
                 ),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=mock_subdag,
             ),
             call(
@@ -206,6 +209,8 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                     ["HJgFV9MHSKmp6Msj5CPBZRb", "CGgFV9MHSKmp6Msj5CPBZRb"],
                     self.mock_get_relation_data
                 ),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=mock_subdag,
             ),
         ]
@@ -263,6 +268,8 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                     ["LL13V9MHSKmp6Msj5CPBZRb"],
                     self.mock_get_relation_data
                 ),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=mock_subdag,
             ),
             call(
@@ -271,6 +278,8 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                 op_kwargs=(
                     {"renditions_to_get": {"LL13V9MHSKmp6Msj5CPBZRb"}}
                 ),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=mock_subdag,
             ),
 
@@ -281,6 +290,8 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                     ["HJgFV9MHSKmp6Msj5CPBZRb", "CGgFV9MHSKmp6Msj5CPBZRb"],
                     self.mock_get_relation_data
                 ),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=mock_subdag,
             ),
             call(
@@ -293,6 +304,8 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                         }
                     }
                 ),
+                retries=1,
+                retry_delay=timedelta(minutes=1),
                 dag=mock_subdag,
             ),
         ]


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona retentativa para as tarefas de `register_documents_groups_id_<bundle_id>_docs` e `register_documents_groups_id_<bundle_id>_renditions` da DAG de sincronização do Kernel com o site. Esta tarefa de retentativa está hoje sendo feita manualmente e, muitas vezes, uma retentativa é suficiente para que a tarefa seja executada com sucesso.

#### Onde a revisão poderia começar?
Commit efb2745.

#### Como este poderia ser testado manualmente?
1. Certifique-se de ter mudanças de documentos registradas no Kernel que não foram aplicadas à sua instância do site
2. Execute a DAG `sync_kernel_to_website`
3. Simule uma falha na conexão com o Kernel durante a execução da subdag `sync_kernel_to_website.register_documents_groups_id`. Ex: se estiver rodando em Docker, pare o conteiner do Kernel.
4. Espere a subdag `sync_kernel_to_website.register_documents_groups_id` falhar.
5. Verifique os logs das tarefas da subdag que falharam. Devem haver 2 registros de execução, como no exemplo de screenshot [1]:

#### Algum cenário de contexto que queira dar?
Este PR não resolve todos os problemas que vem ocorrendo durante a sincronização do kernel com o site na migração dos conteúdos.

### Screenshots
[1] - Identificação de 2 registros de execução da tarefa

![Screen Shot 2020-12-15 at 12 17 28](https://user-images.githubusercontent.com/18053487/102234068-ac9c2a00-3ecf-11eb-8d6d-5b9211b152a8.png)

#### Quais são tickets relevantes?
n/a

### Referências
https://airflow.apache.org/docs/apache-airflow/stable/_api/airflow/models/index.html#airflow.models.BaseOperator.