### PR TITLE
Tk-262: Adiciona análise de ativos digitais identificados como ausentes na checagem de HTMLs

### DIFF
--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -752,6 +752,30 @@ def add_responses(doc_data_list, website_url=None, request=True, timeout=None):
         doc_data["response"] = responses.get(doc_data["uri"])
 
 
+def get_number_of_incomplete_html(incomplete, report):
+    """
+    Analisa os detalhes dos ativos digitais faltando no nível do documento, não das 
+    traduções, pois existem casos em que há ativos digitais diferentes para cada
+    idioma. Para considerar que não está faltando nada no documento, é necessário:
+
+    - Que todos os assets estejam em todos os HTMLs (mesmos assets para todos os 
+      idiomas)
+    - Que cada asset esteja apenas em um dos HTMLs (assets diferentes para cada idioma)
+    - Que haja links para PDFs em outros idiomas
+    - Que haja links para HTMLs em outros idiomas
+
+    Args:
+        incomplete: número de incompletos da análise no nível do HTML
+        report: dados de todos os HTMLs
+    Returns:
+        Número de HTMLs incompletos após análise.
+    """
+    if incomplete == 0 or len(report) == 1:
+        # Se não foram detectados HTMLs incompletos ou se há somente 1 HTML, o argumento
+        # ``incomplete`` já representa o número total de HTMLs incompletos
+        return incomplete
+
+
 def check_html_webpages_availability(html_data_items, assets_data, webpages_data, object_store_url):
     """
     Verifica também se os ativos digitais e outras

--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -775,6 +775,63 @@ def get_number_of_incomplete_html(incomplete, report):
         # ``incomplete`` já representa o número total de HTMLs incompletos
         return incomplete
 
+    """
+    Monta esta estrutura para a análise:
+        summary = [
+            {
+                "missing_pdf_or_html": False,
+                "missing_assets": False,
+                "missing_assets_detail": {
+                    asset_id_1: False,
+                    asset_id_2: True,
+                    asset_id_3: True,
+                },
+            },
+            {
+                "missing_pdf_or_html": False,
+                "missing_assets": False,
+                "missing_assets_detail": {
+                    asset_id_1: True,
+                    asset_id_2: False,
+                    asset_id_3: True,
+                },
+            },
+            {
+                "missing_pdf_or_html": False,
+                "missing_assets": False,
+                "missing_assets_detail": {
+                    asset_id_1: True,
+                    asset_id_2: True,
+                    asset_id_3: False,
+                },
+            },
+        ]
+    """
+    summary = []
+    for html in report:
+        missing_components = {"missing_pdf_or_html": False, "missing_assets": False}
+
+        if html.get("pdf", {}).get("missing") or html.get("html", {}).get("missing"):
+            missing_components["missing_pdf_or_html"] = True
+
+        if html.get("assets", {}).get("total missing") > 0:
+            missing_components["missing_assets"] = True
+            missing_components["missing_assets_detail"] = {}
+            for component in html.get("components", []):
+                if component["type"] == "asset":
+                    if component.get("present_in_html"):
+                        missing_components["missing_assets_detail"][
+                            component["id"]
+                        ] = False
+                    else:
+                        missing_components["missing_assets_detail"][
+                            component["id"]
+                        ] = True
+
+        summary.append(missing_components)
+
+    return 0
+
 
 def check_html_webpages_availability(html_data_items, assets_data, webpages_data, object_store_url):
     """

--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -830,6 +830,28 @@ def get_number_of_incomplete_html(incomplete, report):
 
         summary.append(missing_components)
 
