### PR TITLE
Conserta a formação do issue.label

### DIFF
--- a/airflow/tests/fixtures/kernel-issues-0001-3714-1998-aop.json
+++ b/airflow/tests/fixtures/kernel-issues-0001-3714-1998-aop.json
@@ -1,0 +1,75 @@
+{
+    "_id": "0001-3714-1998-aop",
+    "created": "1998-09-01T00:00:00.000000Z",
+    "updated": "2020-04-28T20:16:24.459467Z",
+    "items": [
+        {
+            "id": "bZX7rgXBcGQvrnDTmzbWzcT",
+            "order": "00208"
+        },
+        {
+            "id": "ccR6t3WVJ5zBjF8rjHHNF3y",
+            "order": "00228"
+        },
+        {
+            "id": "jNwCMvMDT9ZNKLKwKDd6pSJ",
+            "order": "00164"
+        },
+        {
+            "id": "dYJ4tzVhD3sNsbkRV6GgWHB",
+            "order": "00222"
+        },
+        {
+            "id": "8zSJvZ4fvBcFyn594CwyHQG",
+            "order": "00187"
+        },
+        {
+            "id": "MP6KG3V8rMsPwFKr4XPyCfG",
+            "order": "00197"
+        },
+        {
+            "id": "ycHKbKpGhmVbM3fjT8xLXHQ",
+            "order": "00213"
+        },
+        {
+            "id": "yMbDgprf3JrhS3fckGndyhy",
+            "order": "00183"
+        },
+        {
+            "id": "SDqNBws9vPCNxfNcsJfpqKL",
+            "order": "00167"
+        },
+        {
+            "id": "bYyxrmzfVh6PdMkp7vDBPwg",
+            "order": "00159"
+        },
+        {
+            "id": "NyQMYVKpfqQwyYjt7cm69jz",
+            "order": "00202"
+        },
+        {
+            "id": "Q7dtb49KL5S4KfrQKqPh7hc",
+            "order": "00219"
+        },
+        {
+            "id": "HsThZj7D5dNP55tRQwq8ynf",
+            "order": "00193"
+        },
+        {
+            "id": "k54PVgjsVYS4rwLXnhxQcZN",
+            "order": "00174"
+        },
+        {
+            "id": "zg9M58b9Z7bCQ9hwMjSdx6B",
+            "order": "00170"
+        },
+        {
+            "id": "gZ4wYHT3rDDxTvfk9hKmvTJ",
+            "order": "00179"
+        }
+    ],
+    "metadata": {
+        "pid": "0001-371419980003"
+    },
+    "id": "0001-3714-1998-aop"
+}

--- a/airflow/tests/fixtures/kernel-issues-0001-3714-1998-n3-s0.json
+++ b/airflow/tests/fixtures/kernel-issues-0001-3714-1998-n3-s0.json
@@ -1,0 +1,84 @@
+{
+    "_id": "0001-3714-1998-n3-s0",
+    "created": "1998-09-01T00:00:00.000000Z",
+    "updated": "2020-04-28T20:16:24.459467Z",
+    "items": [
+        {
+            "id": "bZX7rgXBcGQvrnDTmzbWzcT",
+            "order": "00208"
+        },
+        {
+            "id": "ccR6t3WVJ5zBjF8rjHHNF3y",
+            "order": "00228"
+        },
+        {
+            "id": "jNwCMvMDT9ZNKLKwKDd6pSJ",
+            "order": "00164"
+        },
+        {
+            "id": "dYJ4tzVhD3sNsbkRV6GgWHB",
+            "order": "00222"
+        },
+        {
+            "id": "8zSJvZ4fvBcFyn594CwyHQG",
+            "order": "00187"
+        },
+        {
+            "id": "MP6KG3V8rMsPwFKr4XPyCfG",
+            "order": "00197"
+        },
+        {
+            "id": "ycHKbKpGhmVbM3fjT8xLXHQ",
+            "order": "00213"
+        },
+        {
+            "id": "yMbDgprf3JrhS3fckGndyhy",
+            "order": "00183"
+        },
+        {
+            "id": "SDqNBws9vPCNxfNcsJfpqKL",
+            "order": "00167"
+        },
+        {
+            "id": "bYyxrmzfVh6PdMkp7vDBPwg",
+            "order": "00159"
+        },
+        {
+            "id": "NyQMYVKpfqQwyYjt7cm69jz",
+            "order": "00202"
+        },
+        {
+            "id": "Q7dtb49KL5S4KfrQKqPh7hc",
+            "order": "00219"
+        },
+        {
+            "id": "HsThZj7D5dNP55tRQwq8ynf",
+            "order": "00193"
+        },
+        {
+            "id": "k54PVgjsVYS4rwLXnhxQcZN",
+            "order": "00174"
+        },
+        {
+            "id": "zg9M58b9Z7bCQ9hwMjSdx6B",
+            "order": "00170"
+        },
+        {
+            "id": "gZ4wYHT3rDDxTvfk9hKmvTJ",
+            "order": "00179"
+        }
+    ],
+    "metadata": {
+        "publication_year": "1998",
+        "number": "3",
+        "supplement": "0",
+        "publication_months": {
+            "range": [
+                9,
+                9
+            ]
+        },
+        "pid": "0001-371419980003"
+    },
+    "id": "0001-3714-1998-n3-s0"
+}

