### PR TITLE
Separate object store public URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,33 @@ $ airflow webserver
 * Conn Type: `Amazon Web Service`
 * Schema: `http` ou `https`
 * Login: login do Object Store
-* Extra: `{"host": "<endereço do host:porta>"}`
+* Extra: `{"host": "<endpoint S3-compatible para upload>", "public_url": "<URL pública para leitura>"}`
+
+Exemplo para ambientes onde o endpoint de escrita e a URL pública são
+diferentes:
+
+```json
+{
+  "region_name": "us-east-1",
+  "host": "https://ny-s3.storage.bunnycdn.com",
+  "public_url": "https://minio.scielo.br"
+}
+```
+
+No Airflow 1.10.12, o `S3Hook` usa `host` como `endpoint_url` do boto3. Por
+isso, `host` deve apontar para o endpoint usado no upload. Para compatibilidade
+com a configuração anterior, quando `public_url` não for informado, `host`
+continua sendo usado também para montar as URLs públicas.
+
+Também é possível usar `public_host` em vez de `public_url`:
+
+```json
+{
+  "region_name": "us-east-1",
+  "host": "https://ny-s3.storage.bunnycdn.com",
+  "public_host": "https://minio.scielo.br"
+}
+```
 
 ## Variáveis:
 

--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -72,8 +72,23 @@ def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=
 def object_store_connect(bytes_data, filepath, bucket_name):
     s3_hook = S3Hook(aws_conn_id="aws_default")
     s3_hook.load_bytes(bytes_data, key=filepath, bucket_name=bucket_name, replace=True)
-    s3_host = s3_hook.get_connection("aws_default").extra_dejson.get("host")
-    return "{}/{}/{}".format(s3_host, bucket_name, filepath)
+    connection = s3_hook.get_connection("aws_default")
+    object_store_public_url = get_object_store_public_url(connection)
+    return "{}/{}/{}".format(
+        object_store_public_url.rstrip("/"),
+        bucket_name.strip("/"),
+        filepath.lstrip("/"),
+    )
+
+
+def get_object_store_public_url(connection):
+    extra = connection.extra_dejson
+    return (
+        extra.get("public_url")
+        or extra.get("public_host")
+        or extra.get("host")
+        or extra.get("endpoint_url")
+    )
 
 
 @retry(wait=wait_exponential(), stop=stop_after_attempt(4))

--- a/airflow/tests/test_hooks.py
+++ b/airflow/tests/test_hooks.py
@@ -1,0 +1,94 @@
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from common.hooks import get_object_store_public_url, object_store_connect
+
+
+class TestObjectStoreConnect(TestCase):
+    @patch("common.hooks.S3Hook")
+    def test_object_store_connect_returns_public_url_when_configured(
+        self, MockS3Hook
+    ):
+        connection = Mock()
+        connection.extra_dejson = {
+            "host": "https://ny-s3.storage.bunnycdn.com",
+            "public_url": "https://minio.scielo.br",
+        }
+        s3_hook = MockS3Hook.return_value
+        s3_hook.get_connection.return_value = connection
+
+        result = object_store_connect(
+            b"<xml/>",
+            "journal/scielo-id/hash.xml",
+            "documentstore",
+        )
+
+        s3_hook.load_bytes.assert_called_once_with(
+            b"<xml/>",
+            key="journal/scielo-id/hash.xml",
+            bucket_name="documentstore",
+            replace=True,
+        )
+        self.assertEqual(
+            "https://minio.scielo.br/documentstore/journal/scielo-id/hash.xml",
+            result,
+        )
+
+    @patch("common.hooks.S3Hook")
+    def test_object_store_connect_returns_public_host_when_configured(
+        self, MockS3Hook
+    ):
+        connection = Mock()
+        connection.extra_dejson = {
+            "host": "https://ny-s3.storage.bunnycdn.com",
+            "public_host": "https://minio.scielo.br/",
+        }
+        s3_hook = MockS3Hook.return_value
+        s3_hook.get_connection.return_value = connection
+
+        result = object_store_connect(
+            b"<xml/>",
+            "/journal/scielo-id/hash.xml",
+            "documentstore",
+        )
+
+        self.assertEqual(
+            "https://minio.scielo.br/documentstore/journal/scielo-id/hash.xml",
+            result,
+        )
+
+
+class TestGetObjectStorePublicUrl(TestCase):
+    def test_get_object_store_public_url_prefers_public_url(self):
+        connection = Mock()
+        connection.extra_dejson = {
+            "endpoint_url": "https://ny-s3.storage.bunnycdn.com",
+            "host": "https://ny-s3.storage.bunnycdn.com",
+            "public_host": "https://public-host.example.org",
+            "public_url": "https://minio.scielo.br",
+        }
+
+        self.assertEqual(
+            "https://minio.scielo.br",
+            get_object_store_public_url(connection),
+        )
+
+    def test_get_object_store_public_url_keeps_host_as_legacy_fallback(self):
+        connection = Mock()
+        connection.extra_dejson = {"host": "https://minio.scielo.br"}
+
+        self.assertEqual(
+            "https://minio.scielo.br",
+            get_object_store_public_url(connection),
+        )
+
+    def test_get_object_store_public_url_accepts_endpoint_url_as_last_fallback(self):
+        connection = Mock()
+        connection.extra_dejson = {
+            "endpoint_url": "https://ny-s3.storage.bunnycdn.com"
+        }
+
+        self.assertEqual(
+            "https://ny-s3.storage.bunnycdn.com",
+            get_object_store_public_url(connection),
+        )


