### PR TITLE
Permite que documentos sejam resincronizados no site sem a dependência de estar listados em changes

### DIFF
--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -8,6 +8,50 @@ from lxml import etree
 logger = logging.getLogger(__name__)
 
 
+def extract_number_and_supplment_from_issue_element(issue):
+    """
+    Extrai do conteúdo de <issue>xxxx</issue>, os valores number e suppl.
+    Valores possíveis
+    5 (suppl), 5 Suppl, 5 Suppl 1, 5 spe, 5 suppl, 5 suppl 1, 5 suppl. 1,
+    25 Suppl 1, 2-5 suppl 1, 2spe, Spe, Supl. 1, Suppl, Suppl 12,
+    s2, spe, spe 1, spe pr, spe2, spe.2, spepr, supp 1, supp5 1, suppl,
+    suppl 1, suppl 5 pr, suppl 12, suppl 1-2, suppl. 1
+    """
+    issue = issue.strip().replace(".", "")
+    splitted = [s for s in issue.split() if s]
+
+    splitted = ["spe"
+                if "spe" in s.lower() and s.isalpha() else s
+                for s in splitted
+                ]
+    if len(splitted) == 1:
+        issue = splitted[0]
+        if issue.isdigit():
+            return issue, None
+        if "sup" in issue.lower():
+            # match como sup*
+            return None, "0"
+        if issue.startswith("s"):
+            if issue[1:].isdigit():
+                return None, issue[1:]
+        # match com spe, 2-5, 3B
+        return issue, None
+
+    if len(splitted) == 2:
+        if "sup" in splitted[0].lower():
+            return None, splitted[1]
+        if "sup" in splitted[1].lower():
+            return splitted[0], "0"
+        # match spe 4 -> spe4
+        return "".join(splitted), None
+
+    if len(splitted) == 3:
+        if "sup" in splitted[1].lower():
+            return splitted[0], splitted[2]
+    # match ????
+    return "".join(splitted), None
+
+
 def parse_date(_date):
     def format(value):
         if value and value.isdigit():

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -10,6 +10,16 @@ import common.hooks as hooks
 from operations.exceptions import InvalidOrderValueError
 
 
