### PR TITLE
Melhora o cadastro do authors_meta para garantir que não exista valores vazios.

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -177,19 +177,23 @@ def ArticleFactory(
 
         for contrib in _nestget(data, "contrib"):
             if _nestget(contrib, "contrib_type", 0) in AUTHOR_CONTRIB_TYPES:
-                authors.append(
-                    models.AuthorMeta(
-                        **{'name':
-                            "%s, %s"
-                            % (
-                                _nestget(contrib, "contrib_surname", 0),
-                                _nestget(contrib, "contrib_given_names", 0),
-                            ),
-                        'orcid': _nestget(contrib, "contrib_orcid", 0),
-                        'affiliation': _get_author_affiliation(data, _nestget(contrib, "xref_aff", 0))
-                        }
-                    )
+                author_dict = {}
+
+                author_dict['name'] = "%s, %s" % (
+                    _nestget(contrib, "contrib_surname", 0),
+                    _nestget(contrib, "contrib_given_names", 0),
                 )
+
+                if _nestget(contrib, "contrib_orcid", 0):
+                    author_dict['orcid'] = _nestget(contrib, "contrib_orcid", 0)
+
+                aff = _get_author_affiliation(
+                    data, _nestget(contrib, "xref_aff", 0))
+
+                if aff:
+                    author_dict['affiliation'] = aff
+
+                authors.append(models.AuthorMeta(**author_dict))
 
         return authors
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -705,6 +705,94 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertEqual(self.document.authors_meta[1].affiliation, "Universidade do Sul de Santa Catarina")
         self.assertEqual(self.document.authors_meta[2].affiliation, "Universidade do Sul de Santa Catarina")
 
+    def test_authors_meta_dont_add_empty_values(self):
+        """
+        Tests that no empty keys in arthors_meta are created.
+        """
+        document_dict = {"contrib": [
+                {
+                    "contrib_bio": [],
+                    "contrib_degrees": [],
+                    "contrib_email": [],
+                    "contrib_name": [
+                        "Kindermann Lucas"
+                    ],
+                    "contrib_given_names": [
+                        "Lucas"
+                    ],
+                    "contrib_prefix": [],
+                    "contrib_role": [],
+                    "contrib_suffix": [],
+                    "contrib_surname": [
+                        "Kindermann"
+                    ],
+                    "contrib_type": [
+                        "author"
+                    ],
+                    "xref_corresp": [
+                        "c1"
+                    ],
+                    "xref_corresp_text": [
+                        ""
+                    ],
+                    "xref_aff": [
+                        "aff1"
+                    ],
+                    "xref_aff_text": [
+                        "I"
+                    ]
+                }
+            ],
+            "aff": [
+                {
+                    "addr_city": [
+                        "Palhoça"
+                    ],
+                    "addr_country": [
+                        "Brasil"
+                    ],
+                    "addr_country_code": [
+                        "BR"
+                    ],
+                    "addr_postal_code": [],
+                    "addr_state": [
+                        "SC"
+                    ],
+                    "aff_id": [
+                        "aff1"
+                    ],
+                    "aff_text": [
+                        "I Universidade do Sul de Santa Catarina Universidade do Sul de Santa Catarina Faculdade de Medicina Palhoça SC Brasil Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+                    ],
+                    "aff_email": [],
+                    "institution_original": [
+                        "Universidade do Sul de Santa Catarina. Faculdade de Medicina. Palhoça, SC, Brasil"
+                    ],
+                    "institution_orgdiv1": [
+                        "Faculdade de Medicina"
+                    ],
+                    "institution_orgdiv2": [],
+                    "institution_orgname_rewritten": [
+                        "Universidade do Sul de Santa Catarina"
+                    ],
+                    "label": [
+                        "I"
+                    ],
+                    "phone": []
+                }
+            ]
+        }
+
+        document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", document_dict, "issue-1", 621, ""
+        )
+
+        self.assertTrue(hasattr(document, "authors_meta"))
+        self.assertIsNone(
+            document.authors_meta[0].orcid)
+        self.assertIsNone(
+            document.authors_meta[0].affiliation)
+
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR é uma melhoria no algoritmo que garante que não seja adicionado campos vazios na entidade author_meta

#### Onde a revisão poderia começar?

Por commit. 

#### Como este poderia ser testado manualmente?

Sugiro que seja utilizado os teste automático para testar esse PR, segue: 

```
docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest -v
````

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?

Esse PR é um melheria da atividade #290  

### Referências
N/A