### PR TITLE
obtém o `new_doc` usando o `document_id`

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -663,6 +663,7 @@ def _unpublish_repeated_documents(document_id, doi):
         logging.info("Error getting documents by doi='%s': %s" % (doi, str(e)))
         return None
 
+    new_doc = models.Article.objects(_id=document_id)
     pids = set()
     for doc in docs:
         if doc._id == document_id:


### PR DESCRIPTION
#### O que esse PR faz?
Corrige bug, inserido no tk309
```
[2021-11-29 18:18:37,140] {sync_kernel_to_website_operations.py:613} ERROR - Could not register document 'Y59FZXNc7JNKv3zNqmtwDht'. Unexpected error 'name 'new_doc' is not defined'.
[2021-11-29 18:18:37,169] {crypto.py:78} WARNING - cryptography not found - values will not be stored encrypted.

```
#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Executando `sync_kernel_to_website` para `Y59FZXNc7JNKv3zNqmtwDht` que é um documento que tem o mesmo doi de 
https://www.scielo.br/j/cadbto/a/vv7N59KhLSVGpyGRSvZybCJ/?lang=es

#### Algum cenário de contexto que queira dar?
n/a

### Screenshots
n/a

#### Quais são tickets relevantes?
#309

### Referências
n/a