+def _nestget(data, *path, default=""):
+    """Obtém valores de list ou dicionários."""
+    for key_or_index in path:
+        try:
+            data = data[key_or_index]
+        except (KeyError, IndexError):
+            return default
+    return data
+
+
 def ArticleFactory(
     document_id: str,
     data: dict,
@@ -33,15 +43,6 @@ def ArticleFactory(
         models.Article: Instância de um artigo próprio do modelo de dados do
             OPAC.
     """
-
-    def _nestget(data, *path, default=""):
-        """Obtém valores de list ou dicionários."""
-        for key_or_index in path:
-            try:
-                data = data[key_or_index]
-            except (KeyError, IndexError):
-                return default
-        return data
 
     def _get_previous_pid(data):
         """Recupera previous-pid, se existir

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -353,25 +353,6 @@ def ArticleFactory(
     # Issue vinculada
     issue = models.Issue.objects.get(_id=issue_id)
 
-    # será bug? um ex-aop continua com o issue_id de aop
-    # registra no log um WARNING para ajudar a resolver a próxima ocorrência
-    _number = _nestget(data, "article_meta", 0, "pub_issue", 0)
-    if not issue.number == _number:
-        _vol = _nestget(data, "article_meta", 0, "pub_volume", 0)
-        # compara issue registrado no opac com issue do kernel/front
-        values = {
-            'kernel/front': {
-                'volume': _vol, 'number': _number},
-            'website': {
-                'issue_id': issue_id,
-                'volume': issue.volume, 'number': issue.number},
-        }
-        msg = (
-            "Divergência nos dados de `issue` do documento (document_id=%s): "
-            "%s" % (document_id, values)
-        )
-        logging.warning(msg)
-
     logging.info("ISSUE %s" % str(issue))
     logging.info("ARTICLE.ISSUE %s" % str(article.issue))
 

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -372,6 +372,9 @@ def ArticleFactory(
         )
         logging.warning(msg)
 
+    logging.info("ISSUE %s" % str(issue))
+    logging.info("ARTICLE.ISSUE %s" % str(article.issue))
+
     article.issue = issue
     article.journal = issue.journal
     article.order = _get_order(document_order, article.scielo_pids.get("v2"))
@@ -424,8 +427,8 @@ def try_register_documents(
 
     for document_id in documents:
         try:
-            issue_id, item = get_relation_data(document_id)
             document_front = fetch_document_front(document_id)
+            issue_id, item = get_relation_data(document_id, document_front)
             document_xml_url = "{base_url}documents/{document_id}".format(
                 base_url=BASE_URL, document_id=document_id
             )
@@ -437,6 +440,7 @@ def try_register_documents(
                 document_xml_url,
             )
             document.save()
+            logging.info("ARTICLE saved %s %s" % (document_id, issue_id))
         except InvalidOrderValueError as e:
             logging.error(
                 "Could not register document %s. "

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -10,6 +10,10 @@ import common.hooks as hooks
 from operations.exceptions import InvalidOrderValueError
 
 
+class KernelFrontHasNoPubYearError(Exception):
+    ...
+
+
 def _nestget(data, *path, default=""):
     """Obtém valores de list ou dicionários."""
     for key_or_index in path:
@@ -18,6 +22,20 @@ def _nestget(data, *path, default=""):
         except (KeyError, IndexError):
             return default
     return data
+
+
+def _get_bundle_pub_year(publication_dates):
+    try:
+        pubdates = {}
+        for pubdate in publication_dates or []:
+            pub_date_type = pubdate.get("date_type") or pubdate.get("pub_type")
+            pub_year = pubdate.get("year")
+            if pub_year and pub_date_type:
+                pubdates[pub_date_type[0]] = pub_year[0]
+        return pubdates.get("collection") or list(pubdates.values())[0]
+    except (IndexError, AttributeError):
+        raise KernelFrontHasNoPubYearError(
+            "Missing publication year in: {}".format(publication_dates))
 
 
 def ArticleFactory(

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -163,6 +163,11 @@ def _get_relation_data_from_kernel_bundle(document_id, front_data=None):
         ('0034-8910-2019-v53',
          {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
     """
+    logging.info(
+        "Unable to find %s in bundles changes. "
+        "Try to get bundle_id and order from Kernel" % document_id
+    )
+
     bundle_id = None
     front_data = front_data or fetch_documents_front(document_id)
     if front_data:
@@ -180,6 +185,9 @@ def _get_relation_data_from_kernel_bundle(document_id, front_data=None):
             if doc.get("id") == document_id:
                 # ('0034-8910-2019-v53',
                 #  {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+                logging.info(
+                    "Got bundle_id and order from Kernel: %s %s" %
+                    (bundle_id, str(doc)))
                 return (bundle_id, doc)
     # retorna o bundle_id e {}
     return bundle_id, {}
@@ -650,7 +658,7 @@ def register_documents(**kwargs):
 
     tasks = kwargs["ti"].xcom_pull(key="tasks", task_ids="read_changes_task")
 
-    def _get_relation_data(document_id: str) -> Tuple[str, Dict]:
+    def _get_relation_data(document_id: str, front_data=None) -> Tuple[str, Dict]:
         """Recupera informações sobre o relacionamento entre o
         DocumentsBundle e o Document.
 
@@ -658,7 +666,8 @@ def register_documents(**kwargs):
         documento está relacionado e o item do relacionamento.
 
         >> _get_relation_data("67TH7T7CyPPmgtVrGXhWXVs")
-        ('0034-8910-2019-v53', {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
+        ('0034-8910-2019-v53',
+         {'id': '67TH7T7CyPPmgtVrGXhWXVs', 'order': '01'})
 
         :param document_id: Identificador único de um documento
         """
@@ -668,7 +677,7 @@ def register_documents(**kwargs):
                 if document_id == item["id"]:
                     return (issue_id, item)
 
-        return (None, {})
+        return _get_relation_data_from_kernel_bundle(document_id, front_data)
 
     def _get_known_documents(**kwargs) -> Dict[str, List[str]]:
         """Recupera a lista de todos os documentos que estão relacionados com

--- a/airflow/tests/test_sps_package.py
+++ b/airflow/tests/test_sps_package.py
@@ -1,8 +1,268 @@
 from unittest import TestCase, skip
 
+from lxml import etree
+
 from common.sps_package import (
+    SPS_Package,
     extract_number_and_supplment_from_issue_element,
 )
+
+
+class  TestSPSPackage(TestCase):
+    """
+    Estes testes são para verificar a saída de
+    SPS_Package.number e SPS_Package.supplement
+    """
+    def get_sps_package(self, issue):
+        xml_text = f"""
+            <article><article-meta>
+                <issue>{issue}</issue>
+            </article-meta></article>
+        """
+        xmltree = etree.fromstring(xml_text)
+        return SPS_Package(xmltree, "sps_package")
+
+    def test_number_and_suppl_for_5_parenteses_suppl(self):
+        expected = "5(", "0"
+        _sps_package = self.get_sps_package("5 (suppl)")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_5_Suppl(self):
+        expected = "5", "0"
+        _sps_package = self.get_sps_package("5 Suppl")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_5_Suppl_1(self):
+        expected = "5", "01"
+        _sps_package = self.get_sps_package("5 Suppl 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_5_spe(self):
+        expected = "5spe", None
+        _sps_package = self.get_sps_package("5 spe")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_5_suppl(self):
+        expected = "5", "0"
+        _sps_package = self.get_sps_package("5 suppl")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_5_suppl_1(self):
+        expected = "5", "01"
+        _sps_package = self.get_sps_package("5 suppl 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_5_suppl_dot_1(self):
+        expected = "5", "01"
+        _sps_package = self.get_sps_package("5 suppl. 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_25_Suppl_1(self):
+        expected = "25", "01"
+        _sps_package = self.get_sps_package("25 Suppl 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_2_hyphen_5_suppl_1(self):
+        expected = "2-5", "01"
+        _sps_package = self.get_sps_package("2-5 suppl 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_2spe(self):
+        expected = "2spe", None
+        _sps_package = self.get_sps_package("2spe")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_Spe(self):
+        expected = "Spe", None
+        _sps_package = self.get_sps_package("Spe")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_Supldot_1(self):
+        expected = None, "01"
+        _sps_package = self.get_sps_package("Supl. 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_Suppl(self):
+        expected = None, "0"
+        _sps_package = self.get_sps_package("Suppl")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_Suppl_12(self):
+        expected = None, "12"
+        _sps_package = self.get_sps_package("Suppl 12")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_s2(self):
+        expected = "s2", "2"
+        _sps_package = self.get_sps_package("s2")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_spe(self):
+        expected = "spe", None
+        _sps_package = self.get_sps_package("spe")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_special(self):
+        expected = "Especial", None
+        _sps_package = self.get_sps_package("Especial")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_spe_1(self):
+        expected = "spe1", None
+        _sps_package = self.get_sps_package("spe 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_spe_pr(self):
+        expected = "spepr", None
+        _sps_package = self.get_sps_package("spe pr")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_spe2(self):
+        expected = "spe2", None
+        _sps_package = self.get_sps_package("spe2")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_spedot2(self):
+        expected = "spe.2", None
+        _sps_package = self.get_sps_package("spe.2")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_spepr(self):
+        expected = "spepr", None
+        _sps_package = self.get_sps_package("spepr")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_supp_1(self):
+        expected = None, "01"
+        _sps_package = self.get_sps_package("supp 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_suppl(self):
+        expected = None, "0"
+        _sps_package = self.get_sps_package("suppl")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_suppl_1(self):
+        expected = None, "01"
+        _sps_package = self.get_sps_package("suppl 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_suppl_12(self):
+        expected = None, "12"
+        _sps_package = self.get_sps_package("suppl 12")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_suppl_1hyphen2(self):
+        expected = None, "1-2"
+        _sps_package = self.get_sps_package("suppl 1-2")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    def test_number_and_suppl_for_suppldot_1(self):
+        expected = None, "01"
+        _sps_package = self.get_sps_package("suppl. 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_number_and_suppl_for_supp5_1(self):
+        expected = "supp5", "1"
+        _sps_package = self.get_sps_package("supp5 1")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_number_and_suppl_for_suppl_5_pr(self):
+        expected = None, "5pr"
+        _sps_package = self.get_sps_package("suppl 5 pr")
+        result = _sps_package.number
+        self.assertEqual(expected[0], result)
+        result = _sps_package.supplement
+        self.assertEqual(expected[1], result)
 
 
 class TestExtractNumberAndSupplmentFromIssueElement(TestCase):

--- a/airflow/tests/test_sps_package.py
+++ b/airflow/tests/test_sps_package.py
@@ -1,0 +1,169 @@
+from unittest import TestCase, skip
+
+from common.sps_package import (
+    extract_number_and_supplment_from_issue_element,
+)
+
+
+class TestExtractNumberAndSupplmentFromIssueElement(TestCase):
+    """
+    Extrai do conteúdo de <issue>xxxx</issue>, os valores number e suppl.
+    Valores possíveis
+    5 (suppl), 5 Suppl, 5 Suppl 1, 5 spe, 5 suppl, 5 suppl 1, 5 suppl. 1,
+    25 Suppl 1, 2-5 suppl 1, 2spe, Spe, Supl. 1, Suppl, Suppl 12,
+    s2, spe, spe 1, spe pr, spe2, spe.2, spepr, supp 1, supp5 1, suppl,
+    suppl 1, suppl 5 pr, suppl 12, suppl 1-2, suppl. 1
+
+    """
+    def test_number_and_suppl_for_5_parenteses_suppl(self):
+        expected = "5", "0"
+        result = extract_number_and_supplment_from_issue_element("5 (suppl)")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_5_Suppl(self):
+        expected = "5", "0"
+        result = extract_number_and_supplment_from_issue_element("5 Suppl")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_5_Suppl_1(self):
+        expected = "5", "1"
+        result = extract_number_and_supplment_from_issue_element("5 Suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_5_spe(self):
+        expected = "5spe", None
+        result = extract_number_and_supplment_from_issue_element("5 spe")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_5_suppl(self):
+        expected = "5", "0"
+        result = extract_number_and_supplment_from_issue_element("5 suppl")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_5_suppl_1(self):
+        expected = "5", "1"
+        result = extract_number_and_supplment_from_issue_element("5 suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_5_suppl_dot_1(self):
+        expected = "5", "1"
+        result = extract_number_and_supplment_from_issue_element("5 suppl. 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_25_Suppl_1(self):
+        expected = "25", "1"
+        result = extract_number_and_supplment_from_issue_element("25 Suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_2_hyphen_5_suppl_1(self):
+        expected = "2-5", "1"
+        result = extract_number_and_supplment_from_issue_element("2-5 suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_2spe(self):
+        expected = "2spe", None
+        result = extract_number_and_supplment_from_issue_element("2spe")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_Spe(self):
+        expected = "spe", None
+        result = extract_number_and_supplment_from_issue_element("Spe")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_Supldot_1(self):
+        expected = None, "1"
+        result = extract_number_and_supplment_from_issue_element("Supl. 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_Suppl(self):
+        expected = None, "0"
+        result = extract_number_and_supplment_from_issue_element("Suppl")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_Suppl_12(self):
+        expected = None, "12"
+        result = extract_number_and_supplment_from_issue_element("Suppl 12")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_s2(self):
+        expected = None, "2"
+        result = extract_number_and_supplment_from_issue_element("s2")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_spe(self):
+        expected = "spe", None
+        result = extract_number_and_supplment_from_issue_element("spe")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_special(self):
+        expected = "spe", None
+        result = extract_number_and_supplment_from_issue_element("Especial")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_spe_1(self):
+        expected = "spe1", None
+        result = extract_number_and_supplment_from_issue_element("spe 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_spe_pr(self):
+        expected = "spepr", None
+        result = extract_number_and_supplment_from_issue_element("spe pr")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_spe2(self):
+        expected = "spe2", None
+        result = extract_number_and_supplment_from_issue_element("spe2")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_spedot2(self):
+        expected = "spe2", None
+        result = extract_number_and_supplment_from_issue_element("spe.2")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_supp_1(self):
+        expected = None, "1"
+        result = extract_number_and_supplment_from_issue_element("supp 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_suppl(self):
+        expected = None, "0"
+        result = extract_number_and_supplment_from_issue_element("suppl")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_suppl_1(self):
+        expected = None, "1"
+        result = extract_number_and_supplment_from_issue_element("suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_suppl_12(self):
+        expected = None, "12"
+        result = extract_number_and_supplment_from_issue_element("suppl 12")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_suppl_1hyphen2(self):
+        expected = None, "1-2"
+        result = extract_number_and_supplment_from_issue_element("suppl 1-2")
+        self.assertEqual(expected, result)
+
+    def test_number_and_suppl_for_suppldot_1(self):
+        expected = None, "1"
+        result = extract_number_and_supplment_from_issue_element("suppl. 1")
+        self.assertEqual(expected, result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_number_and_suppl_for_spepr(self):
+        expected = "spepr", None
+        result = extract_number_and_supplment_from_issue_element("spepr")
+        self.assertEqual(expected, result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_number_and_suppl_for_supp5_1(self):
+        expected = "supp5", "1"
+        result = extract_number_and_supplment_from_issue_element("supp5 1")
+        self.assertEqual(expected, result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_number_and_suppl_for_suppl_5_pr(self):
+        expected = None, "5pr"
+        result = extract_number_and_supplment_from_issue_element("suppl 5 pr")
+        self.assertEqual(expected, result)

--- a/airflow/tests/test_sps_package.py
+++ b/airflow/tests/test_sps_package.py
@@ -5,13 +5,175 @@ from lxml import etree
 from common.sps_package import (
     SPS_Package,
     extract_number_and_supplment_from_issue_element,
+    parse_issue,
 )
 
 
-class  TestSPSPackage(TestCase):
+
+class TestParseIssue(TestCase):
     """
-    Estes testes são para verificar a saída de
+    Estes testes são para explicitar a saída de
+    parse_issue usando o contéudo de <issue></issue>
+    """
+    def test_parse_issue_for_5_parenteses_suppl(self):
+        expected = "05-s0"
+        result = parse_issue("5 (suppl)")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_5_Suppl(self):
+        expected = "05-s0"
+        result = parse_issue("5 Suppl")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_5_Suppl_1(self):
+        expected = "05-s01"
+        result = parse_issue("5 Suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_5_spe(self):
+        expected = "05-spe"
+        result = parse_issue("5 spe")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_5_suppl(self):
+        expected = "05-s0"
+        result = parse_issue("5 suppl")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_5_suppl_1(self):
+        expected = "05-s01"
+        result = parse_issue("5 suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_5_suppl_dot_1(self):
+        expected = "05-s01"
+        result = parse_issue("5 suppl. 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_25_Suppl_1(self):
+        expected = "25-s01"
+        result = parse_issue("25 Suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_2_hyphen_5_suppl_1(self):
+        expected = "2-5-s01"
+        result = parse_issue("2-5 suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_2spe(self):
+        expected = "spe"
+        result = parse_issue("2spe")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_Spe(self):
+        expected = "spe"
+        result = parse_issue("Spe")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_Supldot_1(self):
+        expected = "s01"
+        result = parse_issue("Supl. 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_Suppl(self):
+        expected = "s0"
+        result = parse_issue("Suppl")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_Suppl_12(self):
+        expected = "s12"
+        result = parse_issue("Suppl 12")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_s2(self):
+        expected = "s2"
+        result = parse_issue("s2")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_spe(self):
+        expected = "spe"
+        result = parse_issue("spe")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_special(self):
+        expected = "spe"
+        result = parse_issue("Especial")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_spe_1(self):
+        expected = "spe01"
+        result = parse_issue("spe 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_spe_pr(self):
+        expected = "spepr"
+        result = parse_issue("spe pr")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_spe2(self):
+        expected = "spe"
+        result = parse_issue("spe2")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_spedot2(self):
+        expected = "spe"
+        result = parse_issue("spe.2")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_supp_1(self):
+        expected = "s01"
+        result = parse_issue("supp 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_suppl(self):
+        expected = "s0"
+        result = parse_issue("suppl")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_suppl_1(self):
+        expected = "s01"
+        result = parse_issue("suppl 1")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_suppl_12(self):
+        expected = "s12"
+        result = parse_issue("suppl 12")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_suppl_1hyphen2(self):
+        expected = "s1-2"
+        result = parse_issue("suppl 1-2")
+        self.assertEqual(expected, result)
+
+    def test_parse_issue_for_suppldot_1(self):
+        expected = "s01"
+        result = parse_issue("suppl. 1")
+        self.assertEqual(expected, result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_parse_issue_for_spepr(self):
+        expected = "spepr"
+        result = parse_issue("spepr")
+        self.assertEqual(expected, result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_parse_issue_for_supp5_1(self):
+        expected = "supp5-s01"
+        result = parse_issue("supp5 1")
+        self.assertEqual(expected, result)
+
+    @skip("Encontrado no sistema, porém fora do padrão aceitável")
+    def test_parse_issue_for_suppl_5_pr(self):
+        expected = "5pr"
+        result = parse_issue("suppl 5 pr")
+        self.assertEqual(expected, result)
+
+
+class TestSPSPackage(TestCase):
+    """
+    Estes testes são para explicitar a saída de
     SPS_Package.number e SPS_Package.supplement
+    dado o valor de <issue></issue>
     """
     def get_sps_package(self, issue):
         xml_text = f"""

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -562,35 +562,6 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
         self.assertEqual(self.document.pid, "S1518-87872019053000621")
         self.assertEqual(self.document.aop_pid, "S1518-8787XXXX005000621")
 
-    @patch("operations.sync_kernel_to_website_operations.logging")
-    def test_article_factory_logs_warning_if_issue_id_continues_to_be_aop(
-            self, mock_logging,
-            MockIssueObjects, MockArticleObjects):
-        MockArticle = MagicMock(
-            spec=models.Article,
-            aop_url_segs=None,
-            url_segment="10.151/S1518-8787.2019053000621",
-            pid="pid-aop",
-            issue=self.issue,
-        )
-        MockArticleObjects.get.return_value = MockArticle
-        MockIssueObjects.get.return_value = self.issue
-        regular_issue_id = None
-
-        # ArticleFactory
-        self.document = ArticleFactory(
-            "67TH7T7CyPPmgtVrGXhWXVs", self.document_front,
-            regular_issue_id, "1", ""
-        )
-        msg = (
-            "Divergência nos dados de `issue` do documento "
-            "(document_id=67TH7T7CyPPmgtVrGXhWXVs): "
-            "{'kernel/front': {'volume': '53', 'number': ''}, "
-            "'website': {'issue_id': '0101-0101-aop', "
-            "'volume': None, 'number': 'ahead'}}"
-        )
-        mock_logging.warning.assert_called_once_with(msg)
-
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -703,7 +703,7 @@ class RegisterDocumentTests(unittest.TestCase):
 
         try_register_documents(
             documents=self.documents,
-            get_relation_data=lambda document_id: (
+            get_relation_data=lambda document_id, _front_data: (
                 "issue-1",
                 {"id": "67TH7T7CyPPmgtVrGXhWXVs", "order": "01"},
             ),
@@ -719,7 +719,7 @@ class RegisterDocumentTests(unittest.TestCase):
 
         try_register_documents(
             documents=self.documents,
-            get_relation_data=lambda _: ("", {}),
+            get_relation_data=lambda _, _front_data: ("", {}),
             fetch_document_front=fetch_document_front_mock,
             article_factory=article_factory_mock,
         )
@@ -734,7 +734,7 @@ class RegisterDocumentTests(unittest.TestCase):
 
         try_register_documents(
             documents=self.documents,
-            get_relation_data=lambda _: (
+            get_relation_data=lambda _, _front_data: (
                 "issue-1",
                 {"id": "67TH7T7CyPPmgtVrGXhWXVs", "order": "01"},
             ),


### PR DESCRIPTION
#### O que esse PR faz?
Permite que documentos sejam resincronizados no site sem a dependência de estar listados em changes, pois de fato não houve mudança nos dados, mas sim bug na sincronização.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Incluir pid v3 na lista de orphan_documents e executar o `sync_kernel_to_website`. Verificar no log que há as mensagens."
```
[2021-05-04 21:29:37,391] {sync_kernel_to_website.py:168} INFO - Unable to find QTsr9VQHDd4DL5zqWqkwyjk in bundles changes. Try to get bundle_id and order from Kernel
[2021-05-04 21:29:37,416] {base_hook.py:89} INFO - Using connection to: id: kernel_conn. Host: 192.168.1.19, Port: 6543, Schema: None, Login: None, Password: None, extra: None
[2021-05-04 21:29:37,421] {http_hook.py:136} INFO - Sending 'GET' to url: http://192.168.1.19:6543/bundles/2236-9996-2020-v22-n47
[2021-05-04 21:29:37,434] {sync_kernel_to_website.py:190} INFO - Got bundle_id and order from Kernel: 2236-9996-2020-v22-n47 {'id': 'QTsr9VQHDd4DL5zqWqkwyjk', 'order': '00017'}
[2021-05-04 21:29:37,515] {sync_kernel_to_website_operations.py:356} INFO - ISSUE Cad. Metrop., 2020 22(47)
[2021-05-04 21:29:37,525] {sync_kernel_to_website_operations.py:357} INFO - ARTICLE.ISSUE Cad. Metrop., 2020 22(47)
[2021-05-04 21:29:37,598] {sync_kernel_to_website_operations.py:424} INFO - ARTICLE saved QTsr9VQHDd4DL5zqWqkwyjk 2236-9996-2020-v22-n47
```

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#274

### Referências
n/a
