### PR TITLE
Adicionar a capacidade de pupolar o campo related_articles

### DIFF
--- a/airflow/dags/common/sps_package.py
+++ b/airflow/dags/common/sps_package.py
@@ -399,3 +399,37 @@ class SPS_Package:
         """True if delete tag is present.
         """
         return self.xmltree.find(".//article-id[@specific-use='delete']") is not None
+
+    @property
+    def related_articles(self):
+        """Return a list of dict
+
+        Example:
+
+            "related_articles" : [
+                {
+                    "doi" : "10.1590/S0103-50532006000200015",
+                    "related_type" : "corrected-article"
+                },
+                {
+                    "doi" : "10.1590/S0103-5053200600020098983",
+                    "related_type" : "addendum"
+                },
+                {
+                    "doi" : "10.1590/S0103-50532006000200015",
+                    "related_type" : "retraction"
+                },
+            ]
+        """
+
+        related_list = []
+        for node in self.xmltree.findall(".//related-article"):
+            related_doi = node.attrib['{http://www.w3.org/1999/xlink}href']
+
+            related_dict = {}
+            related_dict['doi'] = related_doi
+            related_dict['related_type'] = node.attrib['related-article-type']
+
+            related_list.append(related_dict)
+
+        return related_list

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -386,7 +386,7 @@ def ArticleFactory(
         xlink:href="10.1590/S0103-50532006000200015"/>
         """
 
-        sps_package = SPS_Package(et.XML(resp.content))
+        sps_package = SPS_Package(et.XML(xml))
 
         for related_dict in sps_package.related_articles:
             if _update_related_articles(related_dict):

--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -385,8 +385,6 @@ def ArticleFactory(
         related-article-type="corrected-article"
         xlink:href="10.1590/S0103-50532006000200015"/>
         """
-        # # sps_package = SPS_Package(et.XML(xml))
-        # resp = requests.get('http://www.scielo.br/j/jbchs/a/Z6mnK3PjKhDZtHJQJYPzxpw/?lang=en&format=xml', verify=False)
 
         sps_package = SPS_Package(et.XML(resp.content))
 

--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -100,7 +100,7 @@ class Reader:
         return entities, last_timestamp
 
 
-def fetch_data(endpoint):
+def fetch_data(endpoint, json=True):
     """
     Obtém o JSON do endpoint do Kernel
     """
@@ -111,7 +111,11 @@ def fetch_data(endpoint):
     kernel_timeout = Variable.get("KERNEL_FETCH_DATA_TIMEOUT", default_var=None)
     if kernel_timeout:
         kwargs["timeout"] = int(kernel_timeout)
-    return kernel_connect(**kwargs).json()
+
+    if json:
+        return kernel_connect(**kwargs).json()
+    else:
+        return kernel_connect(**kwargs)
 
 
 def fetch_changes(since):
@@ -140,6 +144,13 @@ def fetch_documents_front(document_id):
          Obtém o JSON do Document do Kernel com base no parametro 'document_id'
     """
     return fetch_data("/documents/%s/front" % (document_id))
+
+
+def fetch_documents_xml(document_id):
+    """
+         Obtém o XML do Document do Kernel com base no parametro 'document_id'
+    """
+    return fetch_data("/documents/%s" % (document_id), json=False)
 
 
 def _get_relation_data_from_kernel_bundle(document_id, front_data=None):
@@ -727,7 +738,7 @@ def register_documents(**kwargs):
     )
 
     orphans = try_register_documents(
-        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory
+        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory, fetch_documents_xml,
     )
 
     Variable.set("orphan_documents", orphans, serialize_json=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ deepdiff[murmur]==4.0.7
 feedparser==5.2.1
 beautifulsoup4==4.9.0
 git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
-git+https://github.com/scieloorg/opac_schema.git@v2.58#egg=opac_schema
+git+https://github.com/scieloorg/opac_schema.git@v2.60#egg=opac_schema
 git+https://github.com/scieloorg/packtools.git@2.6.4#egg=packtools
 aiohttp==3.6.2


### PR DESCRIPTION
#### O que esse PR faz?

Adicionar a capacidade de pupolar o campo related_articles #301

#### Onde a revisão poderia começar?

Por commit.

#### Como este poderia ser testado manualmente?

Necessário ter um instância local e rodar a DAG: **sync_kernel_to_website**

#### Algum cenário de contexto que queira dar?

Para ter efeito essa mudança é necessário que o kernel recebe uma alteração na lista de /changes para os artigos de errata, adendo e retratação, para garantir que os periódicos sejam atualizados

### Screenshots
N/A

#### Quais são tickets relevantes?

#301 e https://github.com/scieloorg/opac/issues/2052

### Referências
N/A