### PR TITLE
Adiciona o ``suffix``  no nome do autor. 

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -155,9 +155,11 @@ def ArticleFactory(
         for contrib in _nestget(data, "contrib"):
             if _nestget(contrib, "contrib_type", 0) in AUTHOR_CONTRIB_TYPES:
                 yield (
-                    "%s, %s"
+                    "%s%s, %s"
                     % (
                         _nestget(contrib, "contrib_surname", 0),
+                        " " + _nestget(contrib, "contrib_suffix",
+                                       0) if _nestget(contrib, "contrib_suffix", 0) else "",
                         _nestget(contrib, "contrib_given_names", 0),
                     )
                 )
@@ -179,8 +181,10 @@ def ArticleFactory(
             if _nestget(contrib, "contrib_type", 0) in AUTHOR_CONTRIB_TYPES:
                 author_dict = {}
 
-                author_dict['name'] = "%s, %s" % (
+                author_dict['name'] = "%s%s, %s" % (
                     _nestget(contrib, "contrib_surname", 0),
+                    " " + _nestget(contrib, "contrib_suffix",
+                                   0) if _nestget(contrib, "contrib_suffix", 0) else "",
                     _nestget(contrib, "contrib_given_names", 0),
                 )
 

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -793,6 +793,57 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertIsNone(
             document.authors_meta[0].affiliation)
 
+    def test_authors_meta_return_suffix_on_author_name(self):
+        """
+        Tests if return the suffix of author name when exists.
+        """
+        document_dict = {"contrib": [
+                {
+                    "contrib_bio": [],
+                    "contrib_degrees": [],
+                    "contrib_email": [],
+                    "contrib_name": [
+                        "Kindermann Lucas"
+                    ],
+                    "contrib_given_names": [
+                        "Lucas"
+                    ],
+                    "contrib_prefix": [],
+                    "contrib_role": [],
+                    "contrib_suffix": [
+                        "Silva"
+                    ],
+                    "contrib_surname": [
+                        "Kindermann"
+                    ],
+                    "contrib_type": [
+                        "author"
+                    ],
+                    "xref_corresp": [
+                        "c1"
+                    ],
+                    "xref_corresp_text": [
+                        ""
+                    ],
+                    "xref_aff": [
+                        "aff1"
+                    ],
+                    "xref_aff_text": [
+                        "I"
+                    ]
+                }
+            ]
+        }
+
+        document = ArticleFactory(
+            "67TH7T7CyPPmgtVrGXhWXVs", document_dict, "issue-1", 621, ""
+        )
+
+        self.assertTrue(hasattr(document, "authors_meta"))
+
+        self.assertEqual(
+            document.authors_meta[0].name, "Kindermann Silva, Lucas")
+
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")
 @patch("operations.sync_kernel_to_website_operations.models.Issue.objects")

--- a/airflow/tests/test_sync_kernel_to_website.py
+++ b/airflow/tests/test_sync_kernel_to_website.py
@@ -811,7 +811,7 @@ class ArticleFactoryTests(unittest.TestCase):
                     "contrib_prefix": [],
                     "contrib_role": [],
                     "contrib_suffix": [
-                        "Silva"
+                        "Júnior"
                     ],
                     "contrib_surname": [
                         "Kindermann"
@@ -842,7 +842,7 @@ class ArticleFactoryTests(unittest.TestCase):
         self.assertTrue(hasattr(document, "authors_meta"))
 
         self.assertEqual(
-            document.authors_meta[0].name, "Kindermann Silva, Lucas")
+            document.authors_meta[0].name, "Kindermann Júnior, Lucas")
 
 
 @patch("operations.sync_kernel_to_website_operations.models.Article.objects")


### PR DESCRIPTION
#### O que esse PR faz?

Esse PR garante que o ``suffix`` esteja no nome do author.

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Sugiro rodar os teste para assegurar que essa implementação está funcionando.

```
docker-compose -f docker-compose-dev.yml exec opac-airflow python -m unittest -v
```

#### Algum cenário de contexto que queira dar?

Após atualizado o ambiente é necessário um reprocessamento dos artigos.

### Screenshots
N/A

#### Quais são tickets relevantes?

Tíquete referente a essa atividade: 

https://github.com/scieloorg/opac/issues/2017

### Referências
N/A