### PR TITLE
Garante que em caso de o artigo não ter fascículo, não será considerado um documento repetido.

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -861,7 +861,7 @@ def _unpublish_repeated_documents(document_id, doi):
             continue
         if doc.title != new_title:
             continue
-        if doc.issue != new_issue and not doc.issue.endswith("aop"):
+        if doc.issue != new_issue and doc.issue.type != "ahead":
             continue
 
         logging.info("Repeated document %s / %s / %s / %s" %


### PR DESCRIPTION
#### O que esse PR faz?

Garante que em caso de o artigo não ter fascículo, não será considerado um documento repetido.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Executando a DAG sync_kernel_to_website.py

#### Algum cenário de contexto que queira dar?

Esse ajuste tem como intenção evitar o erro: 


<img width="1425" alt="Captura de Tela 2022-04-06 às 11 22 07" src="https://user-images.githubusercontent.com/86991526/162049788-6ab1e934-04b8-4617-8021-530536380c8f.png">

<img width="1424" alt="Captura de Tela 2022-04-06 às 11 21 55" src="https://user-images.githubusercontent.com/86991526/162049799-c4f20788-cc8b-4aaf-8101-02283464fc12.png">


### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A