### PR TITLE
Estabelecer que `issue.is_public` é `False` se não contém documentos

### DIFF
--- a/airflow/dags/sync_kernel_to_website.py
+++ b/airflow/dags/sync_kernel_to_website.py
@@ -606,6 +606,11 @@ def try_register_issues(
             else:
                 # Não é necessário o campo de ordenação(order) no ahead
                 issue = issue_factory(data, journal_id, _type="ahead")
+
+            if not data.get("items"):
+                # issue não tem documentos, então não deve ficar disponível
+                issue.is_public = False
+
             issue.save()
         except models.Journal.DoesNotExist:
             orphans.append(issue_id)


### PR DESCRIPTION
#### O que esse PR faz?
Ao registrar os dados de `issue` no site, deixar `issue.is_public = False` se não tiver documentos.
Esta funcionalidade é importante se os dados de entrada forem a partir da base de dados `issue` que contém dados de fascículos ainda em preparação. Com isso, é possível disparar a DAG `sync_isis_to_kernel` simultaneamente ao `GeraPadrao.bat` e, não posterior a ele, adiantando o processo de publicação. 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Deve-se executar o sync_isis_to_kernel usando uma base de dados issue com todos os fascículos, sendo que alguns deles não tenham os respectivos documentos prontos.

#### Algum cenário de contexto que queira dar?
Não resolve 100% dos casos, pois não verificar se os documentos estão com valor `is_public == True` nem avalia a data de publicação `pub_date` para verificar se está em embargo.

### Screenshots
n/a

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac/issues/2126

### Referências
n/a