### PR TITLE
[sync_kernel_to_website] Não considerar o ahead como último número

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -813,7 +813,8 @@ def register_last_issues(ds, **kwargs):
         try:
             logging.info("Id do journal: %s" % journal._id)
             last_j_issue = (
-                models.Issue.objects.filter(journal=journal._id, is_public=True)
+                models.Issue.objects.filter(
+                    journal=journal._id, is_public=True, number__ne="ahead")
                 .order_by("-year", "-order")
                 .first()
                 .select_related()


### PR DESCRIPTION
#### O que esse PR faz?
Não considerar o ahead como último número ao atualizar o `last_issue` de Journal.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executar o sync_kernel_to_website e verificar que nenhum last_issue será ahead.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots

```
[2021-05-05 15:31:11,794] {sync_kernel_to_website.py:827} INFO - Novos estud. CEBRAP, 9999 (ahead)
[2021-05-05 15:31:11,798] {sync_kernel_to_website.py:828} INFO - Novos estud. CEBRAP, 2020 39(2)
```

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/1866

### Referências
n/a
