### PR TITLE
Garante que a lista de author_meta seja objetos AuthorMeta.

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -178,15 +178,17 @@ def ArticleFactory(
         for contrib in _nestget(data, "contrib"):
             if _nestget(contrib, "contrib_type", 0) in AUTHOR_CONTRIB_TYPES:
                 authors.append(
-                    {'name':
-                        "%s, %s"
-                        % (
-                            _nestget(contrib, "contrib_surname", 0),
-                            _nestget(contrib, "contrib_given_names", 0),
-                        ),
-                     'orcid': _nestget(contrib, "contrib_orcid", 0),
-                     'affiliation': _get_author_affiliation(data, _nestget(contrib, "xref_aff", 0))
-                    }
+                    models.AuthorMeta(
+                        **{'name':
+                            "%s, %s"
+                            % (
+                                _nestget(contrib, "contrib_surname", 0),
+                                _nestget(contrib, "contrib_given_names", 0),
+                            ),
+                        'orcid': _nestget(contrib, "contrib_orcid", 0),
+                        'affiliation': _get_author_affiliation(data, _nestget(contrib, "xref_aff", 0))
+                        }
+                    )
                 )
 
         return authors

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -691,19 +691,19 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertEqual(1234, article.order)
 
     def test_authors_meta_has_attribute_name(self):
-        self.assertEqual(self.document.authors_meta[0].get('name'), "Kindermann, Lucas")
-        self.assertEqual(self.document.authors_meta[1].get('name'), "Traebert, Jefferson")
-        self.assertEqual(self.document.authors_meta[2].get('name'), "Nunes, Rodrigo Dias")
+        self.assertEqual(self.document.authors_meta[0].name, "Kindermann, Lucas")
+        self.assertEqual(self.document.authors_meta[1].name, "Traebert, Jefferson")
+        self.assertEqual(self.document.authors_meta[2].name, "Nunes, Rodrigo Dias")
 
     def test_authors_meta_has_attribute_orcid(self):
-        self.assertEqual(self.document.authors_meta[0].get('orcid'), "0000-0002-9789-501X")
-        self.assertEqual(self.document.authors_meta[1].get('orcid'), "0000-0002-7389-985X")
-        self.assertEqual(self.document.authors_meta[2].get('orcid'), "0000-0002-2261-8253")
+        self.assertEqual(self.document.authors_meta[0].orcid, "0000-0002-9789-501X")
+        self.assertEqual(self.document.authors_meta[1].orcid, "0000-0002-7389-985X")
+        self.assertEqual(self.document.authors_meta[2].orcid, "0000-0002-2261-8253")
 
     def test_authors_meta_has_attribute_affiliation(self):
-        self.assertEqual(self.document.authors_meta[0].get('affiliation'), "Universidade do Sul de Santa Catarina")
-        self.assertEqual(self.document.authors_meta[1].get('affiliation'), "Universidade do Sul de Santa Catarina")
-        self.assertEqual(self.document.authors_meta[2].get('affiliation'), "Universidade do Sul de Santa Catarina")
+        self.assertEqual(self.document.authors_meta[0].affiliation, "Universidade do Sul de Santa Catarina")
+        self.assertEqual(self.document.authors_meta[1].affiliation, "Universidade do Sul de Santa Catarina")
+        self.assertEqual(self.document.authors_meta[2].affiliation, "Universidade do Sul de Santa Catarina")
 
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")


### PR DESCRIPTION
#### O que esse PR faz?
Esse PR corrigi um erro adicionado na tag final v1.0.0-rc33

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Necessário um ambiente completo do opac-airflow para teste manual.

Indico somente rodar os testes manuais.
