### PR TITLE
Trata erro de conexão e resolução de nomes.

### DIFF
--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -67,8 +67,7 @@ def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=
 
 @retry(
     wait=wait_exponential(),
-    stop=stop_after_attempt(4),
-    retry=retry_if_exception_type((requests.ConnectionError, requests.Timeout)),
+    stop=stop_after_attempt(10),
 )
 def object_store_connect(bytes_data, filepath, bucket_name):
     s3_hook = S3Hook(aws_conn_id="aws_default")
@@ -104,6 +103,7 @@ def mongo_connect():
     connect(host=uri, **conn.extra_dejson)
 
 
+@retry(wait=wait_exponential(), stop=stop_after_attempt(10))
 def add_execution_in_database(
     table, data={}, connection_id="postgres_report_connection"
 ):


### PR DESCRIPTION
#### O que esse PR faz?

Trata erro de conexão com o **minio.scielo.br** e resolução de nomes para:  **manager-postgresql.scielo.org**

Remove no momento de conexão com o **minio.scielo.br** a restrição de retentar somente em erros da ``requests``

Adiciona tentativas na função hooks:add_execution_in_database, pois estamos com problema de resolução de nome para o nome: manager-postgresql.scielo.org

Mensagem de erro ao tentar conectar com o manager-postgresql.scielo.org:

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) could not translate host name "manager-postgresql.scielo.org" to address: Try again
```

#### Onde a revisão poderia começar?

Por commit

#### Como este poderia ser testado manualmente?

Para rodar manualmente é preciso executar o [pre_sync_documents_to_kernel](https://airflow.scielo.br/admin/airflow/tree?dag_id=pre_sync_documents_to_kernel) e depois o [sync_documents_to_kernel](https://airflow.scielo.br/admin/airflow/tree?dag_id=sync_documents_to_kernel)

Um pacote que apresentou diversos problema nesse sentido foi o v42 do periódico CTA (publicação continua)

**Importante**: Esse fascículo da CTA contém ~600 artigos, veja: https://www.scielo.br/j/cta/grid

#### Algum cenário de contexto que queira dar?

Para ver esses erros é possível acessando os links: 

https://airflow.scielo.br/admin/airflow/log?task_id=register_update_docs_id&dag_id=sync_documents_to_kernel&execution_date=2022-02-27T21%3A19%3A25.983396%2B00%3A00&format=json

https://airflow.scielo.br/admin/airflow/log?task_id=register_update_docs_id&dag_id=sync_documents_to_kernel&execution_date=2022-02-27T21%3A19%3A25.370829%2B00%3A00&format=json

https://airflow.scielo.br/admin/airflow/log?task_id=register_update_docs_id&dag_id=sync_documents_to_kernel&execution_date=2022-02-27T21%3A19%3A24.957763%2B00%3A00&format=json


### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A