### PR TITLE
Adiciona no recurso de descobertas dos artigos relacionados a capacidade de tratar mais um artigo com o mesmo DOI.

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -390,9 +390,22 @@ def ArticleFactory(
 
         if related_doi:
             try:
-                related_article = models.Article.objects.get(doi=related_doi)
+                related_article = models.Article.objects.get(doi=related_doi, is_public=True)
+            except models.Article.MultipleObjectsReturned as ex:
+                articles = models.Article.objects.filter(
+                    doi=related_doi, is_public=True)
+
+                logging.info("Foram encontrados na base de dados do site mais de 1 artigo com o DOI: %s. Lista de ID de artigos encontrados: %s" % (
+                    related_doi, [d.id for d in articles]))
+
+                # Quando existe mais de um registro no relacionamento, consideramos o primeiro encontrado.
+                first_found = articles[0]
+
+                logging.info("Para essa relação foi considerado o primeiro encontrado, artigo com id: %s" % first_found.id)
+                related_article = first_found
             except models.Article.DoesNotExist as ex:
-                logging.error("Não foi possível encontrar na base de dados do site o artigo com DOI: %s, portanto, não foi possível atualiza o related_articles do relacionado, com os dados: %s, erro: %s" % (article.doi, article_data, ex))
+                logging.error("Não foi possível encontrar na base de dados do site o artigo com DOI: %s, portanto, não foi possível atualiza o related_articles do relacionado, com os dados: %s, erro: %s" % (
+                    related_doi, article_data, ex))
             else:
 
                 related_article_model = models.RelatedArticle(**article_data)
@@ -406,14 +419,14 @@ def ArticleFactory(
                 # Atualiza a referência no ``ref_id`` no dicionário de ``related_article```
                 related_dict['ref_id'] = related_article._id
 
-            article_related_model = models.RelatedArticle(
-            **related_dict)
+                article_related_model = models.RelatedArticle(
+                **related_dict)
 
-            # Garante a unicidade da relação.
-            if article_related_model not in article.related_articles:
-                article.related_articles += [article_related_model]
-                logging.info("Relacionamento entre o documento processado: %s e seu relacionado: %s, realizado com sucesso. Tipo de relação entre os documentos: %s" % (
-                article.doi, related_dict.get('doi'), related_dict.get('related_type')))
+                # Garante a unicidade da relação.
+                if article_related_model not in article.related_articles:
+                    article.related_articles += [article_related_model]
+                    logging.info("Relacionamento entre o documento processado: %s e seu relacionado: %s, realizado com sucesso. Tipo de relação entre os documentos: %s" % (
+                    article.doi, related_dict.get('doi'), related_dict.get('related_type')))
 
 
     def _get_related_articles(xml):


### PR DESCRIPTION

#### O que esse PR faz?
Adiciona na (recurso) de descobertas dos artigos relacionados a capacidade de tratar mais um artigo com o mesmo **DOI**.

Adiciona melhorias nas mensagens.

Garante que seja pesquisado na base de dados apenas artigos públicos.

#### Onde a revisão poderia começar?

Pelo módulo airflow/dags/operations/sync_kernel_to_website_operations.py

#### Como este poderia ser testado manualmente?

Para testar manualmente é necessária uma errata ou retratação, ou adendo e garantir que esta relacionando um **DOI** duplicado na base de dados do site. 

#### Algum cenário de contexto que queira dar?

Quando é encontrado mais de um é elegido para o relacionamento o primeiro encontrado, também esta sendo logado os demais encontrados.

### Screenshots

Veja as massagens: 


![Captura de Tela 2021-11-12 às 07 50 31](https://user-images.githubusercontent.com/86991526/141467003-b026a033-c4b2-4694-bda8-dfef162d1713.png)



#### Quais são tickets relevantes?
N/A

### Referências
N/A