--- a/airflow/tests/fixtures/kernel-issues-0001-3714-1998-n3.json
+++ b/airflow/tests/fixtures/kernel-issues-0001-3714-1998-n3.json
@@ -1,0 +1,83 @@
+{
+    "_id": "0001-3714-1998-n3",
+    "created": "1998-09-01T00:00:00.000000Z",
+    "updated": "2020-04-28T20:16:24.459467Z",
+    "items": [
+        {
+            "id": "bZX7rgXBcGQvrnDTmzbWzcT",
+            "order": "00208"
+        },
+        {
+            "id": "ccR6t3WVJ5zBjF8rjHHNF3y",
+            "order": "00228"
+        },
+        {
+            "id": "jNwCMvMDT9ZNKLKwKDd6pSJ",
+            "order": "00164"
+        },
+        {
+            "id": "dYJ4tzVhD3sNsbkRV6GgWHB",
+            "order": "00222"
+        },
+        {
+            "id": "8zSJvZ4fvBcFyn594CwyHQG",
+            "order": "00187"
+        },
+        {
+            "id": "MP6KG3V8rMsPwFKr4XPyCfG",
+            "order": "00197"
+        },
+        {
+            "id": "ycHKbKpGhmVbM3fjT8xLXHQ",
+            "order": "00213"
+        },
+        {
+            "id": "yMbDgprf3JrhS3fckGndyhy",
+            "order": "00183"
+        },
+        {
+            "id": "SDqNBws9vPCNxfNcsJfpqKL",
+            "order": "00167"
+        },
+        {
+            "id": "bYyxrmzfVh6PdMkp7vDBPwg",
+            "order": "00159"
+        },
+        {
+            "id": "NyQMYVKpfqQwyYjt7cm69jz",
+            "order": "00202"
+        },
+        {
+            "id": "Q7dtb49KL5S4KfrQKqPh7hc",
+            "order": "00219"
+        },
+        {
+            "id": "HsThZj7D5dNP55tRQwq8ynf",
+            "order": "00193"
+        },
+        {
+            "id": "k54PVgjsVYS4rwLXnhxQcZN",
+            "order": "00174"
+        },
+        {
+            "id": "zg9M58b9Z7bCQ9hwMjSdx6B",
+            "order": "00170"
+        },
+        {
+            "id": "gZ4wYHT3rDDxTvfk9hKmvTJ",
+            "order": "00179"
+        }
+    ],
+    "metadata": {
+        "publication_year": "1998",
+        "number": "3",
+        "publication_months": {
+            "range": [
+                9,
+                9
+            ]
+        },
+        "pid": "0001-371419980003"
+    },
+    "id": "0001-3714-1998-n3"
+}

