### PR TITLE
Corrige a atualização de Article.aop_pid. Considera também que kernel…

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -97,25 +97,6 @@ def ArticleFactory(
         if _previous_id:
             return _previous_id
 
-        # tenta obter pelo `article_publisher_id`
-        article_meta = _nestget(data, "article_meta", 0)
-        if not article_meta:
-            return
-
-        scielo_pid_v2 = _nestget(article_meta, "scielo_pid_v2", 0)
-        scielo_pid_v3 = _nestget(article_meta, "scielo_pid_v3", 0)
-        article_ids = set(_nestget(article_meta, "article_publisher_id"))
-
-        # desconsidera pid v2 e v3
-        pids = article_ids - {scielo_pid_v3} - {scielo_pid_v2}
-
-        # dentre os pids que sobraram, retorna um que faça
-        # match com o padrão de pid v2
-        for pid in pids:
-            _matched = match(scielo_pid_v2[:10] + r"(\d{13})", pid)
-            if _matched and _matched.group() == pid:
-                return pid
-
     AUTHOR_CONTRIB_TYPES = (
         "author",
         "editor",
@@ -153,10 +134,8 @@ def ArticleFactory(
         version: value for version, value in scielo_pids if value is not None
     }
 
-    _previous_id = _get_previous_pid(data)
-    if _previous_id:
-        article.aop_pid = _previous_id
-        article.pid = article.scielo_pids.get("v2")
+    article.aop_pid = _get_previous_pid(data)
+    article.pid = article.scielo_pids.get("v2")
 
     article.doi = _nestget(data, "article_meta", 0, "article_doi", 0)
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -729,7 +729,7 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
             regular_issue_id, "1", ""
         )
         self.assertEqual(self.document.pid, "S1518-87872019053000621")
-        self.assertEqual(self.document.aop_pid, "S1518-87872019005000621")
+        self.assertIsNone(self.document.aop_pid)
 
     def test_article_factory_creates_aop_id_from_previous_pid_and_update_pid_with_scielo_pids_v2(
             self, MockIssueObjects, MockArticleObjects):


### PR DESCRIPTION
…/front já explicita `previous_pid`.

#### O que esse PR faz?
Corrige a atualização de Article.aop_pid. Considera também que kernel/front já explicita `previous_pid`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Atualize a variável de ambiente que tem os órfãos.
Executande `sync_kernel_to_website` e verifique que os dados do documento no site foi atualizado (campo aop_pid)

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/clea/pull/7
Tem também a ver com a disponibilidade de documentos ex-aop.

### Referências
Indique as referências utilizadas para a elaboração do pull request.