### PR TITLE
Adiantamento sync isis to kernel

### DIFF
--- a/airflow/dags/sync_isis_to_kernel.py
+++ b/airflow/dags/sync_isis_to_kernel.py
@@ -377,6 +377,23 @@ def copy_mst_files_to_work_folder(**kwargs):
             desatination_path = os.path.join(WORK_ISIS_FILES, file)
             copying_paths.append([origin_path, desatination_path])
 
+    # obtém as title e issue de `airflow-gate`, se existirem,
+    # sobreescrevendo os arquivos que acabaram de ser obtidos de `bases`
+    try:
+        path = Variable.get("XC_SPS_PACKAGES_DIR")
+        if path:
+            files = [
+                f for f in os.listdir(path) if f.endswith(".xrf") or f.endswith(".mst")
+            ]
+            for file in files:
+                origin_path = os.path.join(path, file)
+                desatination_path = os.path.join(WORK_ISIS_FILES, file)
+                copying_paths.append([origin_path, desatination_path])
+    except Exception as e:
+        logging.exception(
+            "ERROR: Getting bases from %s : %s" %
+            (ALTERNATIVE_BASE_FOLDER_PATH, e))
+
     for origin, destination in copying_paths:
         logging.info("copying file from %s to %s." % (origin, destination))
         shutil.copy(origin, destination)

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -18,8 +18,8 @@ GERAPADRAO_ID=$(date "+%Y-%m-%d-%H%M%s")
 nohup ./CallPrepSyncToKernel.bat ${GERAPADRAO_ID} > /tmp/CallPrepSyncToKernel.out 2>&1 &
 
 ./PrepSyncToKernelCpBases.bat
+nohup ./CallTriggerSyncIsisToKernel.bat  ${GERAPADRAO_ID} > /tmp/CallTriggerSyncIsisToKernel.out 2>&1 &
 
 GeraScielo.bat .. .. log/GeraPadrao.log adiciona
 
-nohup ./CallTriggerSyncIsisToKernel.bat  ${GERAPADRAO_ID} > /tmp/CallTriggerSyncIsisToKernel.out 2>&1 &
 nohup ./CallGeraUriList.bat  ${GERAPADRAO_ID} > /tmp/CallGeraUriList.out 2>&1 &

--- a/proc/GeraPadrao.bat
+++ b/proc/GeraPadrao.bat
@@ -17,6 +17,8 @@ echo
 GERAPADRAO_ID=$(date "+%Y-%m-%d-%H%M%s")
 nohup ./CallPrepSyncToKernel.bat ${GERAPADRAO_ID} > /tmp/CallPrepSyncToKernel.out 2>&1 &
 
+./PrepSyncToKernelCpBases.bat
+
 GeraScielo.bat .. .. log/GeraPadrao.log adiciona
 
 nohup ./CallTriggerSyncIsisToKernel.bat  ${GERAPADRAO_ID} > /tmp/CallTriggerSyncIsisToKernel.out 2>&1 &

--- a/proc/PrepSyncToKernelCpBases.bat
+++ b/proc/PrepSyncToKernelCpBases.bat
@@ -1,0 +1,20 @@
+# Disponibiliza as bases title e issue em XC_KERNEL_GATE
+
+if [ -f SyncToKernel.ini ];
+then
+    . ./SyncToKernel.ini
+fi
+
+if [ "" != "${XC_KERNEL_GATE}" ] && [ -e ${XC_KERNEL_GATE} ];
+then
+    if [ -f ../serial/title/title.mst ];
+    then
+        cp ../serial/title/title.mst $XC_KERNEL_GATE
+        cp ../serial/title/title.xrf $XC_KERNEL_GATE
+    fi
+    if [ -f ../serial/issue/issue.mst ];
+    then
+        cp ../serial/issue/issue.mst $XC_KERNEL_GATE
+        cp ../serial/issue/issue.xrf $XC_KERNEL_GATE
+    fi
+fi


### PR DESCRIPTION
#### O que esse PR faz?
O procedimento da carga de dados no kernel é disparado após o término de `GeraScielo.bat` e está demorando demais devido à quantidade de pacotes zip a serem processados pelo airflow, atrasando a atualização do site. A intenção deste PR é fazer com que a carga ocorra antes de finalizar o GeraScielo de modo que não atrase a publicação.
Modifica o GeraPadrao para executar a carga de dados no kernel antes de finalizar o GeraScielo.
Inclui nova fonte de obtenção das bases title e issue para obter as bases mais atualizadas que aquelas que estão em `bases`, pois ao adiantar a carga de dados no kernel, estas bases ainda não foram atualizadas pelo GeraScielo.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
- Executando **PrepSyncToKernelCpBases.bat** e conferindo se as bases title e issue foram copiadas
- Executando a DAG sync_isis_to_kernel

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a
