### PR TITLE
Support object store upload prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ airflow webserver
 * Conn Type: `Amazon Web Service`
 * Schema: `http` ou `https`
 * Login: login do Object Store
-* Extra: `{"host": "<endpoint S3-compatible para upload>", "public_url": "<URL pública para leitura>"}`
+* Extra: `{"host": "<endpoint S3-compatible para upload>", "public_url": "<URL pública para leitura>", "upload_bucket": "<bucket de upload>", "upload_prefix": "<prefixo de upload>"}`
 
 Exemplo para ambientes onde o endpoint de escrita e a URL pública são
 diferentes:
@@ -82,14 +82,32 @@ diferentes:
 {
   "region_name": "us-east-1",
   "host": "https://ny-s3.storage.bunnycdn.com",
+  "upload_bucket": "minio",
+  "upload_prefix": "documentstore",
   "public_url": "https://minio.scielo.br"
 }
+```
+
+Nesse exemplo, o upload é feito em:
+
+```text
+bucket = minio
+key = documentstore/{journal}/{scielo_id}/{sha1}.{ext}
+```
+
+E a URL registrada no Kernel continua sendo:
+
+```text
+https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
 ```
 
 No Airflow 1.10.12, o `S3Hook` usa `host` como `endpoint_url` do boto3. Por
 isso, `host` deve apontar para o endpoint usado no upload. Para compatibilidade
 com a configuração anterior, quando `public_url` não for informado, `host`
-continua sendo usado também para montar as URLs públicas.
+continua sendo usado também para montar as URLs públicas. Quando
+`upload_bucket` não for informado, o bucket usado no upload continua sendo
+`documentstore`. Quando `upload_prefix` não for informado, o objeto continua
+sendo gravado diretamente no bucket.
 
 Também é possível usar `public_host` em vez de `public_url`:
 

--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -71,14 +71,47 @@ def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=
 )
 def object_store_connect(bytes_data, filepath, bucket_name):
     s3_hook = S3Hook(aws_conn_id="aws_default")
-    s3_hook.load_bytes(bytes_data, key=filepath, bucket_name=bucket_name, replace=True)
     connection = s3_hook.get_connection("aws_default")
-    object_store_public_url = get_object_store_public_url(connection)
-    return "{}/{}/{}".format(
-        object_store_public_url.rstrip("/"),
-        bucket_name.strip("/"),
-        filepath.lstrip("/"),
+    object_store_bucket_name = get_object_store_upload_bucket(connection, bucket_name)
+    object_store_filepath = get_object_store_upload_filepath(connection, filepath)
+    s3_hook.load_bytes(
+        bytes_data,
+        key=object_store_filepath,
+        bucket_name=object_store_bucket_name,
+        replace=True,
     )
+    object_store_public_url = get_object_store_public_url(connection)
+    object_store_public_filepath = get_object_store_public_filepath(
+        connection,
+        bucket_name,
+        filepath,
+    )
+    return "{}/{}".format(
+        object_store_public_url.rstrip("/"),
+        object_store_public_filepath,
+    )
+
+
+def join_object_store_path(*parts):
+    return "/".join(
+        str(part).strip("/")
+        for part in parts
+        if part is not None and str(part).strip("/")
+    )
+
+
+def get_object_store_upload_bucket(connection, bucket_name):
+    return connection.extra_dejson.get("upload_bucket") or bucket_name
+
+
+def get_object_store_upload_filepath(connection, filepath):
+    upload_prefix = connection.extra_dejson.get("upload_prefix")
+    return join_object_store_path(upload_prefix, filepath)
+
+
+def get_object_store_public_filepath(connection, bucket_name, filepath):
+    public_prefix = connection.extra_dejson.get("public_prefix", bucket_name)
+    return join_object_store_path(public_prefix, filepath)
 
 
 def get_object_store_public_url(connection):
@@ -94,10 +127,16 @@ def get_object_store_public_url(connection):
 @retry(wait=wait_exponential(), stop=stop_after_attempt(4))
 def update_metadata_in_object_store(filepath, metadata, bucket_name):
     s3_hook = S3Hook(aws_conn_id="aws_default")
-    s3_object = s3_hook.get_key(key=filepath, bucket_name=bucket_name)
+    connection = s3_hook.get_connection("aws_default")
+    object_store_bucket_name = get_object_store_upload_bucket(connection, bucket_name)
+    object_store_filepath = get_object_store_upload_filepath(connection, filepath)
+    s3_object = s3_hook.get_key(
+        key=object_store_filepath,
+        bucket_name=object_store_bucket_name,
+    )
     s3_object.metadata.update(metadata)
     s3_object.copy_from(
-        CopySource={'Bucket': bucket_name, 'Key': filepath},
+        CopySource={'Bucket': object_store_bucket_name, 'Key': object_store_filepath},
         Metadata=s3_object.metadata,
         MetadataDirective='REPLACE'
     )

--- a/airflow/tests/test_hooks.py
+++ b/airflow/tests/test_hooks.py
@@ -1,7 +1,11 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from common.hooks import get_object_store_public_url, object_store_connect
+from common.hooks import (
+    get_object_store_public_url,
+    object_store_connect,
+    update_metadata_in_object_store,
+)
 
 
 class TestObjectStoreConnect(TestCase):
@@ -55,6 +59,76 @@ class TestObjectStoreConnect(TestCase):
         self.assertEqual(
             "https://minio.scielo.br/documentstore/journal/scielo-id/hash.xml",
             result,
+        )
+
+    @patch("common.hooks.S3Hook")
+    def test_object_store_connect_accepts_separate_upload_bucket_and_prefix(
+        self, MockS3Hook
+    ):
+        connection = Mock()
+        connection.extra_dejson = {
+            "host": "https://ny-s3.storage.bunnycdn.com",
+            "upload_bucket": "minio",
+            "upload_prefix": "documentstore",
+            "public_url": "https://minio.scielo.br",
+        }
+        s3_hook = MockS3Hook.return_value
+        s3_hook.get_connection.return_value = connection
+
+        result = object_store_connect(
+            b"<xml/>",
+            "journal/scielo-id/hash.xml",
+            "documentstore",
+        )
+
+        s3_hook.load_bytes.assert_called_once_with(
+            b"<xml/>",
+            key="documentstore/journal/scielo-id/hash.xml",
+            bucket_name="minio",
+            replace=True,
+        )
+        self.assertEqual(
+            "https://minio.scielo.br/documentstore/journal/scielo-id/hash.xml",
+            result,
+        )
+
+
+class TestUpdateMetadataInObjectStore(TestCase):
+    @patch("common.hooks.S3Hook")
+    def test_update_metadata_uses_separate_upload_bucket_and_prefix(
+        self, MockS3Hook
+    ):
+        connection = Mock()
+        connection.extra_dejson = {
+            "upload_bucket": "minio",
+            "upload_prefix": "documentstore",
+        }
+        s3_object = Mock()
+        s3_object.metadata = {"filename": "previous.xml"}
+        s3_hook = MockS3Hook.return_value
+        s3_hook.get_connection.return_value = connection
+        s3_hook.get_key.return_value = s3_object
+
+        update_metadata_in_object_store(
+            "journal/scielo-id/hash.xml",
+            {"mimetype": "application/xml"},
+            "documentstore",
+        )
+
+        s3_hook.get_key.assert_called_once_with(
+            key="documentstore/journal/scielo-id/hash.xml",
+            bucket_name="minio",
+        )
+        s3_object.copy_from.assert_called_once_with(
+            CopySource={
+                'Bucket': "minio",
+                'Key': "documentstore/journal/scielo-id/hash.xml",
+            },
+            Metadata={
+                "filename": "previous.xml",
+                "mimetype": "application/xml",
+            },
+            MetadataDirective='REPLACE',
         )
 
 


### PR DESCRIPTION
No fluxo atual, o bucket está hardcoded em put_object_in_object_store:
object_url = hooks.object_store_connect(
    file, filepath, "documentstore"
)

Ou seja:

filepath: caminho interno do objeto, tipo {journal}/{scielo_id}/{sha1}.{ext}
bucket_name: "documentstore"
Dentro de object_store_connect, esse valor é usado no upload:

s3_hook.load_bytes(
    bytes_data,
    key=filepath,
    bucket_name=bucket_name,
    replace=True
)

Então o bucket não vem do aws_default.extra. Ele é definido pelo código do opac-airflow, hoje como documentstore.

A URL pública também usa esse mesmo bucket na montagem:
{public_url}/{bucket_name}/{filepath}
Resultado esperado:
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}

Para o upload também é o mesmo bucket: documentstore.
A chamada real de upload faz isso:
s3_hook.load_bytes(
    bytes_data,
    key=filepath,
    bucket_name="documentstore",
    replace=True
)

Então, com o extra assim:
{
  "region_name": "us-east-1",
  "host": "https://ny-s3.storage.bunnycdn.com",
  "public_url": "https://minio.scielo.br"
}

o comportamento fica:

Upload:

endpoint: https://ny-s3.storage.bunnycdn.com
bucket: documentstore
key/path: {journal}/{scielo_id}/{sha1}.{ext}
URL salva no Kernel:

base pública: https://minio.scielo.br
bucket: documentstore
path: {journal}/{scielo_id}/{sha1}.{ext}
Resultado salvo:
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}

Solução proposta:
o upload precisa ser:
upload bucket: minio
upload key: documentstore/{journal}/{scielo_id}/{sha1}.{ext}

e a URL pública deve continuar sendo:
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}

Ou seja: o bucket usado no upload (minio) não deve aparecer na URL pública, porque minio.scielo.br já representa essa parte publicamente.

A configuração ideal ficaria algo nessa linha:
{
  "region_name": "us-east-1",
  "host": "https://ny-s3.storage.bunnycdn.com",
  "upload_bucket": "minio",
  "upload_prefix": "documentstore",
  "public_url": "https://minio.scielo.br",
  "public_prefix": "documentstore"
}

Comportamento:
Upload:
bucket = minio
key = documentstore/{journal}/{scielo_id}/{sha1}.{ext}

URL salva no Kernel:
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}