+    number_of_missing_pdf_or_html = sum(
+        [1 for item in summary if item["missing_pdf_or_html"]]
+    )
+    number_of_missing_assets = sum([1 for item in summary if item["missing_assets"]])
+
+    if number_of_missing_pdf_or_html > 0:
+        # Falta PDF e/ou HTML
+        return incomplete
+    elif number_of_missing_assets > 0 and number_of_missing_assets != len(summary):
+        # Nem todos os tem todos os assets
+        return incomplete
+    elif number_of_missing_assets > 0 and number_of_missing_assets == len(summary):
+        # Verifica se é o caso de assets diferentes para cada idioma
+        assets = {}
+        for item in summary:
+            for id, missing_asset in item["missing_assets_detail"].items():
+                assets.setdefault(id, {True: 0, False: 0})
+                assets[id][missing_asset] += 1
+        for id, counter in assets.items():
+            if counter[True] > 1:
+                # Se o asset estiver presente em mais de 1 HTML, deveria estar em todos
+                return incomplete
     return 0
 
 
@@ -905,7 +927,7 @@ def check_html_webpages_availability(html_data_items, assets_data, webpages_data
     summary = {
         "total": len(html_data_items),
         "total unavailable": unavailable,
-        "total incomplete": incomplete,
+        "total incomplete": get_number_of_incomplete_html(incomplete, report),
     }
     return report, summary
 

--- a/airflow/tests/test_check_website_operations.py
+++ b/airflow/tests/test_check_website_operations.py
@@ -4024,6 +4024,228 @@ class TesteGetNumberOfIncompleteHtml(TestCase):
         incomplete = 1
         self.assertEqual(get_number_of_incomplete_html(incomplete, report), incomplete)
 
+    def test_returns_incomplete_if_missing_components_in_one_of_htmls(self):
+        report = [
+            {
+                "lang": "en",
+                "format": "html",
+                "pid_v2": "pid-v2", "acron": "xjk",
+                "doc_id_for_human": "artigo-1234",
+                "doc_id": "ldld",
+                "uri": "https://www.scielo.br/j/xjk/a/ldld?format=html&lang=en",
+                "available": True,
+                "status code": 200,
+                "components": [
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_1",
+                        "present_in_html": ["asset_uri_1.jpg",],
+                        "absent_in_html": ["asset_uri_1.tiff", "asset_uri_1.png",],
+                    },
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_2",
+                        "present_in_html": ["asset_uri_2.jpg",],
+                        "absent_in_html": ["asset_uri_2.tiff", "asset_uri_2.png",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=en",],
+                    },
+                    {
+                        "type": "html",
+                        "id": "es",
+                        "present_in_html": [],
+                        "absent_in_html": ["/j/xjk/a/ldld?format=html&lang=es",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=es",],
+                    },
+                ],
+                "total missing components": 0,
+                "total expected components": 5,
+                "pdf": {"total": 2, "missing": 1},
+                "html": {"total": 1, "missing": 0},
+                "assets": {
+                    "total expected": 2,
+                    "total missing": 0,
+                    "total alternatives": 6,
+                    "total alternatives present in html": 2,
+                },
+            },
+            {
+                "lang": "es",
+                "format": "html",
+                "pid_v2": "pid-v2", "acron": "xjk",
+                "doc_id_for_human": "artigo-1234",
+                "doc_id": "ldld",
+                "uri": "https://www.scielo.br/j/xjk/a/ldld?format=html&lang=es",
+                "available": True,
+                "status code": 200,
+                "start time": START_TIME,
+                "end time": END_TIME,
+                "duration": DURATION,
+                "components": [
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_1",
+                        "present_in_html": [],
+                        "absent_in_html": [
+                            "asset_uri_1.jpg", "asset_uri_1.tiff", "asset_uri_1.png",
+                        ],
+                    },
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_2",
+                        "present_in_html": ["asset_uri_2.jpg",],
+                        "absent_in_html": ["asset_uri_2.tiff", "asset_uri_2.png",],
+                    },
+                    {
+                        "type": "html",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=html&lang=en",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=en",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=es",],
+                    },
+                ],
+                "total expected components": 5,
+                "total missing components": 1,
+                "html": {"total": 1, "missing": 0},
+                "pdf": {"total": 2, "missing": 0},
+                "assets": {
+                    "total expected": 2,
+                    "total missing": 1,
+                    "total alternatives": 6,
+                    "total alternatives present in html": 2,
+                },
+            },
+        ]
+        incomplete = 2
+        self.assertEqual(get_number_of_incomplete_html(incomplete, report), incomplete)
+
+    def test_returns_0_if_missing_components_in_one_of_htmls_but_it_is_in_the_other(self):
+        report = [
+            {
+                "lang": "en",
+                "format": "html",
+                "pid_v2": "pid-v2", "acron": "xjk",
+                "doc_id_for_human": "artigo-1234",
+                "doc_id": "ldld",
+                "uri": "https://www.scielo.br/j/xjk/a/ldld?format=html&lang=en",
+                "available": True,
+                "status code": 200,
+                "components": [
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_1",
+                        "present_in_html": ["asset_uri_1.jpg",],
+                        "absent_in_html": ["asset_uri_1.tiff", "asset_uri_1.png",],
+                    },
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_2",
+                        "present_in_html": [],
+                        "absent_in_html": [
+                            "asset_uri_2.jpg", "asset_uri_2.tiff", "asset_uri_2.png",
+                        ],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=en",],
+                    },
+                    {
+                        "type": "html",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=html&lang=es",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=es",],
+                    },
+                ],
+                "total missing components": 1,
+                "total expected components": 5,
+                "pdf": {"total": 2, "missing": 0},
+                "html": {"total": 1, "missing": 0},
+                "assets": {
+                    "total expected": 2,
+                    "total missing": 1,
+                    "total alternatives": 6,
+                    "total alternatives present in html": 2,
+                },
+            },
+            {
+                "lang": "es",
+                "format": "html",
+                "pid_v2": "pid-v2", "acron": "xjk",
+                "doc_id_for_human": "artigo-1234",
+                "doc_id": "ldld",
+                "uri": "https://www.scielo.br/j/xjk/a/ldld?format=html&lang=es",
+                "available": True,
+                "status code": 200,
+                "start time": START_TIME,
+                "end time": END_TIME,
+                "duration": DURATION,
+                "components": [
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_1",
+                        "present_in_html": [],
+                        "absent_in_html": [
+                            "asset_uri_1.jpg", "asset_uri_1.tiff", "asset_uri_1.png",
+                        ],
+                    },
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_2",
+                        "present_in_html": ["asset_uri_2.jpg",],
+                        "absent_in_html": ["asset_uri_2.tiff", "asset_uri_2.png",],
+                    },
+                    {
+                        "type": "html",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=html&lang=en",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=en",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=es",],
+                    },
+                ],
+                "total expected components": 5,
+                "total missing components": 1,
+                "html": {"total": 1, "missing": 0},
+                "pdf": {"total": 2, "missing": 0},
+                "assets": {
+                    "total expected": 2,
+                    "total missing": 1,
+                    "total alternatives": 6,
+                    "total alternatives present in html": 2,
+                },
+            },
+        ]
+        incomplete = 2
+        res = get_number_of_incomplete_html(incomplete, report)
+        self.assertEqual(res, 0)
+
 
 class TestCheckHtmlWebpagesAvailability(TestCase):
 

