### PR TITLE
Adiciona o título anterior do periódico

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -405,6 +405,9 @@ def JournalFactory(data):
     if metadata.get("next_journal", ""):
         journal.next_title = metadata["next_journal"]["name"]
 
+    if metadata.get("previous_journal", ""):
+        journal.previous_journal_ref = metadata["previous_journal"]["name"]
+
     journal.created = data.get("created", "")
     journal.updated = data.get("updated", "")
 


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona o título anterior do periódico


#### Onde a revisão poderia começar?
 
Por commit. 

#### Como este poderia ser testado manualmente?

Necessário ter um instância local e rodar a DAG: **sync_kernel_to_website**

#### Algum cenário de contexto que queira dar?
 
Para ter efeito essa mudança é necessário que o kernel recebe uma alteração na lista de /changes para garantir que os periódicos sejam atualizados.

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências

Esse ajuste faz parte da resolução dos tíquetes: #1197 #1973 #1972 do OPAC.