--- a/airflow/tests/fixtures/kernel-issues-0001-3714-1998-v29-s0.json
+++ b/airflow/tests/fixtures/kernel-issues-0001-3714-1998-v29-s0.json
@@ -1,0 +1,84 @@
+{
+    "_id": "0001-3714-1998-v29-s0",
+    "created": "1998-09-01T00:00:00.000000Z",
+    "updated": "2020-04-28T20:16:24.459467Z",
+    "items": [
+        {
+            "id": "bZX7rgXBcGQvrnDTmzbWzcT",
+            "order": "00208"
+        },
+        {
+            "id": "ccR6t3WVJ5zBjF8rjHHNF3y",
+            "order": "00228"
+        },
+        {
+            "id": "jNwCMvMDT9ZNKLKwKDd6pSJ",
+            "order": "00164"
+        },
+        {
+            "id": "dYJ4tzVhD3sNsbkRV6GgWHB",
+            "order": "00222"
+        },
+        {
+            "id": "8zSJvZ4fvBcFyn594CwyHQG",
+            "order": "00187"
+        },
+        {
+            "id": "MP6KG3V8rMsPwFKr4XPyCfG",
+            "order": "00197"
+        },
+        {
+            "id": "ycHKbKpGhmVbM3fjT8xLXHQ",
+            "order": "00213"
+        },
+        {
+            "id": "yMbDgprf3JrhS3fckGndyhy",
+            "order": "00183"
+        },
+        {
+            "id": "SDqNBws9vPCNxfNcsJfpqKL",
+            "order": "00167"
+        },
+        {
+            "id": "bYyxrmzfVh6PdMkp7vDBPwg",
+            "order": "00159"
+        },
+        {
+            "id": "NyQMYVKpfqQwyYjt7cm69jz",
+            "order": "00202"
+        },
+        {
+            "id": "Q7dtb49KL5S4KfrQKqPh7hc",
+            "order": "00219"
+        },
+        {
+            "id": "HsThZj7D5dNP55tRQwq8ynf",
+            "order": "00193"
+        },
+        {
+            "id": "k54PVgjsVYS4rwLXnhxQcZN",
+            "order": "00174"
+        },
+        {
+            "id": "zg9M58b9Z7bCQ9hwMjSdx6B",
+            "order": "00170"
+        },
+        {
+            "id": "gZ4wYHT3rDDxTvfk9hKmvTJ",
+            "order": "00179"
+        }
+    ],
+    "metadata": {
+        "publication_year": "1998",
+        "volume": "29",
+        "supplement": "0",
+        "publication_months": {
+            "range": [
+                9,
+                9
+            ]
+        },
+        "pid": "0001-371419980003"
+    },
+    "id": "0001-3714-1998-v29-s0"
+}

--- a/airflow/tests/fixtures/kernel-issues-0001-3714-1998-v29.json
+++ b/airflow/tests/fixtures/kernel-issues-0001-3714-1998-v29.json
@@ -1,0 +1,83 @@
+{
+    "_id": "0001-3714-1998-v29",
+    "created": "1998-09-01T00:00:00.000000Z",
+    "updated": "2020-04-28T20:16:24.459467Z",
+    "items": [
+        {
+            "id": "bZX7rgXBcGQvrnDTmzbWzcT",
+            "order": "00208"
+        },
+        {
+            "id": "ccR6t3WVJ5zBjF8rjHHNF3y",
+            "order": "00228"
+        },
+        {
+            "id": "jNwCMvMDT9ZNKLKwKDd6pSJ",
+            "order": "00164"
+        },
+        {
+            "id": "dYJ4tzVhD3sNsbkRV6GgWHB",
+            "order": "00222"
+        },
+        {
+            "id": "8zSJvZ4fvBcFyn594CwyHQG",
+            "order": "00187"
+        },
+        {
+            "id": "MP6KG3V8rMsPwFKr4XPyCfG",
+            "order": "00197"
+        },
+        {
+            "id": "ycHKbKpGhmVbM3fjT8xLXHQ",
+            "order": "00213"
+        },
+        {
+            "id": "yMbDgprf3JrhS3fckGndyhy",
+            "order": "00183"
+        },
+        {
+            "id": "SDqNBws9vPCNxfNcsJfpqKL",
+            "order": "00167"
+        },
+        {
+            "id": "bYyxrmzfVh6PdMkp7vDBPwg",
+            "order": "00159"
+        },
+        {
+            "id": "NyQMYVKpfqQwyYjt7cm69jz",
+            "order": "00202"
+        },
+        {
+            "id": "Q7dtb49KL5S4KfrQKqPh7hc",
+            "order": "00219"
+        },
+        {
+            "id": "HsThZj7D5dNP55tRQwq8ynf",
+            "order": "00193"
+        },
+        {
+            "id": "k54PVgjsVYS4rwLXnhxQcZN",
+            "order": "00174"
+        },
+        {
+            "id": "zg9M58b9Z7bCQ9hwMjSdx6B",
+            "order": "00170"
+        },
+        {
+            "id": "gZ4wYHT3rDDxTvfk9hKmvTJ",
+            "order": "00179"
+        }
+    ],
+    "metadata": {
+        "publication_year": "1998",
+        "volume": "29",
+        "publication_months": {
+            "range": [
+                9,
+                9
+            ]
+        },
+        "pid": "0001-371419980003"
+    },
+    "id": "0001-3714-1998-v29"
+}

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -207,6 +207,200 @@ class IssueFactoryTests(unittest.TestCase):
         self.assertTrue(self.issue.is_public)
 
 
