### PR TITLE
Como há casos em que o doi pode estar errado (o mesmo doi atribuído p…

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -667,6 +667,11 @@ def _unpublish_repeated_documents(document_id, doi):
     for doc in docs:
         if doc._id == document_id:
             continue
+        if doc.title != new_doc.title:
+            continue
+        if doc.issue != new_doc.issue and not doc.issue.endswith("aop"):
+            continue
+
         logging.info("Repeated document %s / %s / %s / %s" %
                      (doc._id, doc.pid, doc.aop_pid, str(doc.scielo_pids)))
         # obtém os pids


### PR DESCRIPTION
…ara artigos diferentes), deve-se comparar mais dados para garantir de que é uma repetição

#### O que esse PR faz?
Como há casos em que o doi pode estar errado (o mesmo doi atribuído para artigos diferentes), deve-se comparar mais dados para garantir de que é uma repetição.
Há casos em que um artigo foi publicados em dois fascículos distintos por engano.

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando `sync_kernel_to_website` para artigos com mesmo DOI mas que são artigos diferentes ou é o mesmo artigo e por engano do editor foram publicados em fascículos diferentes, logo devem ser tratados como artigos diferentes.
No entanto, se os artigos forem realmente duplicados, por exemplo, aop e regular, deve manter apenas o do regular.

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#309

### Referências
n/a