### PR TITLE
[sync_kernel_to_website] corrige bug que deixa de registrar os órfãos

### DIFF
--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -166,24 +166,15 @@ def finish(bundles, orphan_documents, orphan_renditions, **kwargs):
         task_ids="register_documents_groups_id_renditions") or []
 
     if t1_orphan_documents:
-        try:
-            Variable.set(
-                "orphan_documents", t1_orphan_documents, serialize_json=True)
-        except Exception as e:
-            # sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
-            # could not connect to server: Connection refused
-            Logger.info("%s", e)
-    Logger.info("Finish %i orphan_documents", len(t1_orphan_documents))
+        Variable.set(
+            "orphan_documents", t1_orphan_documents, serialize_json=True)
 
-    if t2_orphan_renditions or t3_orphan_renditions:
-        try:
-            orphan_renditions = t2_orphan_renditions + t3_orphan_renditions
-            Variable.set(
-                "orphan_renditions", orphan_renditions, serialize_json=True)
-        except Exception as e:
-            # sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
-            # could not connect to server: Connection refused
-            Logger.info("%s", e)
+    orphan_renditions = t2_orphan_renditions + t3_orphan_renditions
+    if orphan_renditions:
+        Variable.set(
+            "orphan_renditions", orphan_renditions, serialize_json=True)
+
+    Logger.info("Finish %i orphan_documents", len(t1_orphan_documents))
     Logger.info("Finish %i orphan_renditions", len(orphan_renditions))
     Logger.info("Finish - FIM")
     return True

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -91,7 +91,7 @@ def create_subdag_to_register_documents_grouped_by_bundle(
             task_id=task_id,
             provide_context=True,
             python_callable=finish,
-            op_args=(groups.keys(), orphan_documents, orphan_renditions),
+            op_args=(list(groups.keys()), orphan_documents, list(orphan_renditions)),
             dag=dag_subdag,
         )
 

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -10,15 +10,15 @@ PARENT_DAG_NAME = 'sync_kernel_to_website'
 
 
 def _group_documents_by_bundle(document_ids, _get_relation_data):
