### PR TITLE
Insere em `scielo_pids['other']` também os valores `article_publisher_id` de kernel/front

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -135,6 +135,12 @@ def ArticleFactory(
     article.scielo_pids = {
         version: value for version, value in scielo_pids if value is not None
     }
+
+    # insere outros tipos de PIDs/IDs em `scielo_ids['other']`
+    article_publisher_id = _nestget(
+        data, "article_meta", 0, "article_publisher_id") or []
+    repeated_doc_pids = repeated_doc_pids or []
+    repeated_doc_pids = list(set(repeated_doc_pids + article_publisher_id))
     if repeated_doc_pids:
         article.scielo_pids.update({"other": repeated_doc_pids})
 


### PR DESCRIPTION
#### O que esse PR faz?
Insere em `scielo_pids['other']` também os valores `article_publisher_id` de kernel/front

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Tenha um documento como este
<img width="406" alt="Captura de Tela 2021-07-12 às 15 57 38" src="https://user-images.githubusercontent.com/505143/125341428-f942c900-e329-11eb-94a0-f6acb0f53ae2.png">

É esperado que na base do opac fique como:

```json

"scielo_pids" : {
        "v2" : "S1517-97022021000101203",
        "v3" : "89XTbcZcDv5Mb5nfDgQPzMt",
        "other": [
    "89XTbcZcDv5Mb5nfDgQPzMt",
    "S1517-97022021000101203",
    "cLqBPgzjH6PBjKPWxBZzn9L"
],
    }
```
#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
problemas de artigos não disponíveis

### Referências
n/a