### PR TITLE
Corrige o erro `Unexpected error 'unhashable type: 'BaseList'`

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -561,7 +561,7 @@ def _unpublish_repeated_documents(document_id, doi):
         logging.info("Repeated document %s / %s / %s / %s" %
                      (doc._id, doc.pid, doc.aop_pid, str(doc.scielo_pids)))
         # obtém os pids
-        pids |= set(doc.scielo_pids and doc.scielo_pids.values() or [])
+        pids |= set(doc.scielo_pids and (doc.scielo_pids.get("other") or []))
         pids |= set([i for i in [doc._id, doc.pid, doc.aop_pid] if i])
 
         try:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige o erro `Unexpected error 'unhashable type: 'BaseList'` que ocorre porque os valores do dicionário `scielo_pids` são do tipo `str` e `list`. No caso, só interessa os valores de `scielo_pids['other']`.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Veja em #295 a seção como reproduzir o erro 

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#295 

### Referências
n/a