### PR TITLE
Corrige bug inserido por PR 311

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -664,13 +664,27 @@ def _unpublish_repeated_documents(document_id, doi):
         return None
 
     new_doc = models.Article.objects(_id=document_id)
+    try:
+        new_doc = new_doc[0]
+        new_title = new_doc.title
+        new_issue = new_doc.issue
+    except (IndexError, TypeError, ValueError, AttributeError) as e:
+        logging.info(
+            "Unpublished repeated document %s. %s" %
+            (document_id, e))
+    except Exception as e:
+        logging.info(
+            "Unpublished repeated document %s. Unexpected: %s" %
+            (document_id, e))
+        return
+
     pids = set()
     for doc in docs:
         if doc._id == document_id:
             continue
-        if doc.title != new_doc.title:
+        if doc.title != new_title:
             continue
-        if doc.issue != new_doc.issue and not doc.issue.endswith("aop"):
+        if doc.issue != new_issue and not doc.issue.endswith("aop"):
             continue
 
         logging.info("Repeated document %s / %s / %s / %s" %


### PR DESCRIPTION
#### O que esse PR faz?
Corrige bug inserido por PR 311
```
[2021-11-29 19:15:18,764] {sync_kernel_to_website.py:198} INFO - Got bundle_id and order from Kernel: 2526-8910-2021-v29 {'id': 'Y59FZXNc7JNKv3zNqmtwDht', 'order': '00306'}
[2021-11-29 19:15:18,765] {sync_kernel_to_website_operations.py:698} INFO - Get doi from kernel
[2021-11-29 19:15:18,835] {sync_kernel_to_website_operations.py:613} ERROR - Could not register document 'Y59FZXNc7JNKv3zNqmtwDht'. Unexpected error ''QuerySet' object has no attribute 'title''.
[2021-11-29 19:15:18,875] {crypto.py:78} WARNING - cryptography not found - values will not be stored encrypted.

```

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Ver #311

#### Algum cenário de contexto que queira dar?
Indique um contexto onde as modificações se fazem necessárias ou passe informações que contextualizam
o revisor a fim de facilitar o entendimento da funcionalidade.

### Screenshots
.

#### Quais são tickets relevantes?
#311

### Referências
.