### PR TITLE
Corrige o status do documento para `publicado`

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -112,6 +112,9 @@ def ArticleFactory(
     except models.Article.DoesNotExist:
         article = models.Article()
 
+    # atualiza status
+    article.is_public = True
+
     # Dados principais
     article.title = _get_main_article_title(data)
     article.section = _nestget(data, "article_meta", 0, "pub_subject", 0)


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o status do documento para `publicado`. 
O documento fica com o status errado porque a versão anterior entrou no site como "apagado", então o status é `False`.
E ao ingressar no site para ser publicado, o seu status não estava sendo atualizado para `True`. Este PR é para corrigir este defeito.

#### Onde a revisão poderia começar?
Por commits

#### Como este poderia ser testado manualmente?
Verificar um documento no site que está como não publicado.
Verificar o documento no kernel que está como publicado, ou seja, que a sua última versão não está "deleted".
Inserir o pid v3 na variável `orphans_documents` e executar a sincronização do kernel com o site.
Verificar que o artigo no site passou a ficar público.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
Quando aplicável e se fizer possível adicione screenshots que remetem a situação gráfica do problema que o pull request resolve.

#### Quais são tickets relevantes?
Indique uma issue ao qual o pull request faz relacionamento.

### Referências
Indique as referências utilizadas para a elaboração do pull request.