### PR TITLE
Modifica a forma de atualizar e loga os valores de `article.aop_pid` e `article.pid`

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -87,16 +87,6 @@ def ArticleFactory(
         models.Article: Instância de um artigo próprio do modelo de dados do
             OPAC.
     """
-
-    def _get_previous_pid(data):
-        """Recupera previous-pid, se existir
-        Retorna str ou None"""
-
-        # depende de uma melhoria no clea
-        _previous_id = _nestget(data, "article_meta", 0, "previous_pid", 0)
-        if _previous_id:
-            return _previous_id
-
     AUTHOR_CONTRIB_TYPES = (
         "author",
         "editor",
@@ -134,7 +124,7 @@ def ArticleFactory(
         version: value for version, value in scielo_pids if value is not None
     }
 
-    article.aop_pid = _get_previous_pid(data)
+    article.aop_pid = _nestget(data, "article_meta", 0, "previous_pid", 0)
     article.pid = article.scielo_pids.get("v2")
 
     article.doi = _nestget(data, "article_meta", 0, "article_doi", 0)
@@ -334,10 +324,12 @@ def ArticleFactory(
 
     logging.info("ISSUE %s" % str(issue))
     logging.info("ARTICLE.ISSUE %s" % str(article.issue))
+    logging.info("ARTICLE.AOP_PID %s" % str(article.aop_pid))
+    logging.info("ARTICLE.PID %s" % str(article.pid))
 
     article.issue = issue
     article.journal = issue.journal
-    article.order = _get_order(document_order, article.scielo_pids.get("v2"))
+    article.order = _get_order(document_order, article.pid)
     article.xml = document_xml_url
 
     # Campo de compatibilidade do OPAC

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -729,7 +729,7 @@ class ExAOPArticleFactoryTests(unittest.TestCase):
             regular_issue_id, "1", ""
         )
         self.assertEqual(self.document.pid, "S1518-87872019053000621")
-        self.assertIsNone(self.document.aop_pid)
+        self.assertEqual(self.document.aop_pid, '')
 
     def test_article_factory_creates_aop_id_from_previous_pid_and_update_pid_with_scielo_pids_v2(
             self, MockIssueObjects, MockArticleObjects):


### PR DESCRIPTION
#### O que esse PR faz?
Modifica a forma de atualizar e loga os valores de `article.aop_pid` e `article.pid`

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Verificar a informação que ficou logada.

#### Algum cenário de contexto que queira dar?
Aparentemente o `article.aop_pid` não foi atualizado mesmo com o PR aplicado anteriormente.

### Screenshots

<img width="293" alt="Captura de Tela 2021-06-04 às 08 48 38" src="https://user-images.githubusercontent.com/505143/120796866-b6fbc000-c511-11eb-9781-d84f7b838e8d.png">

<img width="1390" alt="Captura de Tela 2021-06-04 às 08 42 40" src="https://user-images.githubusercontent.com/505143/120796556-53719280-c511-11eb-9f40-4a5e28c03983.png">

<img width="440" alt="Captura de Tela 2021-06-04 às 08 41 12" src="https://user-images.githubusercontent.com/505143/120796544-510f3880-c511-11eb-81f5-2a0e016a1583.png">


#### Quais são tickets relevantes?
#279

### Referências
n/a