### PR TITLE
Support object store uploads to multiple endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ airflow webserver
 * Conn Type: `Amazon Web Service`
 * Schema: `http` ou `https`
 * Login: login do Object Store
-* Extra: `{"host": "<endpoint S3-compatible para upload>", "public_url": "<URL pública para leitura>", "upload_bucket": "<bucket de upload>", "upload_prefix": "<prefixo de upload>"}`
+* Extra: `{"host": "<endpoint S3-compatible para upload>", "public_url": "<URL pública para leitura>", "upload_locations": [{"conn_id": "<conn id de upload>", "bucket": "<bucket de upload>", "prefix": "<prefixo de upload>"}]}`
 
 Exemplo para ambientes onde o endpoint de escrita e a URL pública são
 diferentes:
@@ -82,8 +82,12 @@ diferentes:
 {
   "region_name": "us-east-1",
   "host": "https://ny-s3.storage.bunnycdn.com",
-  "upload_bucket": "minio",
-  "upload_prefix": "documentstore",
+  "upload_locations": [
+    {
+      "bucket": "minio",
+      "prefix": "documentstore"
+    }
+  ],
   "public_url": "https://minio.scielo.br"
 }
 ```
@@ -104,10 +108,61 @@ https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
 No Airflow 1.10.12, o `S3Hook` usa `host` como `endpoint_url` do boto3. Por
 isso, `host` deve apontar para o endpoint usado no upload. Para compatibilidade
 com a configuração anterior, quando `public_url` não for informado, `host`
-continua sendo usado também para montar as URLs públicas. Quando
-`upload_bucket` não for informado, o bucket usado no upload continua sendo
-`documentstore`. Quando `upload_prefix` não for informado, o objeto continua
-sendo gravado diretamente no bucket.
+continua sendo usado também para montar as URLs públicas.
+
+Para um único destino de upload, os campos `upload_bucket` e `upload_prefix`
+continuam sendo aceitos como atalho. Quando `upload_bucket` não for informado,
+o bucket usado no upload continua sendo `documentstore`. Quando `upload_prefix`
+não for informado, o objeto continua sendo gravado diretamente no bucket.
+
+Quando for necessário gravar o mesmo arquivo em dois endpoints S3 diferentes,
+crie uma conexão Airflow para cada endpoint e use `upload_locations` com até
+dois destinos.
+
+Exemplo da conexão principal `aws_default`, usada para Bunny e para montar a URL
+pública:
+
+```json
+{
+  "region_name": "us-east-1",
+  "host": "https://ny-s3.storage.bunnycdn.com",
+  "upload_locations": [
+    {
+      "conn_id": "aws_default",
+      "bucket": "minio",
+      "prefix": "documentstore"
+    },
+    {
+      "conn_id": "aws_node01_minio",
+      "bucket": "documentstore"
+    }
+  ],
+  "public_url": "https://minio.scielo.br"
+}
+```
+
+Exemplo da conexão adicional `aws_node01_minio`, usada para gravar em
+`node01-minio.scielo.org`:
+
+```json
+{
+  "region_name": "us-east-1",
+  "host": "https://node01-minio.scielo.org"
+}
+```
+
+Nesse caso, o mesmo arquivo é gravado em:
+
+```text
+https://ny-s3.storage.bunnycdn.com/minio/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
+https://node01-minio.scielo.org/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
+```
+
+A URL registrada no Kernel continua sendo única:
+
+```text
+https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
+```
 
 Também é possível usar `public_host` em vez de `public_url`:
 

--- a/airflow/dags/common/hooks.py
+++ b/airflow/dags/common/hooks.py
@@ -72,14 +72,18 @@ def kernel_connect(endpoint, method, data=None, headers=DEFAULT_HEADER, timeout=
 def object_store_connect(bytes_data, filepath, bucket_name):
     s3_hook = S3Hook(aws_conn_id="aws_default")
     connection = s3_hook.get_connection("aws_default")
-    object_store_bucket_name = get_object_store_upload_bucket(connection, bucket_name)
-    object_store_filepath = get_object_store_upload_filepath(connection, filepath)
-    s3_hook.load_bytes(
-        bytes_data,
-        key=object_store_filepath,
-        bucket_name=object_store_bucket_name,
-        replace=True,
-    )
+    for upload_conn_id, object_store_bucket_name, object_store_filepath in get_upload_locations(
+        connection,
+        bucket_name,
+        filepath,
+    ):
+        upload_s3_hook = get_upload_s3_hook(s3_hook, upload_conn_id)
+        upload_s3_hook.load_bytes(
+            bytes_data,
+            key=object_store_filepath,
+            bucket_name=object_store_bucket_name,
+            replace=True,
+        )
     object_store_public_url = get_object_store_public_url(connection)
     object_store_public_filepath = get_object_store_public_filepath(
         connection,
@@ -98,6 +102,34 @@ def join_object_store_path(*parts):
         for part in parts
         if part is not None and str(part).strip("/")
     )
+
+
+def get_upload_locations(connection, bucket_name, filepath):
+    extra = connection.extra_dejson
+    upload_locations = extra.get("upload_locations")
+    if not upload_locations:
+        return [
+            (
+                "aws_default",
+                get_object_store_upload_bucket(connection, bucket_name),
+                get_object_store_upload_filepath(connection, filepath),
+            )
+        ]
+
+    return [
+        (
+            upload_location.get("conn_id") or "aws_default",
+            upload_location.get("bucket") or bucket_name,
+            join_object_store_path(upload_location.get("prefix"), filepath),
+        )
+        for upload_location in upload_locations
+    ]
+
+
+def get_upload_s3_hook(default_s3_hook, upload_conn_id):
+    if upload_conn_id == "aws_default":
+        return default_s3_hook
+    return S3Hook(aws_conn_id=upload_conn_id)
 
 
 def get_object_store_upload_bucket(connection, bucket_name):
@@ -128,18 +160,25 @@ def get_object_store_public_url(connection):
 def update_metadata_in_object_store(filepath, metadata, bucket_name):
     s3_hook = S3Hook(aws_conn_id="aws_default")
     connection = s3_hook.get_connection("aws_default")
-    object_store_bucket_name = get_object_store_upload_bucket(connection, bucket_name)
-    object_store_filepath = get_object_store_upload_filepath(connection, filepath)
-    s3_object = s3_hook.get_key(
-        key=object_store_filepath,
-        bucket_name=object_store_bucket_name,
-    )
-    s3_object.metadata.update(metadata)
-    s3_object.copy_from(
-        CopySource={'Bucket': object_store_bucket_name, 'Key': object_store_filepath},
-        Metadata=s3_object.metadata,
-        MetadataDirective='REPLACE'
-    )
+    for upload_conn_id, object_store_bucket_name, object_store_filepath in get_upload_locations(
+        connection,
+        bucket_name,
+        filepath,
+    ):
+        upload_s3_hook = get_upload_s3_hook(s3_hook, upload_conn_id)
+        s3_object = upload_s3_hook.get_key(
+            key=object_store_filepath,
+            bucket_name=object_store_bucket_name,
+        )
+        s3_object.metadata.update(metadata)
+        s3_object.copy_from(
+            CopySource={
+                'Bucket': object_store_bucket_name,
+                'Key': object_store_filepath,
+            },
+            Metadata=s3_object.metadata,
+            MetadataDirective='REPLACE'
+        )
 
 
 @retry(wait=wait_exponential(), stop=stop_after_attempt(10))

--- a/airflow/tests/test_hooks.py
+++ b/airflow/tests/test_hooks.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, call, patch
 
 from common.hooks import (
     get_object_store_public_url,
@@ -92,6 +92,51 @@ class TestObjectStoreConnect(TestCase):
             result,
         )
 
+    @patch("common.hooks.S3Hook")
+    def test_object_store_connect_uploads_to_multiple_connections(
+        self, MockS3Hook
+    ):
+        default_s3_hook = Mock()
+        node01_s3_hook = Mock()
+        connection = Mock()
+        connection.extra_dejson = {
+            "host": "https://ny-s3.storage.bunnycdn.com",
+            "upload_locations": [
+                {"bucket": "minio", "prefix": "documentstore"},
+                {"conn_id": "aws_node01_minio", "bucket": "documentstore"},
+            ],
+            "public_url": "https://minio.scielo.br",
+        }
+        MockS3Hook.side_effect = [default_s3_hook, node01_s3_hook]
+        default_s3_hook.get_connection.return_value = connection
+
+        result = object_store_connect(
+            b"<xml/>",
+            "journal/scielo-id/hash.xml",
+            "documentstore",
+        )
+
+        MockS3Hook.assert_has_calls([
+            call(aws_conn_id="aws_default"),
+            call(aws_conn_id="aws_node01_minio"),
+        ])
+        default_s3_hook.load_bytes.assert_called_once_with(
+            b"<xml/>",
+            key="documentstore/journal/scielo-id/hash.xml",
+            bucket_name="minio",
+            replace=True,
+        )
+        node01_s3_hook.load_bytes.assert_called_once_with(
+            b"<xml/>",
+            key="journal/scielo-id/hash.xml",
+            bucket_name="documentstore",
+            replace=True,
+        )
+        self.assertEqual(
+            "https://minio.scielo.br/documentstore/journal/scielo-id/hash.xml",
+            result,
+        )
+
 
 class TestUpdateMetadataInObjectStore(TestCase):
     @patch("common.hooks.S3Hook")
@@ -123,6 +168,69 @@ class TestUpdateMetadataInObjectStore(TestCase):
             CopySource={
                 'Bucket': "minio",
                 'Key': "documentstore/journal/scielo-id/hash.xml",
+            },
+            Metadata={
+                "filename": "previous.xml",
+                "mimetype": "application/xml",
+            },
+            MetadataDirective='REPLACE',
+        )
+
+    @patch("common.hooks.S3Hook")
+    def test_update_metadata_uses_multiple_upload_connections(
+        self, MockS3Hook
+    ):
+        default_s3_hook = Mock()
+        node01_s3_hook = Mock()
+        connection = Mock()
+        connection.extra_dejson = {
+            "upload_locations": [
+                {"bucket": "minio", "prefix": "documentstore"},
+                {"conn_id": "aws_node01_minio", "bucket": "documentstore"},
+            ],
+        }
+        first_s3_object = Mock()
+        first_s3_object.metadata = {"filename": "previous.xml"}
+        second_s3_object = Mock()
+        second_s3_object.metadata = {"filename": "previous.xml"}
+        MockS3Hook.side_effect = [default_s3_hook, node01_s3_hook]
+        default_s3_hook.get_connection.return_value = connection
+        default_s3_hook.get_key.return_value = first_s3_object
+        node01_s3_hook.get_key.return_value = second_s3_object
+
+        update_metadata_in_object_store(
+            "journal/scielo-id/hash.xml",
+            {"mimetype": "application/xml"},
+            "documentstore",
+        )
+
+        MockS3Hook.assert_has_calls([
+            call(aws_conn_id="aws_default"),
+            call(aws_conn_id="aws_node01_minio"),
+        ])
+        default_s3_hook.get_key.assert_called_once_with(
+            key="documentstore/journal/scielo-id/hash.xml",
+            bucket_name="minio",
+        )
+        node01_s3_hook.get_key.assert_called_once_with(
+            key="journal/scielo-id/hash.xml",
+            bucket_name="documentstore",
+        )
+        first_s3_object.copy_from.assert_called_once_with(
+            CopySource={
+                'Bucket': "minio",
+                'Key': "documentstore/journal/scielo-id/hash.xml",
+            },
+            Metadata={
+                "filename": "previous.xml",
+                "mimetype": "application/xml",
+            },
+            MetadataDirective='REPLACE',
+        )
+        second_s3_object.copy_from.assert_called_once_with(
+            CopySource={
+                'Bucket': "documentstore",
+                'Key': "journal/scielo-id/hash.xml",
             },
             Metadata={
                 "filename": "previous.xml",


### PR DESCRIPTION

#### O que esse PR faz?

Este PR ajusta o upload de arquivos estáticos do `opac-airflow` para suportar cenários em que:

- o endpoint S3 usado para gravação é diferente da URL pública persistida no Kernel;
- o mesmo arquivo precisa ser gravado em mais de um endpoint S3-compatible;
- cada destino de upload pode ter bucket e prefixo próprios.

Com isso, o `opac-airflow` pode gravar o mesmo objeto, por exemplo, em:

```text
https://ny-s3.storage.bunnycdn.com/minio/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
https://node01-minio.scielo.org/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
```

E ainda assim retornar ao Kernel apenas a URL pública esperada:

```text
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
```

A alteração também mantém compatibilidade com a configuração anterior, em que o upload era feito em um único destino usando o bucket `documentstore`.

#### Onde a revisão poderia começar?

A revisão pode começar por:

```text
airflow/dags/common/hooks.py
```

Principais pontos:

- `object_store_connect`
- `get_upload_locations`
- `get_upload_s3_hook`
- `update_metadata_in_object_store`

Os testes relacionados estão em:

```text
airflow/tests/test_hooks.py
```

A documentação da configuração está em:

```text
README.md
```

#### Como este poderia ser testado manualmente?

1. Criar ou atualizar a conexão Airflow principal `aws_default` com o endpoint Bunny:

```json
{
  "region_name": "us-east-1",
  "host": "https://ny-s3.storage.bunnycdn.com",
  "upload_locations": [
    {
      "conn_id": "aws_default",
      "bucket": "minio",
      "prefix": "documentstore"
    },
    {
      "conn_id": "aws_node01_minio",
      "bucket": "documentstore"
    }
  ],
  "public_url": "https://minio.scielo.br"
}
```

2. Criar a conexão adicional `aws_node01_minio` apontando para o MinIO interno:

```json
{
  "region_name": "us-east-1",
  "host": "https://node01-minio.scielo.org"
}
```

3. Executar o fluxo/DAG que chama `put_object_in_object_store`, por exemplo `sync_documents_to_kernel`.

4. Confirmar que o arquivo foi enviado para os dois destinos:

```text
ny-s3.storage.bunnycdn.com / bucket minio / key documentstore/{journal}/{scielo_id}/{sha1}.{ext}
node01-minio.scielo.org / bucket documentstore / key {journal}/{scielo_id}/{sha1}.{ext}
```

5. Confirmar que a URL enviada ao Kernel continua no padrão público:

```text
https://minio.scielo.br/documentstore/{journal}/{scielo_id}/{sha1}.{ext}
```

6. Confirmar que os metadados do objeto também foram atualizados nos dois destinos.

#### Algum cenário de contexto que queira dar?

O Kernel/document-store não realiza upload de arquivos. Ele apenas recebe URLs públicas de XMLs, assets e renditions, valida que são URLs e persiste esses valores no MongoDB.

O upload real acontece no `opac-airflow`. Antes, o código assumia que o mesmo host usado para upload também era a base da URL pública. Isso não atende ambientes onde:

- o endpoint de escrita é S3-compatible/Bunny;
- a URL pública esperada no Kernel é `https://minio.scielo.br`;
- também é necessário manter uma cópia no endpoint `node01-minio.scielo.org`.

Este PR separa explicitamente essas responsabilidades.

### Screenshots

Não aplicável. A alteração é de backend/configuração de integração com object store.

#### Quais são tickets relevantes?

Não informado.

### Referências

- Implementação do `S3Hook` no Airflow 1.10.12, onde `extra["host"]` é usado como `endpoint_url` do boto3:
  https://raw.githubusercontent.com/apache/airflow/1.10.12/airflow/contrib/hooks/aws_hook.py

- Arquivos alterados:
  - `airflow/dags/common/hooks.py`
  - `airflow/tests/test_hooks.py`
  - `README.md`