### PR DESCRIPTION
Segue um contexto pronto para levar para outro projeto/thread:

```markdown
# Contexto: separar endpoint de upload e URL pública do object store

Temos uma arquitetura onde o Kernel/document-store não faz upload de arquivos. Ele apenas recebe URLs públicas de XMLs, assets e renditions, e grava essas URLs no MongoDB.

O upload dos arquivos acontece no repositório `opac-airflow`, especialmente na DAG `sync_documents_to_kernel`.

## Fluxo atual identificado

No `kernel`:

- `PUT /documents/{id}` recebe:
  - `data`: URL do XML
  - `assets`: lista de `{asset_id, asset_url}`
- `PATCH /documents/{id}/renditions` recebe:
  - `filename`
  - `data_url`
  - `mimetype`
  - `lang`
  - `size_bytes`
- O Kernel valida que os valores são URLs e persiste no MongoDB.
- O Kernel não contém código MinIO/S3/Bunny/S3-compatible para upload.

No `opac-airflow`:

- A função `put_object_in_object_store` lê XML/assets/PDFs do pacote SPS.
- Ela chama `hooks.object_store_connect(...)`.
- `object_store_connect` usa `S3Hook(aws_conn_id="aws_default")`.
- O upload é feito com `s3_hook.load_bytes(...)`.
- A URL retornada é montada com:

```python
s3_host = s3_hook.get_connection("aws_default").extra_dejson.get("host")
return "{}/{}/{}".format(s3_host, bucket_name, filepath)
```

Arquivos relevantes:

- `opac-airflow/airflow/dags/common/hooks.py`
- `opac-airflow/airflow/dags/operations/docs_utils.py`
- `opac-airflow/airflow/dags/operations/sync_documents_to_kernel_operations.py`

## Problema

Hoje o `opac-airflow` parece assumir que o mesmo host serve para duas funções diferentes:

1. endpoint S3/API usado para upload;
2. URL pública usada para leitura e persistida no Kernel.

Mas no ambiente atual essas funções são separadas:

- Upload/escrita: `https://ny-s3.storage.bunnycdn.com`
- Leitura/URL pública esperada no Kernel: `https://minio.scielo.br`

Com a implementação atual, se `aws_default.extra.host` estiver como `https://ny-s3.storage.bunnycdn.com`, o Kernel receberá URLs com Bunny CDN/S3 endpoint. Mas o desejado é que o Kernel receba URLs públicas com `https://minio.scielo.br`.

## Mudança desejada

Separar explicitamente:

- `object_store_endpoint_url`: endpoint S3-compatible para upload;
- `object_store_public_url`: base pública usada para montar URLs registradas no Kernel.

Possível configuração na conexão Airflow `aws_default.extra`:

```json
{
  "endpoint_url": "https://ny-s3.storage.bunnycdn.com",
  "public_url": "https://minio.scielo.br"
}
```

Ou, se for mais compatível com o padrão atual:

```json
{
  "host": "https://ny-s3.storage.bunnycdn.com",
  "public_host": "https://minio.scielo.br"
}
```

## Comportamento esperado

Ao processar um XML/assets/PDF:

1. O `opac-airflow` faz upload para Bunny/S3-compatible usando `https://ny-s3.storage.bunnycdn.com`.
2. O objeto é gravado no bucket `documentstore`.
3. O caminho segue o padrão atual:

```text
{journal}/{scielo_id}/{sha1}.{ext}
```

4. A URL retornada para o Kernel deve ser:

```text
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
```

5. O Kernel persiste essa URL pública em MongoDB.

## Pontos de atenção

- Manter compatibilidade com a configuração antiga, se possível.
- Atualizar testes de `object_store_connect` e `put_object_in_object_store`.
- Garantir que metadados continuam sendo atualizados no object store.
- Evitar gravar `https://ny-s3.storage.bunnycdn.com/...` no Kernel.
- Documentar no README a diferença entre endpoint de upload e URL pública.
```

# Implementado no `opac-airflow`

O upload continua usando `S3Hook.load_bytes(...)`, mas a URL retornada para o Kernel agora é montada a partir da base pública em `airflow/dags/common/hooks.py`, a partir da linha 72.

A ordem de configuração ficou:

```text
public_url -> public_host -> host -> endpoint_url

Também foram atualizados:

README.md, a partir da linha 70, documentando a separação entre endpoint de upload e URL pública.
airflow/tests/test_hooks.py, a partir da linha 1, com testes novos cobrindo o caso em que o endpoint de upload é Bunny e a URL pública é MinIO.

Validação
python3 -m py_compile airflow/dags/common/hooks.py airflow/tests/test_hooks.py passou.
git diff --check passou.
Os unit tests completos não rodaram no Python local por falta de dependências:
tenacity
botocore
Também foi feita uma tentativa pelo Docker, mas o build/pull da imagem Airflow ficou extremamente lento e foi interrompido. O Postgres criado nessa tentativa foi parado, e o diretório data/pg_data gerado foi removido.