### PR TITLE
Inclui o pid manager centralizado como dependência no início do fluxo: pre_sync_documents_to_kernel

### DIFF
--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -74,6 +74,7 @@ def get_sps_packages(conf, **kwargs):
     sincronizados.
     Armazena os pacotes em XCom para a próxima tarefa.
     """
+    SCIELO_CORE_ID_PROVIDER_DB_URI = Variable.get("SCIELO_CORE_ID_PROVIDER_DB_URI")
     _xc_sps_packages_dir = Path(Variable.get("XC_SPS_PACKAGES_DIR"))
     _proc_sps_packages_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / kwargs["run_id"]
     if not _proc_sps_packages_dir.is_dir():
@@ -88,6 +89,7 @@ def get_sps_packages(conf, **kwargs):
         _scilista_file_path,
         _xc_sps_packages_dir,
         _proc_sps_packages_dir,
+        SCIELO_CORE_ID_PROVIDER_DB_URI,
     )
 
     if _sps_packages:

--- a/airflow/dags/pre_sync_documents_to_kernel.py
+++ b/airflow/dags/pre_sync_documents_to_kernel.py
@@ -74,7 +74,6 @@ def get_sps_packages(conf, **kwargs):
     sincronizados.
     Armazena os pacotes em XCom para a próxima tarefa.
     """
-    SCIELO_CORE_ID_PROVIDER_DB_URI = Variable.get("SCIELO_CORE_ID_PROVIDER_DB_URI")
     _xc_sps_packages_dir = Path(Variable.get("XC_SPS_PACKAGES_DIR"))
     _proc_sps_packages_dir = Path(Variable.get("PROC_SPS_PACKAGES_DIR")) / kwargs["run_id"]
     if not _proc_sps_packages_dir.is_dir():
@@ -85,6 +84,8 @@ def get_sps_packages(conf, **kwargs):
         _proc_sps_packages_dir,
         Variable.get("GERAPADRAO_ID_FOR_SCILISTA"),
     )
+
+    SCIELO_CORE_ID_PROVIDER_DB_URI = Variable.get("SCIELO_CORE_ID_PROVIDER_DB_URI")
     _sps_packages = pre_sync_documents_to_kernel_operations.get_sps_packages(
         _scilista_file_path,
         _xc_sps_packages_dir,

--- a/airflow/tests/test_pre_sync_documents_to_kernel.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel.py
@@ -97,6 +97,7 @@ class TestGetSPSPackages(TestCase):
             self.dir_source,
             self.dir_dest,
             self.id_proc_gerapadrao,
+            None,
         ]
         _sps_packages = ["package_01", "package_02", "package_03"]
         mk_get_sps_packages.return_value = _sps_packages
@@ -115,6 +116,7 @@ class TestGetSPSPackages(TestCase):
             self.dir_source,
             self.dir_dest,
             self.id_proc_gerapadrao,
+            None,
         ]
         mk_get_sps_packages.return_value = []
         _exec_start_sync_packages = get_sps_packages(**self.kwargs)

--- a/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
+++ b/airflow/tests/test_pre_sync_documents_to_kernel_operations.py
@@ -1,13 +1,154 @@
+import os
 import tempfile
 import shutil
 import pathlib
 import zipfile
 from unittest import TestCase, main
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock, call
 
 from airflow import DAG
 
 from operations.pre_sync_documents_to_kernel_operations import get_sps_packages