-    """Agrupa `document_ids` em grupos
+    """Agrupa `document_ids` em grupos usando `bundle_id`
+    Caso `bundle_id` is `None`, `doc_id` são órfãos
     """
     Logger.info("_group_documents_by_bundle")
     groups = {}
     for doc_id in document_ids:
         bundle_id, doc = _get_relation_data(doc_id)
-        if bundle_id:
-            groups[bundle_id] = groups.get(bundle_id) or []
-            groups[bundle_id].append(doc_id)
+        groups[bundle_id] = groups.get(bundle_id) or []
+        groups[bundle_id].append(doc_id)
     Logger.info("_group_documents_by_bundle: %i", len(groups))
     return groups
 

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -91,6 +91,7 @@ def create_subdag_to_register_documents_grouped_by_bundle(
             task_id=task_id,
             provide_context=True,
             python_callable=finish,
+            op_args=(groups.keys(), orphan_documents, orphan_renditions),
             dag=dag_subdag,
         )
 
@@ -145,44 +146,44 @@ def create_subdag_to_register_documents_grouped_by_bundle(
     return dag_subdag
 
 
-def finish(**kwargs):
+def finish(bundles, orphan_documents, orphan_renditions, **kwargs):
     Logger.info("Finish")
-    t1_orphan_documents = kwargs["ti"].xcom_pull(
-        key="orphan_documents", task_ids="t1") or []
-    t2_orphan_renditions = kwargs["ti"].xcom_pull(
-        key="orphan_renditions", task_ids="t2") or []
+
+    t1_orphan_documents = orphan_documents or []
+    for bundle_id in bundles:
+        t1_orphan_documents += kwargs["ti"].xcom_pull(
+            key="orphan_documents",
+            task_ids=f'register_documents_groups_id_{bundle_id}_docs') or []
+
+    t2_orphan_renditions = orphan_renditions or []
+    for bundle_id in bundles:
+        t2_orphan_renditions += kwargs["ti"].xcom_pull(
+            key="orphan_renditions",
+            task_ids=f'register_documents_groups_id_{bundle_id}_renditions') or []
+
     t3_orphan_renditions = kwargs["ti"].xcom_pull(
-        key="orphan_renditions", task_ids="t3") or []
+        key="orphan_renditions",
+        task_ids="register_documents_groups_id_renditions") or []
 
     if t1_orphan_documents:
         try:
-            orphan_documents = Variable.get(
-                "orphan_documents", [], deserialize_json=True)
-
-            orphan_documents += t1_orphan_documents
             Variable.set(
-                "orphan_documents", orphan_documents, serialize_json=True)
-            Logger.info("Finish %i orphan_documents", len(orphan_documents))
+                "orphan_documents", t1_orphan_documents, serialize_json=True)
         except Exception as e:
             # sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
             # could not connect to server: Connection refused
             Logger.info("%s", e)
+    Logger.info("Finish %i orphan_documents", len(t1_orphan_documents))
 
     if t2_orphan_renditions or t3_orphan_renditions:
         try:
-            orphan_renditions = Variable.get(
-                "orphan_renditions", [], deserialize_json=True)
-
-            orphan_renditions += t2_orphan_renditions + t3_orphan_renditions
+            orphan_renditions = t2_orphan_renditions + t3_orphan_renditions
             Variable.set(
                 "orphan_renditions", orphan_renditions, serialize_json=True)
-            Logger.info("Finish %i orphan_renditions", len(orphan_renditions))
         except Exception as e:
             # sqlalchemy.exc.OperationalError: (psycopg2.OperationalError)
             # could not connect to server: Connection refused
             Logger.info("%s", e)
-
+    Logger.info("Finish %i orphan_renditions", len(orphan_renditions))
     Logger.info("Finish - FIM")
     return True
-
-

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -149,32 +149,31 @@ def create_subdag_to_register_documents_grouped_by_bundle(
 def finish(bundles, orphan_documents, orphan_renditions, **kwargs):
     Logger.info("Finish")
 
-    t1_orphan_documents = orphan_documents or []
+    orphan_documents = orphan_documents or []
     for bundle_id in bundles:
-        t1_orphan_documents += kwargs["ti"].xcom_pull(
+        orphan_documents += kwargs["ti"].xcom_pull(
             key="orphan_documents",
             task_ids=f'register_documents_groups_id_{bundle_id}_docs') or []
 
-    t2_orphan_renditions = list(orphan_renditions) or []
+    orphan_renditions = list(orphan_renditions)
     for bundle_id in bundles:
-        t2_orphan_renditions += kwargs["ti"].xcom_pull(
+        orphan_renditions += kwargs["ti"].xcom_pull(
             key="orphan_renditions",
             task_ids=f'register_documents_groups_id_{bundle_id}_renditions') or []
 
-    t3_orphan_renditions = kwargs["ti"].xcom_pull(
+    orphan_renditions += kwargs["ti"].xcom_pull(
         key="orphan_renditions",
         task_ids="register_documents_groups_id_renditions") or []
 
-    if t1_orphan_documents:
+    if orphan_documents:
         Variable.set(
-            "orphan_documents", t1_orphan_documents, serialize_json=True)
+            "orphan_documents", orphan_documents, serialize_json=True)
 
-    orphan_renditions = t2_orphan_renditions + t3_orphan_renditions
     if orphan_renditions:
         Variable.set(
             "orphan_renditions", orphan_renditions, serialize_json=True)
 
-    Logger.info("Finish %i orphan_documents", len(t1_orphan_documents))
+    Logger.info("Finish %i orphan_documents", len(orphan_documents))
     Logger.info("Finish %i orphan_renditions", len(orphan_renditions))
     Logger.info("Finish - FIM")
     return True

--- a/airflow/dags/subdags/sync_kernel_to_website_subdag.py
+++ b/airflow/dags/subdags/sync_kernel_to_website_subdag.py
@@ -155,7 +155,7 @@ def finish(bundles, orphan_documents, orphan_renditions, **kwargs):
             key="orphan_documents",
             task_ids=f'register_documents_groups_id_{bundle_id}_docs') or []
 
-    t2_orphan_renditions = orphan_renditions or []
+    t2_orphan_renditions = list(orphan_renditions) or []
     for bundle_id in bundles:
         t2_orphan_renditions += kwargs["ti"].xcom_pull(
             key="orphan_renditions",

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -145,6 +145,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                 task_id="register_documents_groups_id_finish",
                 provide_context=True,
                 python_callable=mock_finish,
+                op_args=([], ["XXX3V9MHSKmp6Msj5CPBZRb"], ["XXX3V9MHSKmp6Msj5CPBZRb"]),
                 dag=mock_subdag,
             ),
         ]
@@ -189,6 +190,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                 task_id='register_documents_groups_id_finish',
                 provide_context=True,
                 python_callable=mock_finish,
+                op_args=(["issue_id_2", "issue_id"], [], []),
                 dag=mock_subdag,
             ),
             call(
@@ -255,6 +257,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                 task_id='register_documents_groups_id_finish',
                 provide_context=True,
                 python_callable=mock_finish,
+                op_args=(["issue_id_2", "issue_id"], [], []),
                 dag=mock_subdag,
             ),
             call(
@@ -339,6 +342,7 @@ class TestCreateSubdagToRegisterDocumentsGroupedByBundle(unittest.TestCase):
                 task_id='register_documents_groups_id_finish',
                 provide_context=True,
                 python_callable=mock_finish,
+                op_args=([], [], []),
                 dag=mock_subdag,
             ),
             call(

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -406,3 +406,83 @@ class TestFinish(unittest.TestCase):
         ]
         finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
         mock_set.assert_not_called()
+
+    @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
+    def test_finish_set_no_bundles_and_orphan_docs(self, mock_set):
+        bundles = []
+        orphan_documents = ['LL13V9MHSKmp6Msj5CPBZRb']
+        orphan_renditions = {}
+
+        issue_id_1__orphan_docs = None
+        issue_id_1__orphan_rends = None
+        issue_id_2__orphan_docs = None
+        issue_id_2__orphan_rends = None
+        _orphan_rends = None
+
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            issue_id_1__orphan_docs,
+            issue_id_2__orphan_docs,
+            issue_id_1__orphan_rends,
+            issue_id_2__orphan_rends,
+            _orphan_rends,
+        ]
+        finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
+        calls = [
+            call("orphan_documents",
+                 ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
+        ]
+        self.assertListEqual(calls, mock_set.call_args_list)
+
+    @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
+    def test_finish_set_no_bundles_and_orphan_docs_and_rends(self, mock_set):
+        bundles = []
+        orphan_documents = ['LL13V9MHSKmp6Msj5CPBZRb']
+        orphan_renditions = {'LL13V9MHSKmp6Msj5CPBZRb'}
+
+        issue_id_1__orphan_docs = None
+        issue_id_1__orphan_rends = None
+        issue_id_2__orphan_docs = None
+        issue_id_2__orphan_rends = None
+        _orphan_rends = None
+
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            issue_id_1__orphan_docs,
+            issue_id_2__orphan_docs,
+            issue_id_1__orphan_rends,
+            issue_id_2__orphan_rends,
+            _orphan_rends,
+        ]
+        finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
+        calls = [
+            call("orphan_documents",
+                 ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
+            call("orphan_renditions",
+                 ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
+        ]
+        self.assertListEqual(calls, mock_set.call_args_list)
+
+    @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
+    def test_finish_set_no_bundles_and_orphan_rends(self, mock_set):
+        bundles = []
+        orphan_documents = []
+        orphan_renditions = {'LL13V9MHSKmp6Msj5CPBZRb'}
+
+        issue_id_1__orphan_docs = None
+        issue_id_1__orphan_rends = None
+        issue_id_2__orphan_docs = None
+        issue_id_2__orphan_rends = None
+        _orphan_rends = None
+
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            issue_id_1__orphan_docs,
+            issue_id_2__orphan_docs,
+            issue_id_1__orphan_rends,
+            issue_id_2__orphan_rends,
+            _orphan_rends,
+        ]
+        finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
+        calls = [
+            call("orphan_renditions",
+                 ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
+        ]
+        self.assertListEqual(calls, mock_set.call_args_list)

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -384,3 +384,25 @@ class TestFinish(unittest.TestCase):
         ]
         finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
         mock_set.assert_not_called()
+
+    @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
+    def test_finish_set_no_bundles_and_no_orphans(self, mock_set):
+        bundles = []
+        orphan_documents = []
+        orphan_renditions = {}
+
+        issue_id_1__orphan_docs = None
+        issue_id_1__orphan_rends = None
+        issue_id_2__orphan_docs = None
+        issue_id_2__orphan_rends = None
+        _orphan_rends = None
+
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            issue_id_1__orphan_docs,
+            issue_id_2__orphan_docs,
+            issue_id_1__orphan_rends,
+            issue_id_2__orphan_rends,
+            _orphan_rends,
+        ]
+        finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
+        mock_set.assert_not_called()

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -486,3 +486,50 @@ class TestFinish(unittest.TestCase):
                  ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
         ]
         self.assertListEqual(calls, mock_set.call_args_list)
+
+
+    @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
+    def test_finish_all_have_orphans(self, mock_set):
+        bundles = ['issue_id_1', 'issue_id_2']
+        orphan_documents = ['a113V9MHSKmp6Msj5CPBZRb']
+        orphan_renditions = [
+            'a2gFV9MHSKmp6Msj5CPBZRb', 'a3a3V9MHSKmp6Msj5CPBZRb']
+
+        issue_id_1__orphan_docs = [
+            'I1gFV9MHSKmp6Msj5CPBZRb', 'I113V9MHSKmp6Msj5CPBZRb']
+        issue_id_1__orphan_rends = [
+            'I1gFV9MHSKmp6Msj5CPBZRb', 'I113V9MHSKmp6Msj5CPBZRb']
+        issue_id_2__orphan_docs = [
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb']
+        issue_id_2__orphan_rends = [
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb']
+        _orphan_rends = ['I313V9MHSKmp6Msj5CPBZRb', 'I313xxxxxKmp6Msj5CPBZRb']
+
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            issue_id_1__orphan_docs,
+            issue_id_2__orphan_docs,
+            issue_id_1__orphan_rends,
+            issue_id_2__orphan_rends,
+            _orphan_rends,
+        ]
+
+        expected_orphan_documents = [
+            'a113V9MHSKmp6Msj5CPBZRb',
+            'I1gFV9MHSKmp6Msj5CPBZRb', 'I113V9MHSKmp6Msj5CPBZRb',
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb'
+        ]
+        expected_orphan_renditions = [
+            'a2gFV9MHSKmp6Msj5CPBZRb', 'a3a3V9MHSKmp6Msj5CPBZRb',
+            'I1gFV9MHSKmp6Msj5CPBZRb', 'I113V9MHSKmp6Msj5CPBZRb',
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb',
+            'I313V9MHSKmp6Msj5CPBZRb', 'I313xxxxxKmp6Msj5CPBZRb',
+        ]
+
+        finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
+        calls = [
+            call("orphan_documents",
+                 expected_orphan_documents, serialize_json=True),
+            call("orphan_renditions",
+                 expected_orphan_renditions, serialize_json=True),
+        ]
+        self.assertListEqual(calls, mock_set.call_args_list)

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -63,14 +63,14 @@ class TestGroupDocumentsByBundle(unittest.TestCase):
             document_ids, self.mock_get_relation_data)
         self.assertEqual(expected, result)
 
-    def test__group_documents_by_bundle_returns_empty_dict(self):
+    def test__group_documents_by_bundle_create_group_with_orphans_docs(self):
         def mock_get_relation_data(doc_id):
             return (None, {})
 
         document_ids = (
             "XXX3V9MHSKmp6Msj5CPBZRb",
         )
-        expected = {}
+        expected = {None: ["XXX3V9MHSKmp6Msj5CPBZRb"]}
         result = _group_documents_by_bundle(
             document_ids, mock_get_relation_data)
         self.assertEqual(expected, result)

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -431,11 +431,9 @@ class TestFinish(unittest.TestCase):
             _orphan_rends,
         ]
         finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
-        calls = [
-            call("orphan_documents",
-                 ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
-        ]
-        self.assertListEqual(calls, mock_set.call_args_list)
+        mock_set.assert_called_once_with(
+            "orphan_documents",
+            ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True)
 
     @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
     def test_finish_set_no_bundles_and_orphan_docs_and_rends(self, mock_set):
@@ -463,7 +461,7 @@ class TestFinish(unittest.TestCase):
             call("orphan_renditions",
                  ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
         ]
-        self.assertListEqual(calls, mock_set.call_args_list)
+        mock_set.assert_has_calls(calls)
 
     @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
     def test_finish_set_no_bundles_and_orphan_rends(self, mock_set):
@@ -485,12 +483,9 @@ class TestFinish(unittest.TestCase):
             _orphan_rends,
         ]
         finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
-        calls = [
-            call("orphan_renditions",
-                 ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True),
-        ]
-        self.assertListEqual(calls, mock_set.call_args_list)
-
+        mock_set.assert_called_once_with(
+            "orphan_renditions",
+            ['LL13V9MHSKmp6Msj5CPBZRb'], serialize_json=True)
 
     @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
     def test_finish_all_have_orphans(self, mock_set):

--- a/airflow/tests/test_sync_kernel_to_website_subdag.py
+++ b/airflow/tests/test_sync_kernel_to_website_subdag.py
@@ -533,3 +533,45 @@ class TestFinish(unittest.TestCase):
                  expected_orphan_renditions, serialize_json=True),
         ]
         self.assertListEqual(calls, mock_set.call_args_list)
+
+    @patch("subdags.sync_kernel_to_website_subdag.Variable.set")
+    def test_finish_one_bundle_has_no_orphans(self, mock_set):
+        bundles = ['issue_id_1', 'issue_id_2']
+        orphan_documents = ['a113V9MHSKmp6Msj5CPBZRb']
+        orphan_renditions = [
+            'a2gFV9MHSKmp6Msj5CPBZRb', 'a3a3V9MHSKmp6Msj5CPBZRb']
+
+        issue_id_1__orphan_docs = None
+        issue_id_1__orphan_rends = None
+        issue_id_2__orphan_docs = [
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb']
+        issue_id_2__orphan_rends = [
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb']
+        _orphan_rends = ['I313V9MHSKmp6Msj5CPBZRb', 'I313xxxxxKmp6Msj5CPBZRb']
+
+        self.kwargs["ti"].xcom_pull.side_effect = [
+            issue_id_1__orphan_docs,
+            issue_id_2__orphan_docs,
+            issue_id_1__orphan_rends,
+            issue_id_2__orphan_rends,
+            _orphan_rends,
+        ]
+
+        expected_orphan_documents = [
+            'a113V9MHSKmp6Msj5CPBZRb',
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb'
+        ]
+        expected_orphan_renditions = [
+            'a2gFV9MHSKmp6Msj5CPBZRb', 'a3a3V9MHSKmp6Msj5CPBZRb',
+            'i213V9MHSKmp6Msj5CPBZRb', 'i203V9MHSKmp6Msj5CPBZRb',
+            'I313V9MHSKmp6Msj5CPBZRb', 'I313xxxxxKmp6Msj5CPBZRb',
+        ]
+
+        finish(bundles, orphan_documents, orphan_renditions, **self.kwargs)
+        calls = [
+            call("orphan_documents",
+                 expected_orphan_documents, serialize_json=True),
+            call("orphan_renditions",
+                 expected_orphan_renditions, serialize_json=True),
+        ]
+        self.assertListEqual(calls, mock_set.call_args_list)


### PR DESCRIPTION
#### O que esse PR faz?
Na SubDag que registra os documentos e suas manifestações foi inserido um bug que deixa de registrar os órfãos (`orphan_documents` e `orphans_renditions`)

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Registrando em variáveis lista de órfãos e também incluindo para processar na DAG `sync_kernel_to_website` documentos que tenha órfãos (documents e renditions).
Ao final da DAG, verifique os valores de Variable. Os órfãos devem estar registrados em `orphan_documents` e `orphans_renditions`

#### Algum cenário de contexto que queira dar?
Este bug foi detectado ao revisar a fim de reduzir o tempo de processamento. (ticket original #248)

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
