### PR TITLE
Corrige check_website na verificação assets não referenciados em HTML

### DIFF
--- a/airflow/dags/operations/check_website_operations.py
+++ b/airflow/dags/operations/check_website_operations.py
@@ -839,7 +839,7 @@ def get_number_of_incomplete_html(incomplete, report):
         # Falta PDF e/ou HTML
         return incomplete
     elif number_of_missing_assets > 0 and number_of_missing_assets != len(summary):
-        # Nem todos os tem todos os assets
+        # Nem todos os HTMLs tem todos os assets
         return incomplete
     elif number_of_missing_assets > 0 and number_of_missing_assets == len(summary):
         # Verifica se é o caso de assets diferentes para cada idioma
@@ -849,8 +849,9 @@ def get_number_of_incomplete_html(incomplete, report):
                 assets.setdefault(id, {True: 0, False: 0})
                 assets[id][missing_asset] += 1
         for id, counter in assets.items():
-            if counter[True] > 1:
-                # Se o asset estiver presente em mais de 1 HTML, deveria estar em todos
+            if counter[False] > 1:
+                # Se o asset estiver presente em mais de 1 HTML (missing == False),
+                # deveria estar em todos
                 return incomplete
     return 0
 


### PR DESCRIPTION
#### O que esse PR faz?
Este PR corrige o PR #264. Se o ativo digital estiver presente em mais de um HTML, a lógica de que há ativos digitais para cada idiomas e quebrada e, por mais que esteja correto, será necessário validar.

#### Onde a revisão poderia começar?
Commit ce5abf8.

#### Como este poderia ser testado manualmente?
- Pegue uma amostra do arquivo `homolog-metodologia.scielo.org:/var/www/scielo_br/xc_gerapadrao/airflow-gate/2009_html.csv` e salve no diretório do volume configurado na variável do Airflow `XC_SPS_PACKAGES_DIR`. Confirme que o PID `S0066-782X2009000100006` esteja lá
- Configure as seguites variáveis no Airflow:
  - `PID_LIST_CSV_FILE_NAMES` = ["nome-do-arquivo-criado-no-passo-1.csv"]
  - `WEBSITE_URL_LIST` = ["https://new.scielo.br"]
- Execute a DAG `check_website` e aguarde que a subdag `check_website.check_documents_deeply_grouped_by_issue_pid_v2_id` seja executada
- Acesse a tabela `doc_deep_checkup` no DB Postgres `processinglog` configurado no Airflow
- Verifique os registros apontados com `status` diferente de `complete`. Não devem haver casos em que o artigo tem traduções com ativos digitais para cada um dos idiomas. O documento `S0066-782X2009000100006` não deve estar marcado como incompleto por conta dos ativos digitais.

#### Algum cenário de contexto que queira dar?
.

### Screenshots
.

#### Quais são tickets relevantes?
#262.

### Referências
.