--- a/airflow/tests/test_check_website_operations.py
+++ b/airflow/tests/test_check_website_operations.py
@@ -23,6 +23,7 @@ from operations.check_website_operations import (
     check_doc_webpage_uri_items_expected_in_webpage,
     check_document_webpages_availability,
     check_pdf_webpages_availability,
+    get_number_of_incomplete_html,
     check_html_webpages_availability,
     check_document_html,
     check_document_html_content,
@@ -3959,6 +3960,69 @@ class TestGroupDocDataByWebpageType(TestCase):
         }
         result = group_doc_data_by_webpage_type(doc_webpages_data)
         self.assertDictEqual(expected, result)
+
+
+class TesteGetNumberOfIncompleteHtml(TestCase):
+    def test_returns_0_if_giving_incomplete_is_0(self):
+        incomplete = 0
+        self.assertEqual(get_number_of_incomplete_html(incomplete, []), 0)
+
+    def test_returns_incomplete_if_there_is_only_one_html_and_incomplete(self):
+        report = [
+            {
+                "lang": "en",
+                "format": "html",
+                "pid_v2": "pid-v2", "acron": "xjk",
+                "doc_id_for_human": "artigo-1234",
+                "doc_id": "ldld",
+                "uri": "https://www.scielo.br/j/xjk/a/ldld?format=html&lang=en",
+                "available": True,
+                "status code": 200,
+                "components": [
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_1",
+                        "present_in_html": ["asset_uri_1.jpg",],
+                        "absent_in_html": ["asset_uri_1.tiff", "asset_uri_1.png",],
+                    },
+                    {
+                        "type": "asset",
+                        "id": "asset_uri_2",
+                        "present_in_html": [],
+                        "absent_in_html": [
+                            "asset_uri_2.jpg", "asset_uri_2.tiff", "asset_uri_2.png",
+                        ],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "en",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=en",],
+                    },
+                    {
+                        "type": "html",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=html&lang=es",],
+                    },
+                    {
+                        "type": "pdf",
+                        "id": "es",
+                        "present_in_html": ["/j/xjk/a/ldld?format=pdf&lang=es",],
+                    },
+                ],
+                "total missing components": 1,
+                "total expected components": 5,
+                "pdf": {"total": 2, "missing": 0},
+                "html": {"total": 1, "missing": 0},
+                "assets": {
+                    "total expected": 2,
+                    "total missing": 1,
+                    "total alternatives": 6,
+                    "total alternatives present in html": 1,
+                },
+            },
+        ]
+        incomplete = 1
+        self.assertEqual(get_number_of_incomplete_html(incomplete, report), incomplete)
 
 
 class TestCheckHtmlWebpagesAvailability(TestCase):


