### PR TITLE
Corrige bug de não atualizar os dados de PID se o documento é ex aop.

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -43,8 +43,9 @@ def ArticleFactory(
                 return default
         return data
 
-    def _get_previous_pid(data) -> Generator:
-        """Recupera previous-pid, se existir"""
+    def _get_previous_pid(data):
+        """Recupera previous-pid, se existir
+        Retorna str ou None"""
 
         # depende de uma melhoria no clea
         _previous_id = _nestget(data, "article_meta", 0, "previous_pid", 0)
@@ -53,6 +54,9 @@ def ArticleFactory(
 
         # tenta obter pelo `article_publisher_id`
         article_meta = _nestget(data, "article_meta", 0)
+        if not article_meta:
+            return
+
         scielo_pid_v2 = _nestget(article_meta, "scielo_pid_v2", 0)
         scielo_pid_v3 = _nestget(article_meta, "scielo_pid_v3", 0)
         article_ids = set(_nestget(article_meta, "article_publisher_id"))
@@ -64,7 +68,7 @@ def ArticleFactory(
         # match com o padrão de pid v2
         for pid in pids:
             _matched = match(scielo_pid_v2[:10] + r"(\d{13})", pid)
-            if _matched.group() == pid:
+            if _matched and _matched.group() == pid:
                 return pid
 
     AUTHOR_CONTRIB_TYPES = (

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -78,6 +78,11 @@ def ArticleFactory(
     article.scielo_pids = {
         version: value for version, value in scielo_pids if value is not None
     }
+
+    if article.pid != article.scielo_pids.get("v2"):
+        article.aop_pid = article.pid
+        article.pid = article.scielo_pids.get("v2")
+
     article.doi = _nestget(data, "article_meta", 0, "article_doi", 0)
 
     def _get_article_authors(data) -> Generator:

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -277,6 +277,26 @@ def ArticleFactory(
 
     # Issue vinculada
     issue = models.Issue.objects.get(_id=issue_id)
+
+    # será bug? um ex-aop continua com o issue_id de aop
+    # registra no log um WARNING para ajudar a resolver a próxima ocorrência
+    _number = _nestget(data, "article_meta", 0, "pub_issue", 0)
+    if not issue.number == _number:
+        _vol = _nestget(data, "article_meta", 0, "pub_volume", 0)
+        # compara issue registrado no opac com issue do kernel/front
+        values = {
+            'kernel/front': {
+                'volume': _vol, 'number': _number},
+            'website': {
+                'issue_id': issue_id,
+                'volume': issue.volume, 'number': issue.number},
+        }
+        msg = (
+            "Divergência nos dados de `issue` do documento (document_id=%s): "
+            "%s" % (document_id, values)
+        )
+        logging.warning(msg)
+
     article.issue = issue
     article.journal = issue.journal
     article.order = _get_order(document_order, article.scielo_pids.get("v2"))

--- a/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621_previous_pid.json
+++ b/airflow/tests/fixtures/kernel-document-front-s1518-8787.2019053000621_previous_pid.json
@@ -28,6 +28,9 @@
         "scielo_pid_v3": [
             "67TH7T7CyPPmgtVrGXhWXVs"
         ],
+        "previous_pid": [
+            "S1518-8787XXXX005000621"
+        ],
         "article_title": [
           "Validation of an anxiety scale for prenatal diagnostic procedures"
         ],

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -533,6 +533,35 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
         self.assertEqual(
             self.document.scielo_pids['v2'], "S1518-87872019053000621")
 
+    @patch("operations.sync_kernel_to_website_operations.logging")
+    def test_article_factory_logs_warning_if_issue_id_continues_to_be_aop(
+            self, mock_logging,
+            MockIssueObjects, MockArticleObjects):
+        MockArticle = MagicMock(
+            spec=models.Article,
+            aop_url_segs=None,
+            url_segment="10.151/S1518-8787.2019053000621",
+            pid="pid-aop",
+            issue=self.issue,
+        )
+        MockArticleObjects.get.return_value = MockArticle
+        MockIssueObjects.get.return_value = self.issue
+        regular_issue_id = None
+
+        # ArticleFactory
+        self.document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front,
+            regular_issue_id, "1", ""
+        )
+        msg = (
+            "Divergência nos dados de `issue` do documento "
+            "(document_id=67TH7T7CyPPmgtVrGXhWXVs): "
+            "{'kernel/front': {'volume': '53', 'number': ''}, "
+            "'website': {'issue_id': '0101-0101-aop', "
+            "'volume': None, 'number': 'ahead'}}"
+        )
+        mock_logging.warning.assert_called_once_with(msg)
+
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -511,6 +511,28 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
             "2019.nahead"
         )
 
+    def test_article_factory_creates_aop_id_and_update_pid_with_scielo_pids_v2(
+            self, MockIssueObjects, MockArticleObjects):
+        MockArticle = MagicMock(
+            spec=models.Article,
+            aop_url_segs=None,
+            url_segment="10.151/S1518-8787.2019053000621",
+            pid="pid-aop",
+        )
+        MockArticleObjects.get.return_value = MockArticle
+
+        regular_issue_id = None
+
+        # ArticleFactory
+        self.document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front,
+            regular_issue_id, "1", ""
+        )
+        self.assertEqual(self.document.pid, "S1518-87872019053000621")
+        self.assertEqual(self.document.aop_pid, "pid-aop")
+        self.assertEqual(
+            self.document.scielo_pids['v2'], "S1518-87872019053000621")
+
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -517,7 +517,7 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
             spec=models.Article,
             aop_url_segs=None,
             url_segment="10.151/S1518-8787.2019053000621",
-            pid="pid-aop",
+            pid="S1518-87872019005000621",
         )
         MockArticleObjects.get.return_value = MockArticle
 
@@ -529,9 +529,32 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
             regular_issue_id, "1", ""
         )
         self.assertEqual(self.document.pid, "S1518-87872019053000621")
-        self.assertEqual(self.document.aop_pid, "pid-aop")
-        self.assertEqual(
-            self.document.scielo_pids['v2'], "S1518-87872019053000621")
+        self.assertEqual(self.document.aop_pid, "S1518-87872019005000621")
+
+    def test_article_factory_creates_aop_id_from_previous_pid_and_update_pid_with_scielo_pids_v2(
+            self, MockIssueObjects, MockArticleObjects):
+        MockArticle = MagicMock(
+            spec=models.Article,
+            aop_url_segs=None,
+            url_segment="10.151/S1518-8787.2019053000621",
+            pid="S1518-87872019005000621",
+        )
+        MockArticleObjects.get.return_value = MockArticle
+
+        regular_issue_id = self.issue._id
+
+        # obtém de kernel front: previous_pid (nao implementado no clea ainda)
+        self.document_front = load_json_fixture(
+            "kernel-document-front-s1518-8787.2019053000621_previous_pid.json"
+        )
+
+        # ArticleFactory
+        self.document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front,
+            regular_issue_id, "1", ""
+        )
+        self.assertEqual(self.document.pid, "S1518-87872019053000621")
+        self.assertEqual(self.document.aop_pid, "S1518-8787XXXX005000621")
 
     @patch("operations.sync_kernel_to_website_operations.logging")
     def test_article_factory_logs_warning_if_issue_id_continues_to_be_aop(


### PR DESCRIPTION
#### O que esse PR faz?
Corrige bug de não atualizar os dados de PID se o documento é ex aop.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver #273, a seção como reproduzir

#### Algum cenário de contexto que queira dar?
n/a

#### Quais são tickets relevantes?
#273

### Referências
n/a