### PR TITLE
Adiciona uma condicional para iniciar a execução do sync_kernel_to_website. 

### DIFF
--- a/airflow/dags/common/airflow_functions.py
+++ b/airflow/dags/common/airflow_functions.py
@@ -1,0 +1,17 @@
+from airflow.models import DagRun
+
+
+def get_most_recent_dag_run(dag_id):
+    """
+    Get the most recent dag run from a DAG id.
+
+    Param:
+        dag_id: String with id of the dag.
+
+    Return a airflow.models.DagRun object or None.
+
+    Link to airflow.models.DagRun class: https://github.com/apache/airflow/blob/main/airflow/models/dagrun.py
+    """
+    dag_runs = DagRun.find(dag_id=dag_id)
+    dag_runs.sort(key=lambda x: x.execution_date, reverse=True)
+    return dag_runs[0] if dag_runs else None


### PR DESCRIPTION
#### O que esse PR faz?

Adiciona uma condicional para iniciar a execução do **sync_kernel_to_website**. 

A condição deve ser a última DagRun.

#### Onde a revisão poderia começar?

Sugiro por commit.

#### Como este poderia ser testado manualmente?

Executando a dag **sync_documents_to_kernel** com o disparo de diversos DagRun.

#### Algum cenário de contexto que queira dar?

A ideia dessa solução é avaliar se é a última DagRun caso seja dispara o próxima DAG. 

### Screenshots

Testes realizados localmente: 

![Captura de Tela 2022-05-13 às 09 49 05](https://user-images.githubusercontent.com/86991526/168286555-f1ffb6df-aaf9-486c-9770-972555fa2dc0.png)


#### Quais são tickets relevantes?
N/A

### Referências
N/A