+class IssueFactoryVolSupplTests(unittest.TestCase):
+    def setUp(self):
+        self.mongo_connect_mock = patch(
+            "sync_kernel_to_website.mongo_connect"
+        )
+        self.mongo_connect_mock.start()
+        self.journal_objects = patch(
+            "sync_kernel_to_website.models.Journal.objects"
+        )
+        self.MockJournal = MagicMock(spec=models.Journal)
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = self.MockJournal
+        self.issue_objects = patch("sync_kernel_to_website.models.Issue.objects")
+        IssueObjectsMock = self.issue_objects.start()
+        IssueObjectsMock.get.side_effect = models.Issue.DoesNotExist
+
+        self.issue_data = load_json_fixture("kernel-issues-0001-3714-1998-v29-s0.json")
+        self.issue = IssueFactory(self.issue_data, "0001-3714", "12345")
+
+    def tearDown(self):
+        self.mongo_connect_mock.stop()
+        self.journal_objects.stop()
+        self.issue_objects.stop()
+
+    def test_attribute_number(self):
+        self.assertEqual(self.issue.number, None)
+
+    def test_attribute_volume(self):
+        self.assertEqual(self.issue.volume, "29")
+
+    def test_attribute_label(self):
+        self.assertEqual(self.issue.label, "v29s0")
+
+    def test_attribute_suppl_text(self):
+        self.assertEqual(self.issue.suppl_text, "0")
+
+    def test_attribute_type(self):
+        self.assertEqual(self.issue.type, "supplement")
+
+
+class IssueFactoryNumSupplTests(unittest.TestCase):
+    def setUp(self):
+        self.mongo_connect_mock = patch(
+            "sync_kernel_to_website.mongo_connect"
+        )
+        self.mongo_connect_mock.start()
+        self.journal_objects = patch(
+            "sync_kernel_to_website.models.Journal.objects"
+        )
+        self.MockJournal = MagicMock(spec=models.Journal)
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = self.MockJournal
+        self.issue_objects = patch("sync_kernel_to_website.models.Issue.objects")
+        IssueObjectsMock = self.issue_objects.start()
+        IssueObjectsMock.get.side_effect = models.Issue.DoesNotExist
+
+        self.issue_data = load_json_fixture("kernel-issues-0001-3714-1998-n3-s0.json")
+        self.issue = IssueFactory(self.issue_data, "0001-3714", "12345")
+
+    def test_attribute_number(self):
+        self.assertEqual(self.issue.number, "3")
+
+    def test_attribute_volume(self):
+        # idealmente volume deveria ser None
+        self.assertEqual(self.issue.volume, '')
+
+    def test_attribute_label(self):
+        self.assertEqual(self.issue.label, "n3s0")
+
+    def test_attribute_suppl_text(self):
+        self.assertEqual(self.issue.suppl_text, "0")
+
+    def test_attribute_type(self):
+        self.assertEqual(self.issue.type, "supplement")
+
+
+class IssueFactoryVolTests(unittest.TestCase):
+    def setUp(self):
+        self.mongo_connect_mock = patch(
+            "sync_kernel_to_website.mongo_connect"
+        )
+        self.mongo_connect_mock.start()
+        self.journal_objects = patch(
+            "sync_kernel_to_website.models.Journal.objects"
+        )
+        self.MockJournal = MagicMock(spec=models.Journal)
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = self.MockJournal
+        self.issue_objects = patch("sync_kernel_to_website.models.Issue.objects")
+        IssueObjectsMock = self.issue_objects.start()
+        IssueObjectsMock.get.side_effect = models.Issue.DoesNotExist
+
+        self.issue_data = load_json_fixture("kernel-issues-0001-3714-1998-v29.json")
+        self.issue = IssueFactory(self.issue_data, "0001-3714", "12345")
+
+    def test_attribute_number(self):
+        self.assertIsNone(self.issue.number)
+
+    def test_attribute_volume(self):
+        self.assertEqual(self.issue.volume, "29")
+
+    def test_attribute_label(self):
+        self.assertEqual(self.issue.label, "v29")
+
+    def test_attribute_suppl_text(self):
+        self.assertIsNone(self.issue.suppl_text)
+
+    def test_attribute_type(self):
+        # deveria ser regular ou publicação contínua...
+        self.assertEqual(self.issue.type, "volume_issue")
+
+
+class IssueFactoryNumTests(unittest.TestCase):
+    def setUp(self):
+        self.mongo_connect_mock = patch(
+            "sync_kernel_to_website.mongo_connect"
+        )
+        self.mongo_connect_mock.start()
+        self.journal_objects = patch(
+            "sync_kernel_to_website.models.Journal.objects"
+        )
+        self.MockJournal = MagicMock(spec=models.Journal)
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = self.MockJournal
+        self.issue_objects = patch("sync_kernel_to_website.models.Issue.objects")
+        IssueObjectsMock = self.issue_objects.start()
+        IssueObjectsMock.get.side_effect = models.Issue.DoesNotExist
+
+        self.issue_data = load_json_fixture("kernel-issues-0001-3714-1998-n3.json")
+        self.issue = IssueFactory(self.issue_data, "0001-3714", "12345")
+
+    def tearDown(self):
+        self.mongo_connect_mock.stop()
+        self.journal_objects.stop()
+        self.issue_objects.stop()
+
+    def test_attribute_number(self):
+        self.assertEqual(self.issue.number, "3")
+
+    def test_attribute_volume(self):
+        # idealmente volume deveria ser None
+        self.assertEqual(self.issue.volume, "")
+
+    def test_attribute_label(self):
+        self.assertEqual(self.issue.label, "n3")
+
+    def test_attribute_suppl_text(self):
+        self.assertIsNone(self.issue.suppl_text)
+
+    def test_attribute_type(self):
+        self.assertEqual(self.issue.type, "regular")
+
+
+class IssueFactoryAOPTests(unittest.TestCase):
+    def setUp(self):
+        self.mongo_connect_mock = patch(
+            "sync_kernel_to_website.mongo_connect"
+        )
+        self.mongo_connect_mock.start()
+        self.journal_objects = patch(
+            "sync_kernel_to_website.models.Journal.objects"
+        )
+        self.MockJournal = MagicMock(spec=models.Journal)
+        JournalObjectsMock = self.journal_objects.start()
+        JournalObjectsMock.get.return_value = self.MockJournal
+        self.issue_objects = patch("sync_kernel_to_website.models.Issue.objects")
+        IssueObjectsMock = self.issue_objects.start()
+        IssueObjectsMock.get.side_effect = models.Issue.DoesNotExist
+
+        self.issue_data = load_json_fixture("kernel-issues-0001-3714-1998-aop.json")
+        self.issue = IssueFactory(self.issue_data, "0001-3714", "12345")
+
+    def tearDown(self):
+        self.mongo_connect_mock.stop()
+        self.journal_objects.stop()
+        self.issue_objects.stop()
+
+    def test_attribute_number(self):
+        self.assertIsNone(self.issue.number)
+
+    def test_attribute_volume(self):
+        # idealmente volume deveria ser None
+        self.assertEqual(self.issue.volume, '')
+
+    def test_attribute_label(self):
+        self.assertIsNone(self.issue.label)
+
+    def test_attribute_suppl_text(self):
+        self.assertIsNone(self.issue.suppl_text)
+
+    def test_attribute_type(self):
+        self.assertEqual(self.issue.type, "ahead")
+
+
 class ArticleFactoryTests(unittest.TestCase):
     def setUp(self):
         self.article_objects = patch(


### PR DESCRIPTION

#### O que esse PR faz?
Conserta a formação do issue.label: quando há volume, prefixar com `v`, se há número prefixar com `n`, se há suplemento prefixar com `s`.

#### Onde a revisão poderia começar?
airflow/dags/sync_kernel_to_website.py

#### Como este poderia ser testado manualmente?
Executando a sincronização do kernel com o site, ao registrar fascículos.

#### Algum cenário de contexto que queira dar?
Este campo é usado para obter, por exemplo, os pdf com url no formato `/pdf/<acron>/<issue_label>/<filename>.pdf`

### Screenshots
n/a

#### Quais são tickets relevantes?
#279 e https://github.com/scieloorg/opac/issues/1921

Ambos relacionados com o problema de ficar inacessíveis os pdfs acessados por este formato de rota: `/pdf/<acron>/<issue_label>/<filename>.pdf`

### Referências
n/a