### PR DESCRIPTION
#### O que esse PR faz?
Este PR adiciona análise dos detalhes de HTMLs incompletos para verificar se no nível do documento, com todos os HTMLs, é considerado ou não incompleto. Há casos em que são usados ativos digitais diferentes para cada tradução do texto e apontá-los como ausentes é um problema.

#### Onde a revisão poderia começar?
Commit 07c12af.

#### Como este poderia ser testado manualmente?
- Pegue uma amostra do arquivo `homolog-metodologia.scielo.org:/var/www/scielo_br/xc_gerapadrao/airflow-gate/2012-2014_errors_html.csv` e salve no diretório do volume configurado na variável do Airflow `XC_SPS_PACKAGES_DIR`. Inclua o PID `S0103-507X2012000100012`
- Configure as seguites variáveis no Airflow:
  - `PID_LIST_CSV_FILE_NAMES` = ["nome-do-arquivo-criado-no-passo-1.csv"]
  - `WEBSITE_URL_LIST` = ["https://new.scielo.br"]
- Execute a DAG `check_website` e aguarde que a subdag `check_website.check_documents_deeply_grouped_by_issue_pid_v2_id` seja executada
- Acesse a tabela `doc_deep_checkup` no DB Postgres `processinglog` configurado no Airflow
- Verifique os registros apontados com `status` diferente de `complete`. Não devem haver casos em que o artigo tem traduções com ativos digitais para cada um dos idiomas. O documento `S0103-507X2012000100012` não deve estar marcado como incompleto por conta dos ativos digitais.

#### Algum cenário de contexto que queira dar?
Para artigos migrados dos anos entre 2012 e 2014, mais de 5000 artigos foram identificados como incompletos e, por amostragem, percemos este problema. É possível visualizá-los no link https://grafana-new.scielo.org/d/-gKQYadMk/documents-deep-checkup?orgId=1&from=1610334000000&to=1610506800000&var-pid=&var-_airflow_host=http:%2F%2F172.16.6.46.
Esta abordagem não é ótima mas tenta retirar a sinalização de artigos com problema que não apresentam ausencia de fato. Talvez a abordagem que faria mais sentido pegando como ponto de partida o XML ao invés do manifest do Kernel.

### Screenshots
.

#### Quais são tickets relevantes?
#262 

### Referências
.