### PR TITLE
Auto run sync to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ cd airflow
 python -m unittest -v
 ```
 
+## Sequência de execução das DAGs
+
+>sync_isis_to_kernel
+>>   pre_sync_documents_to_kernel
+>>>     sync_documents_to_kernel
+>>>>        sync_kernel_to_website
+
+> sync_external_content_to_website (executado todo 00:00 do sábado)
 
 ## Licença de uso
 

--- a/airflow/dags/sync_documents_to_kernel.py
+++ b/airflow/dags/sync_documents_to_kernel.py
@@ -26,6 +26,7 @@ from tempfile import mkdtemp
 
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator, ShortCircuitOperator
+from airflow.operators.dagrun_operator import TriggerDagRunOperator
 from airflow.models import Variable
 
 from operations import sync_documents_to_kernel_operations
@@ -193,8 +194,14 @@ link_documents_task = ShortCircuitOperator(
     dag=dag,
 )
 
+trigger_sync_kernel_to_website_dag_task = TriggerDagRunOperator(
+    task_id="trigger_sync_kernel_to_website_dag_task",
+    trigger_dag_id="sync_kernel_to_website",
+    dag=dag,
+)
+
 list_documents_task >> delete_documents_task
 delete_documents_task >> optimize_package_task
 optimize_package_task >> register_update_documents_task
 register_update_documents_task >> link_documents_task
-
+link_documents_task >> trigger_sync_kernel_to_website_dag_task

--- a/airflow/dags/sync_external_content_to_website.py
+++ b/airflow/dags/sync_external_content_to_website.py
@@ -22,7 +22,7 @@ default_args = {
 dag = DAG(
     dag_id="sync_external_content_to_website",
     default_args=default_args,
-    schedule_interval="@hourly",
+    schedule_interval="0 0 * * 6",
     catchup=False
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ feedparser==5.2.1
 beautifulsoup4==4.9.0
 git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
 git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
-git+https://github.com/scieloorg/packtools.git@2.6.4#egg=packtools
+git+https://github.com/scieloorg/packtools.git@2.9.5#egg=packtools
 aiohttp==3.6.2


### PR DESCRIPTION
#### O que esse PR faz?
Adiciona a execução automática da dag ``sync_kernel_to_website`` na dag ``sync_documents_to_kernel``.
Adiciona um agendamento para a dag ``external_content`` At 00:00 on Saturday
Atualiza o packtools para a versão 2.9.5.
Documenta a sequência de execução das DAGs

#### Onde a revisão poderia começar?
Por commit 

#### Como este poderia ser testado manualmente?
Executando a DAG sync_documents_to_kernel e verificando que a DAG sync_kernel_to_website é executada.

#### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

#### Quais são tickets relevantes?
N/A

### Referências
N/A