### PR TITLE
Altera nível de mensagens de log de subdags

### DIFF
--- a/airflow/dags/subdags/check_website_subdags.py
+++ b/airflow/dags/subdags/check_website_subdags.py
@@ -13,18 +13,18 @@ Logger = logging.getLogger(__name__)
 
 
 def _group_documents_by_issue_pid_v2(args, default_uri_items=None):
-    Logger.info(args)
+    Logger.debug(args)
     try:
         uri_items = Variable.get(
             "_sci_arttext", default_var=[], deserialize_json=True)
-        Logger.info("Variable: %s", uri_items)
+        Logger.debug("Variable: %s", uri_items)
     except Exception:
         # sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) 
         # could not connect to server: Connection refused
         uri_items = args.get("_sci_arttext") or []
-        Logger.info("args: %s", uri_items)
+        Logger.debug("args: %s", uri_items)
     uri_items = uri_items or default_uri_items or []
-    Logger.info("create_subdag for %i", len(uri_items))
+    Logger.debug("create_subdag for %i", len(uri_items))
     return group_documents_by_issue_pid_v2(uri_items)
 
 
@@ -34,10 +34,10 @@ def create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(
     Cria uma subdag para executar check_documents_deeply em lotes menores
     para facilitar a reexecução
     """
-    Logger.info("Create check_documents_deeply subdag")
+    Logger.debug("Create check_documents_deeply subdag")
 
     groups = group_documents_callable(args)
-    Logger.info("%s", groups)
+    Logger.debug("%s", groups)
     parent_dag_name = 'check_website'
     child_dag_name = 'check_documents_deeply_grouped_by_issue_pid_v2_id'
 
@@ -49,14 +49,14 @@ def create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(
     # FIXME
     dag_run_data = {}
     with dag_subdag:
-        Logger.info("%i", len(groups.items()))
+        Logger.debug("%i", len(groups.items()))
         for k, uri_items in groups.items():
             id = k
             task_id = '{}_{}'.format(child_dag_name, id)
 
-            Logger.info("%s", k)
-            Logger.info("%s", uri_items)
-            Logger.info("%s", task_id)
+            Logger.debug("%s", k)
+            Logger.debug("%s", uri_items)
+            Logger.debug("%s", task_id)
 
             PythonOperator(
                 task_id=task_id,
@@ -65,7 +65,7 @@ def create_subdag_to_check_documents_deeply_grouped_by_issue_pid_v2(
                 dag=dag_subdag,
             )
         if not groups:
-            Logger.info("Do nothing")
+            Logger.debug("Do nothing")
             task_id = f'{child_dag_name}_do_nothing'
             PythonOperator(
                 task_id=task_id,

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -864,9 +864,9 @@ def register_documents_subdag_params(dag, args):
 
         return _get_relation_data_new(remodeled_known_documents, document_id)
 
-    logging.info("register_documents_subdag_params")
+    logging.debug("register_documents_subdag_params")
     try:
-        logging.info("Variable.get()")
+        logging.debug("Variable.get()")
         documents_to_get = Variable.get(
             "documents_to_get", [], deserialize_json=True)
         renditions_to_get = Variable.get(


### PR DESCRIPTION
#### O que esse PR faz?
Este PR altera o nível do log das mensagens nas funções de criação das SubDags `check_website.check_documents_deeply_grouped_by_issue_pid_v2_id` e `sync_kernel_to_website.register_documents_groups_id`, pois a execução delas está fazendo com que os arquivos de log cresçam muito.

#### Onde a revisão poderia começar?
Commit 14de163.

#### Como este poderia ser testado manualmente?
- Certifique-se que o nível de log da aplicação está como o de produção (INFO)
- Suba os serviços do Airflow usando o `docker-compose-dev`
- Verifique os arquivos de log nos caminhos `../airflow/logs/scheduler/2021-01-05/check_website.py.log` e `airflow/logs/scheduler/2021-01-05/sync_kernel_to_website.py.log`
- Observe que as mensagens com o nível alterado pelo PR não são mais registradas

#### Algum cenário de contexto que queira dar?
Foram alterados específicamente estes pontos pois são os que estão aumentando mais o volume de logs por conta do scheduler. Ainda faltam melhorias nos níveis de log da aplicação como um todo e entender melhor como os logs são produzidos pelo Airflow, para melhor usá-los.

### Screenshots
.

#### Quais são tickets relevantes?
#257

### Referências
.