### PR TITLE
Garante que o campo de relacionamento com outro artigo esteja vazio.

### DIFF
--- a/airflow/dags/operations/sync_kernel_to_website_operations.py
+++ b/airflow/dags/operations/sync_kernel_to_website_operations.py
@@ -125,6 +125,9 @@ def ArticleFactory(
     # atualiza status
     article.is_public = True
 
+    # Garante que o campo de relacionamento com outro artigo esteja vazio.
+    article.related_articles = []
+
     # Dados principais
     article.title = _get_main_article_title(data)
     article.section = _nestget(data, "article_meta", 0, "pub_subject", 0)


### PR DESCRIPTION
#### O que esse PR faz?
Garante que o campo de relacionamento com outro artigo esteja vazio.

#### Onde a revisão poderia começar?

Por commit 

#### Como este poderia ser testado manualmente?

Necessário subir uma instância local e realizar o processamento de sincronização com o site.

#### Algum cenário de contexto que queira dar?

Foram realizados testes locais com um artigo com o campo related_articles e submetendo um novo registro com o mesmo **id** para sem o related_articles para seja garantido que seja removido! 

### Screenshots
N/A

#### Quais são tickets relevantes?
https://github.com/scieloorg/opac-airflow/issues/369

### Referências
N/A