### PR TITLE
Adiciona a capacidade de armazenar o material suplementar.

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -162,6 +162,13 @@ def fetch_documents_xml(document_id):
     return fetch_data("/documents/%s" % (document_id), json=False)
 
 
+def fetch_documents_manifest(document_id):
+    """
+         Obtém o XML do Document do Kernel com base no parametro 'document_id'
+    """
+    return fetch_data("/documents/%s/manifest" % (document_id), json=True)
+
+
 def _get_relation_data_from_kernel_bundle(document_id, front_data=None):
     """
     Obtém os dados do documento no bundle
@@ -747,7 +754,7 @@ def register_documents(**kwargs):
     )
 
     orphans = try_register_documents(
-        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory, fetch_documents_xml,
+        documents_to_get, _get_relation_data, fetch_documents_front, ArticleFactory, fetch_documents_xml, fetch_documents_manifest,
     )
 
     Variable.set("orphan_documents", orphans, serialize_json=True)
@@ -915,6 +922,7 @@ def register_last_issues(ds, **kwargs):
             journal.save()
         except AttributeError:
             logging.info("No issues are registered to models.Journal: %s " % journal)
+
 
 def must_send_email(ds, **kwargs):
     """If IS_SPORADIC == True return False to avoid send e-mail,

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ deepdiff[murmur]==4.0.7
 feedparser==5.2.1
 beautifulsoup4==4.9.0
 git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
-git+https://github.com/scieloorg/opac_schema.git@v2.60#egg=opac_schema
+git+https://github.com/scieloorg/opac_schema.git@v2.65#egg=opac_schema
 git+https://github.com/scieloorg/packtools.git@2.6.4#egg=packtools
 aiohttp==3.6.2


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona a capacidade de armazenar o material suplementar. 

#### Onde a revisão poderia começar?

Sugiro que verifique principalmente pelo módulo: **airflow/dags/operations/sync_kernel_to_website_operations.py**

#### Como este poderia ser testado manualmente?

Para realizar um teste manual é possível adicionando o PID v3: **d6DyD7CHXbpTJbLq7NQQNdq** como **orphan** no opac-airflow e verificando que é encontrado material suplementar para o registro.

Veja: 

![Captura de Tela 2022-02-21 às 02 21 12](https://user-images.githubusercontent.com/86991526/154894139-84c29949-c71e-4051-af17-0fd7e905905f.png)


#### Algum cenário de contexto que queira dar?

Essa atividade é essencial para resolver o legado do SciELO com artigos com material suplementar e os novos registros, bem como uma (URL) para resolução no site. 

### Screenshots

Exemplo de um registro com material suplementar na base de dados: 
![Captura de Tela 2022-02-21 às 02 23 01](https://user-images.githubusercontent.com/86991526/154894336-667dd8ab-871b-42e3-b48d-d65742faaa1a.png)


#### Quais são tickets relevantes?

#315 

### Referências
N/A