+
+
+def _create_scilista_and_filenames(scilista_file_path, scilista_lines=None):
+    """
+    Cria uma scilista e 3 nomes de arquivos para cada item da scilista
+    """
+    scilista_lines = scilista_lines or ["rba v53n1", "rba 2019nahead", "rsp v10n4s1"]
+    source_filenames = []
+    scilista_file_path = pathlib.Path(scilista_file_path)
+    with scilista_file_path.open("w") as scilista_file:
+        for line in scilista_lines:
+            scilista_file.write(line + "\n")
+            source_filenames += [
+                "_".join([f"2020-01-01-00-0{i}-09-090901"] + line.split()) + ".zip"
+                for i in range(1, 4)
+            ]
+    return source_filenames
+
+
+def _create_zip(source_filenames, src_folder, zipfile_path):
+    files = []
+    for filename in source_filenames:
+        zip_filename = pathlib.Path(src_folder) / filename
+        files.append(str(zip_filename))
+        with zipfile.ZipFile(zip_filename, "w") as zip_file:
+            zip_file.write(zipfile_path)
+    return files
+
+
+@patch("operations.pre_sync_documents_to_kernel_operations.get_id_provider_functions")
+class TestGetSPSPackagesWithPidManager(TestCase):
+    def setUp(self):
+        self.xc_dir_name = tempfile.mkdtemp()
+        self.proc_dir_name = tempfile.mkdtemp()
+        self.kwargs = {
+            "scilista_file_path": str(pathlib.Path(self.xc_dir_name) / "scilista.lst"),
+            "xc_dir_name": self.xc_dir_name,
+            "proc_dir_name": self.proc_dir_name,
+            "id_provider_db_uri": 'db_uri'
+        }
+        self.test_filepath = pathlib.Path(self.xc_dir_name) / "test.txt"
+        with self.test_filepath.open("w") as test_file:
+            test_file.write("Text test file")
+        source_filenames = _create_scilista_and_filenames(self.kwargs["scilista_file_path"])
+        self.zipfiles = _create_zip(source_filenames, self.xc_dir_name, self.test_filepath)
+
+    def tearDown(self):
+        shutil.rmtree(self.xc_dir_name)
+        shutil.rmtree(self.proc_dir_name)
+
+    @patch("operations.pre_sync_documents_to_kernel_operations.move_package_to_proc_dir")
+    def test_get_sps_packages_calls_move_package_to_proc_dir(
+            self,
+            mk_move_package_to_proc_dir,
+            mk_id_provider_functions,
+            ):
+        """
+        Testa que move_package_to_proc_dir será executado porque as funções do
+        ID provider são None, None no lugar de `request_document_id`, `connect`
+        """
+        mk_id_provider_functions.return_value = {
+            "request_document_id": None,
+            "connect": None
+        }
+
+        get_sps_packages(**self.kwargs)
+
+        calls = mk_move_package_to_proc_dir.call_args_list
+        self.assertEqual(len(calls), 9)
+        for zipfile in self.zipfiles:
+            with self.subTest(zipfile):
+                self.assertIn(call(zipfile, self.proc_dir_name), calls)
+
+    @patch("operations.pre_sync_documents_to_kernel_operations.move_package_to_proc_dir")
+    def test_get_sps_packages_does_not_move_package_to_proc_dir_and_calls_connect_and_request_id(
+            self,
+            mk_move_package_to_proc_dir,
+            mk_id_provider_functions,
+            ):
+        """
+        Testa que move_package_to_proc_dir NÃO será executado porque
+        as funções `request_document_id`, `connect` do ID provider foram
+        carregadas
+        """
+        mk_request_id = MagicMock(name='request_id')
+        mk_connect = Mock(name='connect')
+
+        mk_id_provider_functions.return_value = {
+            "request_document_id": mk_request_id,
+            "connect": mk_connect
+        }
+        get_sps_packages(**self.kwargs)
+        mk_connect.assert_called_once_with("db_uri")
+
+        calls = mk_request_id.call_args_list
+        self.assertEqual(len(calls), 9)
+        for zipfile in self.zipfiles:
+            with self.subTest(zipfile):
+                _call = call(
+                    zipfile,
+                    os.path.join(self.proc_dir_name, os.path.basename(zipfile)),
+                    "airflow",
+                    "db_uri"
+                )
+                self.assertIn(_call, calls)
+        mk_move_package_to_proc_dir.assert_not_called()
+
+    @patch("operations.pre_sync_documents_to_kernel_operations.move_package_to_proc_dir")
+    def test_get_sps_packages_calls_move_package_to_proc_dir_because_request_id_raises_exception(
+            self,
+            mk_move_package_to_proc_dir,
+            mk_id_provider_functions,
+            ):
+        """
+        Testa que move_package_to_proc_dir será executado porque
+        as funções `request_document_id`, `connect` do ID provider foram
+        carregadas, mas request_document_id levantou uma exceção
+        """
+        mk_request_id = MagicMock(name='request_id', side_effect=Exception)
+        mk_connect = Mock(name='connect')
+
+        mk_id_provider_functions.return_value = {
+            "request_document_id": mk_request_id,
+            "connect": mk_connect
+        }
+        get_sps_packages(**self.kwargs)
+        mk_connect.assert_called_once_with("db_uri")
+
+        calls = mk_request_id.call_args_list
+        self.assertEqual(len(calls), 9)
+        for zipfile in self.zipfiles:
+            with self.subTest(zipfile):
+                _call = call(
+                    zipfile,
+                    os.path.join(self.proc_dir_name, os.path.basename(zipfile)),
+                    "airflow",
+                    "db_uri"
+                )
+                self.assertIn(_call, calls)
+        self.assertEqual(mk_move_package_to_proc_dir.call_count, 9)
 
 
 class TestGetSPSPackages(TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ beautifulsoup4==4.9.0
 git+https://github.com/scieloorg/xylose.git@1.35.8#egg=xylose
 git+https://github.com/scieloorg/opac_schema.git@v2.66#egg=opac_schema
 git+https://github.com/scieloorg/packtools.git@2.9.5#egg=packtools
+git+https://github.com/robertatakenaka/scielo_core.git@v0.14#egg=scielo_core
 aiohttp==3.6.2


### PR DESCRIPTION
#### O que esse PR faz?
Inclui o pid manager centralizado como dependência no início do fluxo: pre_sync_documents_to_kernel.

A variável `SCIELO_CORE_ID_PROVIDER_DB_URI` contém os dados para registrar dos dados e também ativa e desativa a integração 

#### Onde a revisão poderia começar?
por commits

#### Como este poderia ser testado manualmente?
Instanciando a variável
Executando a DAG `pre_sync_documents_to_kernel` com pacotes XML 

#### Algum cenário de contexto que queira dar?
Em caso de qualquer levantamento de exceção no trecho da dependência com pid_manager, o fluxo seguirá o caminho padrão anterior.

### Screenshots
n/a

#### Quais são tickets relevantes?
n/a

### Referências
n/a